### PR TITLE
Pass correct gc-before-benchmark parameter value to run-benchmark

### DIFF
--- a/src/criterium/core.clj
+++ b/src/criterium/core.clj
@@ -824,8 +824,8 @@ See http://www.ellipticgroup.com/misc/article_supplement.pdf, p17."
         (merge *default-benchmark-opts*
                {:overhead (or overhead (estimated-overhead))}
                options)
-        times (run-benchmark
-               samples warmup-jit-period target-execution-time f opts overhead)]
+        times (run-benchmark samples warmup-jit-period target-execution-time f
+                             gc-before-sample overhead)]
     (benchmark-stats times opts)))
 
 (defn benchmark-round-robin*


### PR DESCRIPTION
benchmark* was calling run-benchmark with a 5th parameter value of
opts, which is a map in benchmark*, but was used as logical true/false
in run-benchmark, and since it was a map, is always considered as
logical true by run-benchmark.  It appears that the intent was to
instead pass the value associated with the key :gc-before-sample in
the map.