### PR TITLE
Fix division by zero exception when warmup-n > warmup-t

### DIFF
--- a/src/criterium/core.clj
+++ b/src/criterium/core.clj
@@ -442,7 +442,7 @@ class counts, change in compilation time and result of specified function."
   [period f gc-before-sample estimated-fn-time]
   (progress "Estimating execution count ...")
   (debug " estimated-fn-time" estimated-fn-time)
-  (loop [n (max 1 (long (/ period estimated-fn-time 5)))
+  (loop [n (max 1 (long (/ period (max 1 estimated-fn-time) 5)))
          cl-state (jvm-class-loader-state)
          comp-state (jvm-compilation-state)]
     (let [t (ffirst (collect-samples 1 n f gc-before-sample))


### PR DESCRIPTION
When using Criterium in code compiled with Skummet (optimizing Clojure compiler), I get `Divide by zero` exception during `(estimate-overhead)` phase. This happens because the average time for running `(fn [] 0)` is reported to be sub 1 nanosecond which is rounded to zero.

I presume that in Skummet that dummy function is not being executed at all, which allows the estimating function to squeeze in more "runs" than there are nanosecond. But for all other purposes Criterium runs just fine there. So I'll appreciate if you accept this PR to fix this obscure but trivial issue.