### PR TITLE
feat(measured): allow use of locals as arguments in expr macro

### DIFF
--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -154,10 +154,8 @@
 
   Takes an expression to benchmark, and optional configuration options.
 
-  The expression must be free of local references.
-
   Parameters:
-    expr    - Expression to benchmark
+    expr    - Expression to benchmark (may reference local bindings)
     options - Keyword/value pairs for configuration:
       :viewer      - Output format [:pprint, :portal, or nil(default)]
       :analyse     - Vector of analysis steps [[:outliers] [:stats]]
@@ -181,6 +179,10 @@
   ;; With pretty-printed output
   (bench (+ 1 1) :viewer :pprint)
 
+  ;; With local bindings
+  (let [data (vec (range 1000))]
+    (bench (reduce + data)))
+
   ;; With specific metrics and time limit
   (bench (my-function)
          :metric-ids [:elapsed-time :memory]
@@ -200,7 +202,7 @@
   - Handles JVM warmup automatically
   - Accounts for GC interference
   - Ensures statistical significance
-  - Expression cannot refer to local bindings"
+  - Local bindings from enclosing scope can be used in the expression"
   [expr & options]
   (let [options-map  (apply hash-map options)
         expr-options (select-keys options-map [:time-fn])

--- a/bases/criterium/src/criterium/measured.clj
+++ b/bases/criterium/src/criterium/measured.clj
@@ -93,11 +93,14 @@
   The function arguments are treated as constant expressions and are
   hoisted into a state function.  The result of the state function is a
   vector that is passed to the function wrapper as a vector and
-  destructured."
+  destructured.
+
+  Local bindings from the enclosing scope can be used as arguments in
+  the expression."
   ([expr]
-   (impl/measured-expr* expr nil))
+   (impl/measured-expr* expr nil &env))
   ([expr options]
-   (impl/measured-expr* expr options)))
+   (impl/measured-expr* expr options &env)))
 
 (defmacro callable
   "Return a Measured for the given no arg function."

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -194,6 +194,8 @@
                         type-name-conversion)]
       {:tag type-name})))
 
+(declare collect-symbols)
+
 (defn ^:no-doc capture-arg-types
   "Return a sequence of metadata maps with :tag type hints for arg expressions.
   For local bindings, extracts type from LocalBinding in env or preserves

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -1,5 +1,6 @@
 (ns criterium.measured.impl
   (:require
+   [clojure.set]
    [criterium.jvm :as jvm]
    [criterium.util.blackhole :as blackhole]
    [criterium.util.helpers :as util]))
@@ -200,6 +201,43 @@
   (let [types (mapv (comp type eval) arg-exprs)]
     (mapv tag-meta types)))
 
+(defn ^:no-doc collect-symbols
+  "Collect all symbols used in an expression.
+  Returns a set of symbols."
+  [expr]
+  (cond
+    (symbol? expr) #{expr}
+    (coll? expr)   (into #{} (mapcat collect-symbols) expr)
+    :else          #{}))
+
+(defn ^:no-doc locals-in-expr
+  "Identify which symbols in expr are local bindings.
+  Returns a set of symbols that are present in env."
+  [expr env]
+  (if env
+    (let [local-names (set (keys env))
+          expr-syms   (collect-symbols expr)]
+      (clojure.set/intersection expr-syms local-names))
+    #{}))
+
+(defn ^:no-doc local-arg-val?
+  "Check if an arg-val is a local binding.
+  Returns true if the value is a symbol present in env."
+  [arg-val env]
+  (and (symbol? arg-val)
+       (contains? env arg-val)))
+
+(defn ^:no-doc identify-local-args
+  "Identify which arg-vals are local bindings.
+  Returns a set of arg-syms (gensymed keys) whose values are locals."
+  [arg-vals env]
+  (if env
+    (->> arg-vals
+         (filter (fn [[_arg-sym arg-val]] (local-arg-val? arg-val env)))
+         (map first)
+         set)
+    #{}))
+
 (defn measured-expr*
   "Return a measured function for the given expression.
 
@@ -207,13 +245,20 @@
   argument to the a function that wraps the expression.
 
   Any expr that is not a List is treated as a constant.  This is mainly
-  for internal benchmarking."
-  [expr options]
+  for internal benchmarking.
+
+  The env parameter is the macro's &env, used to identify local bindings."
+  [expr options env]
   (let [{:keys [expr arg-vals] :as _f} (factor-expr expr)
+        ;; local-arg-syms used by subsequent phases (Task #144)
+        #_:clj-kondo/ignore
+        local-arg-syms                 (identify-local-args arg-vals env)
         arg-metas                      (capture-arg-types (vals arg-vals))
         options                        (update
                                         options
                                         :arg-metas merge-metas arg-metas)]
+    ;; local-arg-syms computed for future use in Task #144
+    ;; For now, the code path is unchanged - locals are treated as constants
     `(measured
       (fn ~'measured-args [] ~(vec (vals arg-vals)))
       ~(measured-expr-fn

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -49,10 +49,10 @@
 
 (defrecord FnCallExpr
     ;; a representation of an s-expression
-  [op                          ; the operand
-   arg-syms                    ; arguments as symbols
-   arg-vals                    ; the symbolic value of of the arg-syms
-   metamap                     ; metadata on the FnCallExpr
+  [op ; the operand
+   arg-syms ; arguments as symbols
+   arg-vals ; the symbolic value of of the arg-syms
+   metamap ; metadata on the FnCallExpr
    ])
 
 (defn- fn-call-expr?
@@ -79,7 +79,7 @@
 (defn ^:no-doc factor-form
   "Factor form, extracting constant expressions."
   [form]
-  (let [subj  (first form)
+  (let [subj (first form)
         tform (fn [x]
                 (if (and (s-expression? x) (= subj (first x)))
                   (reduce
@@ -99,15 +99,15 @@
                     (meta x))
                    (rest x))
                   x))
-        res   (util/postwalk
-               tform
-               form)]
-    {:expr     (form-print res)
+        res (util/postwalk
+             tform
+             form)]
+    {:expr (form-print res)
      :arg-vals (:arg-vals res)}))
 
 (defn ^:no-doc factor-const [expr]
   (let [arg-sym (gen-arg-sym)]
-    {:expr     arg-sym
+    {:expr arg-sym
      :arg-vals {arg-sym expr}}))
 
 (defn ^:no-doc factor-expr [expr]
@@ -135,10 +135,10 @@
   Captures the expression arguments into a state function."
   [arg-syms expr {:keys [arg-metas time-fn]}]
   (let [eval-count-sym (gensym "eval-count")
-        time-fn        (when time-fn
-                         (with-meta
-                           time-fn
-                           {:tag 'clojure.lang.IFn$L}))]
+        time-fn (when time-fn
+                  (with-meta
+                    time-fn
+                    {:tag 'clojure.lang.IFn$L}))]
     `(fn ~'measured
        [~arg-syms
         ;; explicitly not tagged as 'long, since this function is invoked
@@ -149,11 +149,11 @@
              ;; once outside the loop.
              ~(with-meta eval-count-sym {:tag 'long})
              ~eval-count-sym ; convert to 'long
-             n#             (long (unchecked-dec ~eval-count-sym))
-             start#         ~(if time-fn
-                               `(. ~time-fn invokePrim)
-                               `(jvm/timestamp))
-             val#           ~expr]      ; evaluate once to get a return value
+             n# (long (unchecked-dec ~eval-count-sym))
+             start# ~(if time-fn
+                       `(. ~time-fn invokePrim)
+                       `(jvm/timestamp))
+             val# ~expr] ; evaluate once to get a return value
          (loop [i# n#]
            (when (pos? i#)
              (blackhole/consume ~expr)
@@ -179,10 +179,10 @@
 (def ^:private TYPE-NAME-CONVERSIONS
   ;; converting is good for measureds that use these values directly
   ;; but causes wrapping if the values are returned from the measured.
-  {'java.lang.Long    'long
+  {'java.lang.Long 'long
    'java.lang.Integer 'int
-   'java.lang.Double  'double
-   'java.lang.Float   'float})
+   'java.lang.Double 'double
+   'java.lang.Float 'float})
 
 (defn ^:no-doc type-name-conversion [t]
   (TYPE-NAME-CONVERSIONS t t))
@@ -195,17 +195,33 @@
       {:tag type-name})))
 
 (defn ^:no-doc capture-arg-types
-  "Use eval to get types of the arg expressions.
-  Return a sequence of metadata maps with :tag type hints.
-  For local bindings, preserves user-provided type hints from the expression.
-  For non-locals, uses eval to detect types at compile time."
-  [arg-syms arg-vals local-arg-syms]
+  "Return a sequence of metadata maps with :tag type hints for arg expressions.
+  For local bindings, extracts type from LocalBinding in env or preserves
+  user-provided type hints. For non-locals, uses eval to detect types."
+  [arg-syms arg-vals local-arg-syms env]
   (mapv (fn [arg-sym]
           (if (contains? local-arg-syms arg-sym)
-            ;; For locals, preserve user-provided hints from the expression
             (let [arg-val (get arg-vals arg-sym)]
-              (when-let [tag (:tag (meta arg-val))]
-                {:tag tag}))
+              (or
+               ;; First try user-provided hint on the expression
+               (when-let [tag (:tag (meta arg-val))]
+                 {:tag tag})
+               ;; Then try to get type from LocalBinding if arg-val is a symbol
+               (when (symbol? arg-val)
+                 (when-let [^clojure.lang.Compiler$LocalBinding lb (get env arg-val)]
+                   (when (.hasJavaClass lb)
+                     (tag-meta (.getJavaClass lb)))))
+               ;; For compound expressions, find locals and use their type if uniform
+               (let [local-syms (filter #(contains? env %) (collect-symbols arg-val))
+                     local-types (keep (fn [sym]
+                                         (let [^clojure.lang.Compiler$LocalBinding lb (get env sym)]
+                                           (when (and lb (.hasJavaClass lb))
+                                             (.getJavaClass lb))))
+                                       local-syms)]
+                 (when (and (seq local-types)
+                            (apply = local-types)
+                            (#{Long/TYPE Double/TYPE} (first local-types)))
+                   (tag-meta (first local-types))))))
             ;; For non-locals, eval to get the type
             (tag-meta (type (eval (get arg-vals arg-sym))))))
         arg-syms))
@@ -216,8 +232,8 @@
   [expr]
   (cond
     (symbol? expr) #{expr}
-    (coll? expr)   (into #{} (mapcat collect-symbols) expr)
-    :else          #{}))
+    (coll? expr) (into #{} (mapcat collect-symbols) expr)
+    :else #{}))
 
 (defn ^:no-doc locals-in-expr
   "Identify which symbols in expr are local bindings.
@@ -225,7 +241,7 @@
   [expr env]
   (if env
     (let [local-names (set (keys env))
-          expr-syms   (collect-symbols expr)]
+          expr-syms (collect-symbols expr)]
       (clojure.set/intersection expr-syms local-names))
     #{}))
 
@@ -235,7 +251,7 @@
   an expression containing any symbols present in env."
   [arg-val env]
   (let [local-names (set (keys env))
-        expr-syms   (collect-symbols arg-val)]
+        expr-syms (collect-symbols arg-val)]
     (boolean (seq (clojure.set/intersection expr-syms local-names)))))
 
 (defn ^:no-doc identify-local-args
@@ -263,13 +279,13 @@
   measurement pipeline alongside hoisted constants."
   [expr options env]
   (let [{:keys [expr arg-vals] :as _f} (factor-expr expr)
-        arg-syms                       (keys arg-vals)
-        local-arg-syms                 (identify-local-args arg-vals env)
-        arg-metas                      (capture-arg-types
-                                        arg-syms arg-vals local-arg-syms)
-        options                        (update
-                                        options
-                                        :arg-metas merge-metas arg-metas)]
+        arg-syms (keys arg-vals)
+        local-arg-syms (identify-local-args arg-vals env)
+        arg-metas (capture-arg-types
+                   arg-syms arg-vals local-arg-syms env)
+        options (update
+                 options
+                 :arg-metas merge-metas arg-metas)]
     `(measured
       (fn ~'measured-args [] ~(vec (vals arg-vals)))
       ~(measured-expr-fn

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -196,10 +196,14 @@
 
 (defn ^:no-doc capture-arg-types
   "Use eval to get types of the arg expressions.
-  Return a sequence of metadata maps with :tag tupe hints."
-  [arg-exprs]
-  (let [types (mapv (comp type eval) arg-exprs)]
-    (mapv tag-meta types)))
+  Return a sequence of metadata maps with :tag type hints.
+  Skips eval for local bindings (returns nil metadata for them)."
+  [arg-syms arg-vals local-arg-syms]
+  (mapv (fn [arg-sym]
+          (if (contains? local-arg-syms arg-sym)
+            nil ; locals can't be eval'd at compile time
+            (tag-meta (type (eval (get arg-vals arg-sym))))))
+        arg-syms))
 
 (defn ^:no-doc collect-symbols
   "Collect all symbols used in an expression.
@@ -221,11 +225,13 @@
     #{}))
 
 (defn ^:no-doc local-arg-val?
-  "Check if an arg-val is a local binding.
-  Returns true if the value is a symbol present in env."
+  "Check if an arg-val is or contains a local binding.
+  Returns true if the value is a symbol present in env, or if it's
+  an expression containing any symbols present in env."
   [arg-val env]
-  (and (symbol? arg-val)
-       (contains? env arg-val)))
+  (let [local-names (set (keys env))
+        expr-syms   (collect-symbols arg-val)]
+    (boolean (seq (clojure.set/intersection expr-syms local-names)))))
 
 (defn ^:no-doc identify-local-args
   "Identify which arg-vals are local bindings.
@@ -247,22 +253,22 @@
   Any expr that is not a List is treated as a constant.  This is mainly
   for internal benchmarking.
 
-  The env parameter is the macro's &env, used to identify local bindings."
+  The env parameter is the macro's &env, used to identify local bindings.
+  Local bindings are captured at the call-site and passed through the
+  measurement pipeline alongside hoisted constants."
   [expr options env]
   (let [{:keys [expr arg-vals] :as _f} (factor-expr expr)
-        ;; local-arg-syms used by subsequent phases (Task #144)
-        #_:clj-kondo/ignore
+        arg-syms                       (keys arg-vals)
         local-arg-syms                 (identify-local-args arg-vals env)
-        arg-metas                      (capture-arg-types (vals arg-vals))
+        arg-metas                      (capture-arg-types
+                                        arg-syms arg-vals local-arg-syms)
         options                        (update
                                         options
                                         :arg-metas merge-metas arg-metas)]
-    ;; local-arg-syms computed for future use in Task #144
-    ;; For now, the code path is unchanged - locals are treated as constants
     `(measured
       (fn ~'measured-args [] ~(vec (vals arg-vals)))
       ~(measured-expr-fn
-        (vec (keys arg-vals))
+        (vec arg-syms)
         expr
         options)
       (fn ~'measured-expr []

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -197,11 +197,16 @@
 (defn ^:no-doc capture-arg-types
   "Use eval to get types of the arg expressions.
   Return a sequence of metadata maps with :tag type hints.
-  Skips eval for local bindings (returns nil metadata for them)."
+  For local bindings, preserves user-provided type hints from the expression.
+  For non-locals, uses eval to detect types at compile time."
   [arg-syms arg-vals local-arg-syms]
   (mapv (fn [arg-sym]
           (if (contains? local-arg-syms arg-sym)
-            nil ; locals can't be eval'd at compile time
+            ;; For locals, preserve user-provided hints from the expression
+            (let [arg-val (get arg-vals arg-sym)]
+              (when-let [tag (:tag (meta arg-val))]
+                {:tag tag}))
+            ;; For non-locals, eval to get the type
             (tag-meta (type (eval (get arg-vals arg-sym))))))
         arg-syms))
 

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -138,22 +138,73 @@
     (testing "local-arg-val?"
       (testing "returns true for symbol in env"
         (is (true? (impl/local-arg-val? 'x env))))
+      (testing "returns true for expression containing symbol in env"
+        (is (true? (impl/local-arg-val? '(+ x 1) env)))
+        (is (true? (impl/local-arg-val? '(foo (bar x)) env))))
       (testing "returns false for symbol not in env"
         (is (false? (impl/local-arg-val? 'z env))))
-      (testing "returns false for non-symbol"
+      (testing "returns false for expression not containing locals"
+        (is (false? (impl/local-arg-val? '(+ 1 2) env))))
+      (testing "returns false for non-symbol non-expression"
         (is (false? (impl/local-arg-val? 42 env)))
         (is (false? (impl/local-arg-val? "string" env)))))))
 
 (deftest identify-local-args-test
   (let [env      {'x 'local-binding-x 'y 'local-binding-y}
-        arg-vals {'arg1 'x    ; local
-                  'arg2 '(+ 1 2) ; constant expression
-                  'arg3 'y    ; local
-                  'arg4 'z}]  ; not a local
+        arg-vals {'arg1 'x         ; local symbol
+                  'arg2 '(+ 1 2)   ; constant expression
+                  'arg3 'y         ; local symbol
+                  'arg4 'z         ; not a local
+                  'arg5 '(+ x 1)}] ; expression containing local
     (testing "identify-local-args"
       (testing "returns empty set when env is nil"
         (is (= #{} (impl/identify-local-args arg-vals nil))))
-      (testing "identifies arg-syms whose values are locals"
-        (is (= #{'arg1 'arg3} (impl/identify-local-args arg-vals env))))
+      (testing "identifies arg-syms whose values are or contain locals"
+        (is (= #{'arg1 'arg3 'arg5} (impl/identify-local-args arg-vals env))))
       (testing "returns empty set when no arg-vals are locals"
         (is (= #{} (impl/identify-local-args {'a '(+ 1 2)} env)))))))
+
+;;; Local capture integration tests
+;; Tests verifying that locals are correctly captured and passed through
+;; the measurement pipeline.
+
+(deftest expr-local-capture-test
+  (testing "measured/expr with local bindings"
+    (testing "captures simple local binding"
+      (let [x   42
+            m   (measured/expr (+ x 1))
+            res (second (invoke m))]
+        (is (= 43 res))))
+    (testing "captures collection local"
+      (let [coll [1 2 3 4 5]
+            m    (measured/expr (reduce + coll))
+            res  (second (invoke m))]
+        (is (= 15 res))))
+    (testing "captures multiple locals"
+      (let [a 10
+            b 20
+            m (measured/expr (+ a b))
+            res (second (invoke m))]
+        (is (= 30 res))))
+    (testing "captures local in nested expression"
+      (let [x 5
+            m (measured/expr (* 2 (+ x 3)))
+            res (second (invoke m))]
+        (is (= 16 res))))
+    (testing "mixes locals with constants"
+      (let [x 10
+            m (measured/expr (+ x (+ 1 2)))
+            res (second (invoke m))]
+        (is (= 13 res))))
+    (testing "captures local used multiple times"
+      (let [x 3
+            m (measured/expr (+ x x x))
+            res (second (invoke m))]
+        (is (= 9 res))))
+    (testing "works in loop binding context"
+      (let [results (atom [])]
+        (doseq [i (range 3)]
+          (let [m   (measured/expr (+ i 10))
+                res (second (invoke m))]
+            (swap! results conj res)))
+        (is (= [10 11 12] @results))))))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer [deftest is testing]]
    [criterium.agent :as agent]
    [criterium.jvm :as jvm]
-   [criterium.measured :as measured]))
+   [criterium.measured :as measured]
+   [criterium.measured.impl :as impl]))
 
 (defn- inc-long [x] (inc (long x)))
 
@@ -95,3 +96,64 @@
         (tap> {:zero-garbage-test
                {:allocations (frequencies thread-allocations)}}))
       (is (= [1 2] ret) "hold reference to return value until end of test"))))
+
+;;; Local detection tests
+;; Tests for the local binding detection functionality used by measured-expr*.
+;; These verify that locals from &env are correctly identified in expressions.
+
+(deftest collect-symbols-test
+  (testing "collect-symbols"
+    (testing "returns empty set for non-symbol expressions"
+      (is (= #{} (impl/collect-symbols 42)))
+      (is (= #{} (impl/collect-symbols "string")))
+      (is (= #{} (impl/collect-symbols nil))))
+    (testing "returns singleton set for symbol"
+      (is (= #{'x} (impl/collect-symbols 'x))))
+    (testing "collects symbols from list"
+      (is (= #{'+ 'x 'y} (impl/collect-symbols '(+ x y)))))
+    (testing "collects symbols from nested expressions"
+      (is (= #{'+ '* 'a 'b 'c} (impl/collect-symbols '(+ (* a b) c)))))
+    (testing "collects symbols from vectors"
+      (is (= #{'a 'b} (impl/collect-symbols '[a b]))))
+    (testing "collects symbols from maps"
+      (is (= #{'val} (impl/collect-symbols '{:key val}))))))
+
+(deftest locals-in-expr-test
+  ;; Simulated env maps, structured like Clojure's &env
+  (let [env {'x 'local-binding-x 'y 'local-binding-y}]
+    (testing "locals-in-expr"
+      (testing "returns empty set when env is nil"
+        (is (= #{} (impl/locals-in-expr '(+ x y) nil))))
+      (testing "returns empty set when no locals match"
+        (is (= #{} (impl/locals-in-expr '(+ a b) env))))
+      (testing "identifies single local in expression"
+        (is (= #{'x} (impl/locals-in-expr '(+ x 1) env))))
+      (testing "identifies multiple locals"
+        (is (= #{'x 'y} (impl/locals-in-expr '(+ x y) env))))
+      (testing "handles nested expressions with locals"
+        (is (= #{'x 'y} (impl/locals-in-expr '(foo (bar x) (baz y z)) env)))))))
+
+(deftest local-arg-val-test
+  (let [env {'x 'local-binding-x}]
+    (testing "local-arg-val?"
+      (testing "returns true for symbol in env"
+        (is (true? (impl/local-arg-val? 'x env))))
+      (testing "returns false for symbol not in env"
+        (is (false? (impl/local-arg-val? 'z env))))
+      (testing "returns false for non-symbol"
+        (is (false? (impl/local-arg-val? 42 env)))
+        (is (false? (impl/local-arg-val? "string" env)))))))
+
+(deftest identify-local-args-test
+  (let [env      {'x 'local-binding-x 'y 'local-binding-y}
+        arg-vals {'arg1 'x    ; local
+                  'arg2 '(+ 1 2) ; constant expression
+                  'arg3 'y    ; local
+                  'arg4 'z}]  ; not a local
+    (testing "identify-local-args"
+      (testing "returns empty set when env is nil"
+        (is (= #{} (impl/identify-local-args arg-vals nil))))
+      (testing "identifies arg-syms whose values are locals"
+        (is (= #{'arg1 'arg3} (impl/identify-local-args arg-vals env))))
+      (testing "returns empty set when no arg-vals are locals"
+        (is (= #{} (impl/identify-local-args {'a '(+ 1 2)} env)))))))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -23,12 +23,12 @@
 
 (deftest measured-test
   (let [eval-count (volatile! 0)
-        m          (measured/measured
-                    (fn [] :arg)
-                    (fn [arg ^long n]
-                      (vswap! eval-count #(+ n ^long %))
-                      [1 [arg arg]])
-                    (fn [] ::symbolic))]
+        m (measured/measured
+           (fn [] :arg)
+           (fn [arg ^long n]
+             (vswap! eval-count #(+ n ^long %))
+             [1 [arg arg]])
+           (fn [] ::symbolic))]
     (is (measured/measured? m))
     (is (= ::symbolic (measured/symbolic m)))
     (testing "invoke calls the function with one eval"
@@ -51,8 +51,8 @@
     (let [fncall-m (measured/expr (identity ::value))]
       (is (= ::value (second (invoke fncall-m))))))
   (testing "recursive function call"
-    (let [call-count         (volatile! 0)
-          f                  (fn [v] (vswap! call-count inc-long) v)
+    (let [call-count (volatile! 0)
+          f (fn [v] (vswap! call-count inc-long) v)
           recursive-fncall-m (measured/expr (f (f ::value)))]
       (is (= ::value (second (invoke recursive-fncall-m))))
       (is (= 2 @call-count))))
@@ -67,10 +67,10 @@
       (is (= 1 (second (invoke vec-nth-m))))))
   (testing "accepts time-fn option"
     (let [invokes (volatile! 0)
-          f       (fn ^long []
-                    (vswap! invokes inc-long)
-                    (jvm/thread-cpu-time))
-          m       (measured/expr 1 {:time-fn f})]
+          f (fn ^long []
+              (vswap! invokes inc-long)
+              (jvm/thread-cpu-time))
+          m (measured/expr 1 {:time-fn f})]
       (is (= 1 (second (invoke m))))
       (is (= 2 @invokes))))
   (testing "with transduce"
@@ -80,15 +80,15 @@
 
 (deftest zero-garbage-test
   (testing "return value is zero garbage"
-    (let [measured              (measured/measured
-                                 (fn [] nil)
-                                 (fn [_ _] [1 2]))
-          _                     (dotimes [_ 1000]
-                                  (measured/invoke measured nil 1))
-          [allocations ret]     (agent/with-allocation-tracing
-                                  (measured/invoke measured nil 1))
-          thread-allocations    (->> allocations
-                                     (filterv (agent/allocation-on-thread?)))
+    (let [measured (measured/measured
+                    (fn [] nil)
+                    (fn [_ _] [1 2]))
+          _ (dotimes [_ 1000]
+              (measured/invoke measured nil 1))
+          [allocations ret] (agent/with-allocation-tracing
+                              (measured/invoke measured nil 1))
+          thread-allocations (->> allocations
+                                  (filterv (agent/allocation-on-thread?)))
           {:keys [freed-bytes]} (-> thread-allocations
                                     agent/allocations-summary)]
       (is (zero? freed-bytes) thread-allocations)
@@ -150,11 +150,11 @@
         (is (false? (impl/local-arg-val? "string" env)))))))
 
 (deftest identify-local-args-test
-  (let [env      {'x 'local-binding-x 'y 'local-binding-y}
-        arg-vals {'arg1 'x         ; local symbol
-                  'arg2 '(+ 1 2)   ; constant expression
-                  'arg3 'y         ; local symbol
-                  'arg4 'z         ; not a local
+  (let [env {'x 'local-binding-x 'y 'local-binding-y}
+        arg-vals {'arg1 'x ; local symbol
+                  'arg2 '(+ 1 2) ; constant expression
+                  'arg3 'y ; local symbol
+                  'arg4 'z ; not a local
                   'arg5 '(+ x 1)}] ; expression containing local
     (testing "identify-local-args"
       (testing "returns empty set when env is nil"
@@ -171,40 +171,40 @@
 (deftest expr-local-capture-test
   (testing "measured/expr with local bindings"
     (testing "captures simple local binding"
-      (let [x   42
-            m   (measured/expr (+ x 1))
+      (let [x (long 42)
+            m (measured/expr (+ x 1))
             res (second (invoke m))]
         (is (= 43 res))))
     (testing "captures collection local"
       (let [coll [1 2 3 4 5]
-            m    (measured/expr (reduce + coll))
-            res  (second (invoke m))]
+            m (measured/expr (reduce + coll))
+            res (second (invoke m))]
         (is (= 15 res))))
     (testing "captures multiple locals"
-      (let [a 10
-            b 20
+      (let [a (long 10)
+            b (long 20)
             m (measured/expr (+ a b))
             res (second (invoke m))]
         (is (= 30 res))))
     (testing "captures local in nested expression"
-      (let [x 5
+      (let [x (long 5)
             m (measured/expr (* 2 (+ x 3)))
             res (second (invoke m))]
         (is (= 16 res))))
     (testing "mixes locals with constants"
-      (let [x 10
+      (let [x (long 10)
             m (measured/expr (+ x (+ 1 2)))
             res (second (invoke m))]
         (is (= 13 res))))
     (testing "captures local used multiple times"
-      (let [x 3
+      (let [x (long 3)
             m (measured/expr (+ x x x))
             res (second (invoke m))]
         (is (= 9 res))))
     (testing "works in loop binding context"
       (let [results (atom [])]
         (doseq [i (range 3)]
-          (let [m   (measured/expr (+ i 10))
+          (let [m (measured/expr (+ ^long i 10))
                 res (second (invoke m))]
             (swap! results conj res)))
         (is (= [10 11 12] @results))))))
@@ -216,30 +216,57 @@
 (deftest capture-arg-types-test
   (testing "capture-arg-types"
     (testing "returns nil for unhinted local symbol"
-      (let [arg-vals      {'arg1 'x}
+      (let [arg-vals {'arg1 'x}
             local-arg-syms #{'arg1}]
         (is (= [nil] (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
     (testing "preserves user hint on local symbol"
-      (let [arg-vals       {'arg1 (with-meta 'x {:tag 'long})}
+      (let [arg-vals {'arg1 (with-meta 'x {:tag 'long})}
             local-arg-syms #{'arg1}]
         (is (= [{:tag 'long}]
                (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
     (testing "preserves user hint on local with class tag"
-      (let [arg-vals       {'arg1 (with-meta 'x {:tag 'String})}
+      (let [arg-vals {'arg1 (with-meta 'x {:tag 'String})}
             local-arg-syms #{'arg1}]
         (is (= [{:tag 'String}]
                (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
     (testing "uses eval for non-local constants"
-      (let [arg-vals       {'arg1 42}
+      (let [arg-vals {'arg1 42}
             local-arg-syms #{}]
         (is (= [{:tag 'long}]
                (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
     (testing "handles mixed locals and constants"
-      (let [arg-vals       {'arg1 (with-meta 'x {:tag 'double})
-                            'arg2 "string"
-                            'arg3 'y}
+      (let [arg-vals {'arg1 (with-meta 'x {:tag 'double})
+                      'arg2 "string"
+                      'arg3 'y}
             local-arg-syms #{'arg1 'arg3}]
         (is (= [{:tag 'double}
                 {:tag 'java.lang.String}
                 nil]
                (impl/capture-arg-types ['arg1 'arg2 'arg3] arg-vals local-arg-syms)))))))
+
+;;; Acceptance Criteria Tests
+;; Tests matching the exact examples from the story acceptance criteria.
+
+(deftest acceptance-criteria-test
+  ;; This test verifies the exact acceptance criteria from the story:
+  ;; - Simple local binding
+  ;; - Collection local
+  ;; - Loop binding
+  (testing "measured/expr acceptance criteria"
+    (testing "simple local binding: (let [x 42] (measured/expr (+ x 1)))"
+      (let [x (long 42)
+            m (measured/expr (+ x 1))
+            res (second (invoke m))]
+        (is (= 43 res))))
+    (testing "collection local: (let [coll (vec (range 1000))] (measured/expr (reduce + coll)))"
+      (let [coll (vec (range 1000))
+            m (measured/expr (reduce + coll))
+            res (second (invoke m))]
+        (is (= 499500 res))))
+    (testing "loop binding: (doseq [i (range 3)] (measured/expr (+ i 2)))"
+      (let [results (atom [])]
+        (doseq [i (range 3)]
+          (let [m (measured/expr (+ ^long i 2))
+                res (second (invoke m))]
+            (swap! results conj res)))
+        (is (= [2 3 4] @results))))))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -208,3 +208,38 @@
                 res (second (invoke m))]
             (swap! results conj res)))
         (is (= [10 11 12] @results))))))
+
+;;; Type hint tests for locals
+;; Tests verifying that user-provided type hints on locals are preserved,
+;; while unhinted locals work without hints (accepting reflection warnings).
+
+(deftest capture-arg-types-test
+  (testing "capture-arg-types"
+    (testing "returns nil for unhinted local symbol"
+      (let [arg-vals      {'arg1 'x}
+            local-arg-syms #{'arg1}]
+        (is (= [nil] (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+    (testing "preserves user hint on local symbol"
+      (let [arg-vals       {'arg1 (with-meta 'x {:tag 'long})}
+            local-arg-syms #{'arg1}]
+        (is (= [{:tag 'long}]
+               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+    (testing "preserves user hint on local with class tag"
+      (let [arg-vals       {'arg1 (with-meta 'x {:tag 'String})}
+            local-arg-syms #{'arg1}]
+        (is (= [{:tag 'String}]
+               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+    (testing "uses eval for non-local constants"
+      (let [arg-vals       {'arg1 42}
+            local-arg-syms #{}]
+        (is (= [{:tag 'long}]
+               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+    (testing "handles mixed locals and constants"
+      (let [arg-vals       {'arg1 (with-meta 'x {:tag 'double})
+                            'arg2 "string"
+                            'arg3 'y}
+            local-arg-syms #{'arg1 'arg3}]
+        (is (= [{:tag 'double}
+                {:tag 'java.lang.String}
+                nil]
+               (impl/capture-arg-types ['arg1 'arg2 'arg3] arg-vals local-arg-syms)))))))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -215,25 +215,25 @@
 
 (deftest capture-arg-types-test
   (testing "capture-arg-types"
-    (testing "returns nil for unhinted local symbol"
+    (testing "returns nil for unhinted local symbol without env"
       (let [arg-vals {'arg1 'x}
             local-arg-syms #{'arg1}]
-        (is (= [nil] (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+        (is (= [nil] (impl/capture-arg-types ['arg1] arg-vals local-arg-syms nil)))))
     (testing "preserves user hint on local symbol"
       (let [arg-vals {'arg1 (with-meta 'x {:tag 'long})}
             local-arg-syms #{'arg1}]
         (is (= [{:tag 'long}]
-               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms nil)))))
     (testing "preserves user hint on local with class tag"
       (let [arg-vals {'arg1 (with-meta 'x {:tag 'String})}
             local-arg-syms #{'arg1}]
         (is (= [{:tag 'String}]
-               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms nil)))))
     (testing "uses eval for non-local constants"
       (let [arg-vals {'arg1 42}
             local-arg-syms #{}]
         (is (= [{:tag 'long}]
-               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms)))))
+               (impl/capture-arg-types ['arg1] arg-vals local-arg-syms nil)))))
     (testing "handles mixed locals and constants"
       (let [arg-vals {'arg1 (with-meta 'x {:tag 'double})
                       'arg2 "string"
@@ -242,7 +242,7 @@
         (is (= [{:tag 'double}
                 {:tag 'java.lang.String}
                 nil]
-               (impl/capture-arg-types ['arg1 'arg2 'arg3] arg-vals local-arg-syms)))))))
+               (impl/capture-arg-types ['arg1 'arg2 'arg3] arg-vals local-arg-syms nil)))))))
 
 ;;; Acceptance Criteria Tests
 ;; Tests matching the exact examples from the story acceptance criteria.

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -171,40 +171,40 @@
 (deftest expr-local-capture-test
   (testing "measured/expr with local bindings"
     (testing "captures simple local binding"
-      (let [x (long 42)
-            m (measured/expr (+ x 1))
+      (let [x   42
+            m   (measured/expr (+ x 1))
             res (second (invoke m))]
         (is (= 43 res))))
     (testing "captures collection local"
       (let [coll [1 2 3 4 5]
-            m (measured/expr (reduce + coll))
-            res (second (invoke m))]
+            m    (measured/expr (reduce + coll))
+            res  (second (invoke m))]
         (is (= 15 res))))
     (testing "captures multiple locals"
-      (let [a (long 10)
-            b (long 20)
-            m (measured/expr (+ a b))
+      (let [a   10
+            b   20
+            m   (measured/expr (+ a b))
             res (second (invoke m))]
         (is (= 30 res))))
     (testing "captures local in nested expression"
-      (let [x (long 5)
-            m (measured/expr (* 2 (+ x 3)))
+      (let [x   5
+            m   (measured/expr (* 2 (+ x 3)))
             res (second (invoke m))]
         (is (= 16 res))))
     (testing "mixes locals with constants"
-      (let [x (long 10)
-            m (measured/expr (+ x (+ 1 2)))
+      (let [x   10
+            m   (measured/expr (+ x 1 2))
             res (second (invoke m))]
         (is (= 13 res))))
     (testing "captures local used multiple times"
-      (let [x (long 3)
-            m (measured/expr (+ x x x))
+      (let [x   3
+            m   (measured/expr (+ x x x))
             res (second (invoke m))]
         (is (= 9 res))))
     (testing "works in loop binding context"
       (let [results (atom [])]
-        (doseq [i (range 3)]
-          (let [m (measured/expr (+ ^long i 10))
+        (doseq [^long i (range 3)]
+          (let [m   (measured/expr (+ i 10))
                 res (second (invoke m))]
             (swap! results conj res)))
         (is (= [10 11 12] @results))))))
@@ -254,19 +254,19 @@
   ;; - Loop binding
   (testing "measured/expr acceptance criteria"
     (testing "simple local binding: (let [x 42] (measured/expr (+ x 1)))"
-      (let [x (long 42)
-            m (measured/expr (+ x 1))
+      (let [x   42
+            m   (measured/expr (+ x 1))
             res (second (invoke m))]
         (is (= 43 res))))
     (testing "collection local: (let [coll (vec (range 1000))] (measured/expr (reduce + coll)))"
       (let [coll (vec (range 1000))
-            m (measured/expr (reduce + coll))
-            res (second (invoke m))]
+            m    (measured/expr (reduce + coll))
+            res  (second (invoke m))]
         (is (= 499500 res))))
     (testing "loop binding: (doseq [i (range 3)] (measured/expr (+ i 2)))"
       (let [results (atom [])]
-        (doseq [i (range 3)]
-          (let [m (measured/expr (+ ^long i 2))
+        (doseq [^long i (range 3)]
+          (let [m   (measured/expr (+ i 2))
                 res (second (invoke m))]
             (swap! results conj res)))
         (is (= [2 3 4] @results))))))

--- a/bases/notebooks/src/criterium/basic_usage_notebook.clj
+++ b/bases/notebooks/src/criterium/basic_usage_notebook.clj
@@ -125,8 +125,7 @@
 
 ;; ### Comparing Implementations
 ;;
-;; Use `last-bench` to compare different implementations.
-;; Define test data at namespace level since bench can't use locals:
+;; Use `last-bench` to compare different implementations:
 
 (def numbers-for-sum
   "Test data for comparing sum implementations."
@@ -155,17 +154,14 @@
 
 ;; ### Isolate What You Measure
 ;;
-;; Define setup data outside the bench expression. Since bench expressions
-;; cannot reference locals, use def or pass data as function arguments:
-
-(def large-data
-  "Pre-computed data for benchmarking."
-  (vec (range 10000)))
+;; Separate data setup from the code being measured. You can use local bindings
+;; directly in bench expressions:
 
 (defn bench-with-setup
-  "Demonstrate separating setup from measurement."
+  "Demonstrate using local bindings in bench."
   []
-  (bench/bench (reduce + large-data)))
+  (let [large-data (vec (range 10000))]
+    (bench/bench (reduce + large-data))))
 
 ;; ### Avoid Side Effects
 ;;
@@ -181,22 +177,22 @@
 ;; The JIT compiler optimizes hot code paths. Criterium handles warmup
 ;; automatically, but initial runs may be slower.
 
-;; ## Important Constraint
+;; ## Using Local Bindings
 ;;
-;; The bench macro cannot reference local bindings. Expressions must use:
-;; - Literals
-;; - Vars (def'd values)
-;; - Function calls with literal or var arguments
-;;
-;; This works:
+;; The bench macro supports local bindings from the enclosing scope.
+;; This makes it easy to benchmark with dynamically created data:
 
-(kind/code "(def data [1 2 3])
-(bench (reduce + data))")
+(let [data (vec (range 1000))]
+  (bench/bench (reduce + data)))
 
-;; This does NOT work:
+;; Local bindings work in loop contexts too:
 
-(kind/code "(let [data [1 2 3]]
-  (bench (reduce + data)))  ; Error: Can't eval locals")
+(doseq [size [100 1000 10000]]
+  (println
+   "Size:" size
+   "," (-> (bench/bench (reduce + (range size)) :return-value [] :viewer :none)
+           (util/stats-value :stats :elapsed-time :mean))
+   "ns"))
 
 ;; ## Running Examples
 ;;


### PR DESCRIPTION
## Summary

- Enable the `expr` macro in `criterium.measured` to capture and use local bindings as arguments to the measured expression
- Extract type information from `LocalBinding` in `&env` to preserve primitive type hints
- Infer types for compound expressions containing locals when all locals have the same primitive type

## Acceptance Criteria

All three acceptance criteria from issue #142 are now supported:

```clojure
;; Simple local binding
(let [x 42] (measured/expr (+ x 1)))

;; Collection local  
(let [coll (vec (range 1000))] (measured/expr (reduce + coll)))

;; Loop binding
(doseq [i (range 3)] (measured/expr (+ i 2)))
```

## Test plan

- [x] Unit tests for local detection (`collect-symbols`, `locals-in-expr`, `local-arg-val?`, `identify-local-args`)
- [x] Unit tests for type capture (`capture-arg-types-test`)
- [x] Integration tests for local capture (`expr-local-capture-test`)
- [x] Acceptance criteria tests (`acceptance-criteria-test`)
- [x] All existing tests pass

Closes #142