### PR TITLE
fix(ci): allow release workflow to run from develop branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,9 @@ jobs:
 
     steps:
       - name: Check branch for non-dry-run
-        if: github.event.inputs.dry_run == 'false' && github.ref != 'refs/heads/master'
+        if: github.event.inputs.dry_run == 'false' && github.ref != 'refs/heads/develop'
         run: |
-          echo "::error::Non-dry-run releases are only allowed from the master branch"
+          echo "::error::Non-dry-run releases are only allowed from the develop branch"
           exit 1
 
       - name: Prepare java


### PR DESCRIPTION
## Summary
- Update release workflow branch check to use `develop` instead of `master`
- The project uses develop as the main integration branch, so releases should originate from there

## Test plan
- Run release workflow in dry-run mode from develop branch