### PR TITLE
Fixed typo in report-result example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Lower level functions are available, that separate benchmark statistic
 generation and reporting.
 
 ```clj
-(report-result (benchmark (Thread/sleep 1000)) {:verbose true})
+(report-result (benchmark (Thread/sleep 1000) {:verbose true}))
 (report-result (quick-benchmark (Thread/sleep 1000)))
 ```
 


### PR DESCRIPTION
- example resulted in following exception:
  CompilerException clojure.lang.ArityException:
  Wrong number of args (1) passed to: core$benchmark
