### PR TITLE
feat(viewer): Add Kindly output viewer for Clay notebook integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,8 +13,7 @@ This is currently version 0.5.x (ALPHA) which represents a significant architect
 ### Testing
 ```bash
 # Prepare dependencies with Java sources (required once after checkout or deps.edn changes)
-cd bases/agent && clojure -T:deps prep
-cd bases/blackhole && clojure -T:deps prep
+cd bases/criterium && clojure -T:deps prep
 
 # Run tests with Kaocha
 clojure -M:kaocha:dev:test --reporter dots

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -184,3 +184,8 @@ When using the `:portal` viewer:
 - Function docstrings precede argument vectors
 - Comprehensive namespace documentation required
 - Test files mirror source structure with `_test` suffix
+
+- if you see Exception:
+    clojure.lang.Compiler$CompilerException: Syntax error macroexpanding at (criterium/agent.clj:144:1)
+  then you need to prepare the java libs with:
+    cd bases/criterium && clojure -T:deps prep

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,7 +6,8 @@
    criterium.util.forms/cond*          hooks.impl/cond*}}
  :lint-as {clojure.test.check.clojure-test/defspec clojure.core/def
            clojure.test.check.properties/for-all   clojure.core/let
-           criterium.util/optional-require         clojure.core/require}
+           criterium.util/optional-require         clojure.core/require
+           criterium.viewer.kindly-clay-test/with-temp-dir clj-kondo.lint-as/def-catch-all}
  :linters {:unused-bindings              {:exclude-defmulti-args true}
            :used-underscored-binding     {:level :warning}
            :unsorted-required-namespaces {:level :warning}}

--- a/bases/criterium/deps.edn
+++ b/bases/criterium/deps.edn
@@ -7,7 +7,8 @@
             {local/agent {:local/root "../agent"}
              org.clojure/clojure {:mvn/version "1.11.2"}
              expound/expound {:mvn/version "0.9.0"}
-             org.clojure/test.check {:mvn/version "1.1.1"}}}
+             org.clojure/test.check {:mvn/version "1.1.1"}
+             org.scicloj/clay {:mvn/version "2.0.3"}}}
            :kaocha {:extra-deps
                     {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                      lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -112,7 +112,7 @@
   Parameters:
     measured - A wrapped function/expression prepared for measurement
     options  - Map of configuration options:
-      :viewer      - Output format [:pprint, :portal, or nil(default)]
+      :viewer      - Output format [:print (default), :pprint, :portal, :kindly]
       :analyse     - Vector of analysis steps [[:outliers] [:stats]]
       :view       - Vector of view components [:stats]
       :metric-ids  - Vector of metrics to collect, from:
@@ -159,7 +159,7 @@
   Parameters:
     expr    - Expression to benchmark
     options - Keyword/value pairs for configuration:
-      :viewer      - Output format [:pprint, :portal, or nil(default)]
+      :viewer      - Output format [:print (default), :pprint, :portal, :kindly]
       :analyse     - Vector of analysis steps [[:outliers] [:stats]]
       :view       - Vector of view components [:stats]
       :metric-ids  - Vector of metrics to collect, from:

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -122,8 +122,9 @@
     (let [data-map (->> (collect-data-map
                          (:collector-config bench-plan)
                          (:collect-plan bench-plan) measured)
-                        (analyze (:analyse bench-plan)))]
-      (view (:view bench-plan) (:viewer bench-plan) data-map)
+                        (analyze (:analyse bench-plan)))
+          viewer-output (view (:view bench-plan) (:viewer bench-plan) data-map)
+          data-map (assoc-in data-map [:viewer :output] viewer-output)]
       (impl/last-bench! {:bench-plan bench-plan :data data-map})
       (return-value bench-plan data-map))))
 
@@ -226,9 +227,9 @@
   - Ensures statistical significance
   - Expression cannot refer to local bindings"
   [expr & options]
-  (let [options-map  (apply hash-map options)
+  (let [options-map (apply hash-map options)
         expr-options (select-keys options-map [:time-fn])
-        options      (dissoc options-map :time-fn)]
+        options (dissoc options-map :time-fn)]
     `(bench-measured
       (options->bench-plan ~options)
       (measured/expr ~expr ~expr-options))))

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -9,13 +9,16 @@
   - Statistical significance
 
   Primary API:
-  - bench         - Macro for benchmarking expressions
-  - bench-measured - Function for benchmarking pre-wrapped measurements
-  - last-bench    - Access results from most recent benchmark
+  - bench             - Macro for benchmarking expressions
+  - bench-measured    - Function for benchmarking pre-wrapped measurements
+  - last-bench        - Access results from most recent benchmark
+  - set-default-viewer! - Set default output viewer
+  - default-viewer    - Get current default viewer
 
   Example:
   (bench (+ 1 1))                 ; Basic usage
-  (bench (+ 1 1) :viewer :pprint) ; With pretty-printed output"
+  (bench (+ 1 1) :viewer :pprint) ; With pretty-printed output
+  (set-default-viewer! :kindly)   ; Set default for all bench calls"
   (:require
    [criterium.analyse]
    [criterium.bench.config :as bench-config]
@@ -25,6 +28,26 @@
    [criterium.collector :as collector]
    [criterium.measured :as measured]
    [criterium.util.output :as output]))
+
+(defn default-viewer
+  "Returns the current default viewer.
+
+  The default viewer is used when no explicit :viewer option is provided
+  to bench calls. Initial value is :print."
+  []
+  bench-config/*default-viewer*)
+
+(defn set-default-viewer!
+  "Set the default viewer for all bench calls that don't specify an explicit
+  :viewer option.
+
+  viewer - Keyword identifying the viewer, e.g. :print, :pprint, :portal, :kindly
+
+  Example:
+    (set-default-viewer! :kindly)
+    (bench (+ 1 1))  ; Now uses :kindly viewer by default"
+  [viewer]
+  (bench-config/set-default-viewer! viewer))
 
 (defn last-bench
   "Returns the complete measurement data from the most recent benchmark.
@@ -159,7 +182,8 @@
   Parameters:
     expr    - Expression to benchmark
     options - Keyword/value pairs for configuration:
-      :viewer      - Output format [:print (default), :pprint, :portal, :kindly]
+      :viewer      - Output format [:print, :pprint, :portal, :kindly]
+                     Default can be set via (set-default-viewer! :kindly)
       :analyse     - Vector of analysis steps [[:outliers] [:stats]]
       :view       - Vector of view components [:stats]
       :metric-ids  - Vector of metrics to collect, from:

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -124,7 +124,11 @@
                          (:collect-plan bench-plan) measured)
                         (analyze (:analyse bench-plan)))
           viewer-output (view (:view bench-plan) (:viewer bench-plan) data-map)
-          data-map (assoc-in data-map [:viewer :output] viewer-output)]
+          ;; Store viewer output as a proper data-entry-map
+          data-map (assoc data-map :viewer
+                          {:type :criterium/viewer-output
+                           :transform {:sample-> identity :->sample identity}
+                           :output viewer-output})]
       (impl/last-bench! {:bench-plan bench-plan :data data-map})
       (return-value bench-plan data-map))))
 

--- a/bases/criterium/src/criterium/bench/config.clj
+++ b/bases/criterium/src/criterium/bench/config.clj
@@ -13,6 +13,31 @@
    [criterium.viewer.pprint]
    [criterium.viewer.print]))
 
+(def ^:dynamic *default-viewer*
+  "Dynamic var for the default viewer to use when no explicit :viewer option
+  is provided. Initial value is :print.
+
+  This can be bound dynamically or altered via set-default-viewer!.
+
+  Precedence (highest to lowest):
+  1. Explicit :viewer option on bench call
+  2. :viewer from bench-plan (if provided)
+  3. This dynamic default viewer
+  4. Hard-coded fallback :print (if this var is nil)"
+  :print)
+
+(defn set-default-viewer!
+  "Set the default viewer for all bench calls that don't specify an explicit
+  :viewer option.
+
+  viewer - Keyword identifying the viewer, e.g. :print, :pprint, :portal, :kindly
+
+  Example:
+    (set-default-viewer! :kindly)
+    (bench (+ 1 1))  ; Now uses :kindly viewer by default"
+  [viewer]
+  (alter-var-root #'*default-viewer* (constantly viewer)))
+
 (defn metric-ids->collector-config
   [metric-ids]
   (let [metrics    (zipmap
@@ -84,7 +109,7 @@
                     [:return-value :verbose])
                    :collect-plan collect-plan
                    :collector-config collector-config
-                   :viewer (:viewer options-map :print)
+                   :viewer (:viewer options-map (or *default-viewer* :print))
                    :return-value (:return-value
                                   options-map
                                   [:samples :expr-value]))

--- a/bases/criterium/src/criterium/bench/config.clj
+++ b/bases/criterium/src/criterium/bench/config.clj
@@ -8,6 +8,7 @@
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.util.units :as units]
+   [criterium.viewer.kindly]
    [criterium.viewer.portal]
    [criterium.viewer.pprint]
    [criterium.viewer.print]))

--- a/bases/criterium/src/criterium/bench/config.clj
+++ b/bases/criterium/src/criterium/bench/config.clj
@@ -40,11 +40,11 @@
 
 (defn metric-ids->collector-config
   [metric-ids]
-  (let [metrics    (zipmap
-                    metric-ids
-                    (mapv collector/maybe-var-get-stage metric-ids))
+  (let [metrics (zipmap
+                 metric-ids
+                 (mapv collector/maybe-var-get-stage metric-ids))
         terminator (util/filter-map collector/terminal? metrics)
-        stages     (util/filter-map (complement collector/terminal?) metrics)]
+        stages (util/filter-map (complement collector/terminal?) metrics)]
     (when (> (count terminator) 1)
       (throw (ex-info
               "More than one terminal function specified in metric-ids"
@@ -53,7 +53,7 @@
       (throw (ex-info
               "Unknown metric-ids"
               {:metric-ids (keys unknown)})))
-    {:stages     (filterv stages metric-ids)
+    {:stages (filterv stages metric-ids)
      :terminator (or (some-> terminator
                              first
                              key)
@@ -63,44 +63,48 @@
   "Convert option arguments into a criterium configuration map.
   The config map specifies how criterium will execute."
   [options-map]
-  (let [unknown-keys     (set/difference
-                          (set (keys options-map))
-                          #{:limit-time-s
-                            :metric-ids
-                            :return-value
-                            :collect-plan
-                            :analyse
-                            :view
-                            :bench-plan
-                            :verbose
-                            :viewer})
-        limit-time-s     (:limit-time-s options-map)
-        analyse          (:analyse options-map)
-        view             (:view options-map)
-        bench-plan       (:bench-plan options-map)
-        options-map      (cond-> options-map
-                           (:limit-time-s options-map)
-                           (assoc :limit-time-ns
-                                  (* (long limit-time-s)
-                                     (long units/SEC-NS))))
-        collect-plan     (or (:collect-plan options-map)
-                             (:collect-plan bench-plan)
-                             :with-jit-warmup)
-        collect-plan     (if (keyword? collect-plan)
-                           (collect-plan-config/collect-plan-config
-                            collect-plan
-                            options-map)
-                           (collect-plan-config/collect-plan-config
-                            (:scheme-type collect-plan)
-                            options-map))
-        scheme-type      (have (:scheme-type collect-plan))
+  (let [unknown-keys (set/difference
+                      (set (keys options-map))
+                      #{:limit-time-s
+                        :metric-ids
+                        :return-value
+                        :collect-plan
+                        :analyse
+                        :view
+                        :bench-plan
+                        :verbose
+                        :viewer})
+        limit-time-s (:limit-time-s options-map)
+        analyse (:analyse options-map)
+        view (:view options-map)
+        bench-plan (:bench-plan options-map)
+        viewer (:viewer options-map (or *default-viewer* :print))
+        options-map (cond-> options-map
+                      (:limit-time-s options-map)
+                      (assoc :limit-time-ns
+                             (* (long limit-time-s)
+                                (long units/SEC-NS))))
+        collect-plan (or (:collect-plan options-map)
+                         (:collect-plan bench-plan)
+                         :with-jit-warmup)
+        collect-plan (if (keyword? collect-plan)
+                       (collect-plan-config/collect-plan-config
+                        collect-plan
+                        options-map)
+                       (collect-plan-config/collect-plan-config
+                        (:scheme-type collect-plan)
+                        options-map))
+        scheme-type (have (:scheme-type collect-plan))
         collector-config (->>
                           (or (when-let [metric-ids (:metric-ids options-map)]
                                 (metric-ids->collector-config metric-ids))
                               (:collector-config bench-plan)
                               collector-configs/default-collector-config)
                           (collect-plan-config/ensure-pipeline-stages
-                           scheme-type))]
+                           scheme-type))
+        default-return (if (= viewer :kindly)
+                         [:viewer :output]
+                         [:samples :expr-value])]
 
     (when (seq unknown-keys)
       (throw (ex-info "Unknown options" {:options unknown-keys})))
@@ -109,10 +113,8 @@
                     [:return-value :verbose])
                    :collect-plan collect-plan
                    :collector-config collector-config
-                   :viewer (:viewer options-map (or *default-viewer* :print))
-                   :return-value (:return-value
-                                  options-map
-                                  [:samples :expr-value]))
+                   :viewer viewer
+                   :return-value (:return-value options-map default-return))
 
       (= scheme-type :with-jit-warmup)
       (assoc :analyse (or analyse

--- a/bases/criterium/src/criterium/benchmark.clj
+++ b/bases/criterium/src/criterium/benchmark.clj
@@ -88,8 +88,7 @@
       {:pre [(have? keyword? viewer)
              (have? types/result-map? result)]}
       (run! #(% viewer result) fns)
-      (view/flush-viewer viewer)
-      result)))
+      (or (view/flush-viewer viewer) result))))
 
 (defn ->benchmark
   "Compose a benchmark based on a declarative map.

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -17,34 +17,35 @@
   Returns a Vega-Lite layer spec."
   [metric->values transforms outliers metric]
   {:pre [(have? map? metric->values)]}
-  (let [path       (:path metric)
-        k          (first path)
+  (let [path (:path metric)
+        k (first path)
         field-name (name k)
-        data       (mapv
-                    #(let [outlier (get
-                                    (:outliers (get-in outliers path))
-                                    %2
-                                    "")]
-                       (assoc
-                        {k
-                         (util/transform-sample->
-                          %1
-                          transforms)}
-                        :index %2
-                        :outlier outlier))
-                    (have some?
-                          (metric->values path)
-                          {:path path :available (keys metric->values)})
-                    (range))]
-    {:data     {:values data}
-     :encoding {:x       {:field "index" :type "quantitative"}
-                :y       {:field field-name
-                          :type  "quantitative"
-                          :scale {:zero false}}
+        data (mapv
+              #(let [outlier (get
+                              (:outliers (get-in outliers path))
+                              %2
+                              "")]
+                 (assoc
+                  {k
+                   (util/transform-sample->
+                    %1
+                    transforms)}
+                  :index %2
+                  :outlier outlier))
+              (have some?
+                    (metric->values path)
+                    {:path path :available (keys metric->values)})
+              (range))]
+    {:data {:values data}
+     :encoding {:x {:field "index" :type "quantitative"}
+                :y {:field field-name
+                    :type "quantitative"
+                    :scale {:zero false}}
                 :tooltip [{:field "index" :type "quantitative"}
                           {:field field-name :type "quantitative"}]
-                :color   {:field "outlier"}}
-     :mark     "point"}))
+                :color {:field "outlier"
+                        :legend {:orient "top-left" :offset 10}}}
+     :mark "point"}))
 
 ;;; Histograms
 
@@ -53,45 +54,46 @@
 
   Returns a Vega-Lite layer spec for displaying histogram bins."
   [transforms histogram metric _layer-num]
-  (let [path       (:path metric)
-        k          (first path)
+  (let [path (:path metric)
+        k (first path)
         field-name (name k)
         {:keys [counts centers widths width density]}
         histogram
 
-        tform   #(util/transform-sample-> % transforms)
+        tform #(util/transform-sample-> % transforms)
         centers (mapv tform centers)
-        widths  (when widths (mapv tform widths))
-        width   (when width (tform width))
-        data    (if widths
+        widths (when widths (mapv tform widths))
+        width (when width (tform width))
+        data (if widths
                   ;; Variable width histogram
-                  (mapv (fn [_count ^double center ^double width density]
-                          (let [half-w (* 0.95 (/ width 2.0))]
-                            {field-name (- center half-w)
-                             "end"      (+ center half-w)
-                             "density"  density}))
-                        counts centers widths density)
+               (mapv (fn [_count ^double center ^double width density]
+                       (let [half-w (* 0.95 (/ width 2.0))]
+                         {field-name (- center half-w)
+                          "end" (+ center half-w)
+                          "density" density}))
+                     counts centers widths density)
                   ;; Fixed width histogram
-                  (mapv (fn [_count ^double center ^double density]
-                          (let [half-w (* 0.95 (/ (double width) 2.0))]
-                            {field-name (- center half-w)
-                             "end"      (+ center half-w)
-                             "density"  density}))
-                        counts centers density))]
-    {:data      {:values data}
+               (mapv (fn [_count ^double center ^double density]
+                       (let [half-w (* 0.95 (/ (double width) 2.0))]
+                         {field-name (- center half-w)
+                          "end" (+ center half-w)
+                          "density" density}))
+                     counts centers density))]
+    {:data {:values data}
      :transform [{:calculate (str "'" "Histogram " (:label metric) "'") :as "layer"}]
-     :encoding  {:y2    {:datum 0
-                         :type  "quantitative"}
-                 :y     {:field "density"
-                         :type  "quantitative"}
-                 :x     {:field field-name
-                         :type  "quantitative"
-                         :scale {:zero false}}
-                 :x2    {:field "end"
-                         :type  "quantitative"}
-                 :color {:field "layer" :type "nominal"}}
-     :mark      {:type       "bar"
-                 :binSpacing 0}}))
+     :encoding {:y2 {:datum 0
+                     :type "quantitative"}
+                :y {:field "density"
+                    :type "quantitative"}
+                :x {:field field-name
+                    :type "quantitative"
+                    :scale {:zero false}}
+                :x2 {:field "end"
+                     :type "quantitative"}
+                :color {:field "layer" :type "nominal"
+                        :legend {:orient "top-left" :offset 10}}}
+     :mark {:type "bar"
+            :binSpacing 0}}))
 
 ;;; Normal distribution overlay
 
@@ -102,7 +104,7 @@
   [min-val max-val mean variance transforms]
   (let [sigma (Math/sqrt variance)
         delta (/ (- (double max-val) (double min-val)) 120)
-        pdf   (probability/normal-pdf mean sigma)]
+        pdf (probability/normal-pdf mean sigma)]
     (mapv
      (fn [z]
        {:z (util/transform-sample-> z transforms)
@@ -118,7 +120,7 @@
   (let [{:keys [mean-minus-3sigma mean-plus-3sigma mean variance]}
         stats
         path (:path metric-config)
-        k    (first path)
+        k (first path)
         data (normal-pdf-points
               mean-minus-3sigma
               mean-plus-3sigma
@@ -127,28 +129,29 @@
               transforms)]
     [{:resolve {:scale {:y "shared"}}
       :layer
-      [{:data      {:values data}
+      [{:data {:values data}
         :transform [{:calculate
                      (str "'" "LogNormal fit " (:label metric-config) "'")
                      :as "layer"}]
-        :encoding  {:x       {:field "z"
-                              :type  "quantitative"
-                              :scale {:zero false}}
-                    :y       {:field "p"
-                              :type  "quantitative"}
-                    :tooltip [{:field (name k)
-                               :title "Normal"}]
-                    :color   {:field "layer" :type "nominal"}}
-        :mark      {:type "line"}}
-       {:data     {:values [{k
-                             (util/transform-sample-> mean transforms)
-                             :title "mean"}]}
-        :encoding {:x       {:field (name k)
-                             :type  "quantitative"
-                             :scale {:zero false}}
+        :encoding {:x {:field "z"
+                       :type "quantitative"
+                       :scale {:zero false}}
+                   :y {:field "p"
+                       :type "quantitative"}
+                   :tooltip [{:field (name k)
+                              :title "Normal"}]
+                   :color {:field "layer" :type "nominal"
+                           :legend {:orient "top-left" :offset 10}}}
+        :mark {:type "line"}}
+       {:data {:values [{k
+                         (util/transform-sample-> mean transforms)
+                         :title "mean"}]}
+        :encoding {:x {:field (name k)
+                       :type "quantitative"
+                       :scale {:zero false}}
                    :tooltip [{:field (name k)
                               :title (str "Mean " (name k))}]}
-        :mark     "rule"}]}]))
+        :mark "rule"}]}]))
 
 ;;; Event markers
 
@@ -160,7 +163,7 @@
   (reduce
    (fn [res metric-config]
      (let [path (:path metric-config)
-           v    (get (get events path) index)]
+           v (get (get events path) index)]
        (if (pos? (long v))
          (assoc res (viewer-common/composite-key path) v :index index)
          res)))
@@ -179,11 +182,11 @@
                               count)))
                   (filterv some?))]
     (when (seq data)
-      [{:data     {:values data}
-        :encoding {:x       {:field "index"
-                             :type  "quantitative"}
-                   :color   {:vvalue "white"}
-                   :size    {:value 2},
+      [{:data {:values data}
+        :encoding {:x {:field "index"
+                       :type "quantitative"}
+                   :color {:vvalue "white"}
+                   :size {:value 2},
                    :tooltip (conj
                              (mapv
                               #(hash-map
@@ -193,8 +196,8 @@
                                 :title (str (:label metrics) " " (:label %)))
                               (:values metrics))
                              {:field "index" :type "quantitative"})}
-        :mark     {:type       "rule"
-                   :strokeDash [2 2]}}])))
+        :mark {:type "rule"
+               :strokeDash [2 2]}}])))
 
 ;;; Percentile charts
 
@@ -204,29 +207,29 @@
   Uses a logarithmic scale on the x-axis to emphasize tail percentiles.
   Returns a Vega-Lite layer spec."
   [metric->values transforms metric]
-  (let [path        (:path metric)
-        k           (first path)
-        field-name  (name k)
-        vs          (->> (metric->values path)
-                         (map #(util/transform-sample-> % transforms))
-                         sort
-                         vec)
-        n           (count vs)
-        max-val     (Math/log10 (double n))
-        xs          (mapv
-                     #(/ (- max-val (Math/log10 (- n (double %)))) max-val)
-                     (range 0 n))
-        delta       (/ 100.0 (dec n))
+  (let [path (:path metric)
+        k (first path)
+        field-name (name k)
+        vs (->> (metric->values path)
+                (map #(util/transform-sample-> % transforms))
+                sort
+                vec)
+        n (count vs)
+        max-val (Math/log10 (double n))
+        xs (mapv
+            #(/ (- max-val (Math/log10 (- n (double %)))) max-val)
+            (range 0 n))
+        delta (/ 100.0 (dec n))
         percentiles (take n
                           (iterate
                            #(+ delta (double %)) 0))
-        data        (mapv
-                     #(hash-map k %1 :p %2 :x %3)
-                     vs
-                     percentiles
-                     xs)]
-    {:data   {:values data
-              :name   "vals"}
+        data (mapv
+              #(hash-map k %1 :p %2 :x %3)
+              vs
+              percentiles
+              xs)]
+    {:data {:values data
+            :name "vals"}
      :height 800
      :encoding
      {:x
@@ -239,13 +242,13 @@
          "format( (%d - pow(%d, 1 - min(datum.index, 1.0))) / %d,'.3%%')",
          n,n,(dec n))
         :tickCount 10}}
-      :y       {:field field-name
-                :type  "quantitative"
-                :scale {:zero false
-                        :type "log"}}
+      :y {:field field-name
+          :type "quantitative"
+          :scale {:zero false
+                  :type "log"}}
       :tooltip [{:field "p" :type "quantitative"}
                 {:field field-name :type "quantitative"}]}
-     :mark   "point"}))
+     :mark "point"}))
 
 ;;; Sample diffs
 
@@ -255,31 +258,31 @@
   Shows sorted unique differences from minimum value.
   Returns a Vega-Lite layer spec."
   [samples metric]
-  (let [path       (:path metric)
-        k          (first path)
+  (let [path (:path metric)
+        k (first path)
         field-name (name k)
-        vs         (->> (get samples path)
-                        sort
-                        vec)
-        min-v      (double (first vs))
-        diffs      (-> (mapv
-                        #(- (double %) min-v)
-                        vs)
-                       sort
-                       distinct
-                       vec)
-        data       (mapv
-                    #(hash-map k %1 :x %2)
-                    diffs
-                    (range))]
-    {:data   {:values data
-              :name   "vals"}
+        vs (->> (get samples path)
+                sort
+                vec)
+        min-v (double (first vs))
+        diffs (-> (mapv
+                   #(- (double %) min-v)
+                   vs)
+                  sort
+                  distinct
+                  vec)
+        data (mapv
+              #(hash-map k %1 :x %2)
+              diffs
+              (range))]
+    {:data {:values data
+            :name "vals"}
      :height 800
      :encoding
      {:x
       {:field "x" :type "quantitative"}
-      :y       {:field field-name
-                :type  "quantitative"
-                :scale {:zero false}}
+      :y {:field field-name
+          :type "quantitative"
+          :scale {:zero false}}
       :tooltip [{:field field-name :type "quantitative"}]}
-     :mark   "point"}))
+     :mark "point"}))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -1,0 +1,285 @@
+(ns criterium.viewer.common-charts
+  "Common Vega-Lite chart generation functions for viewers.
+
+  Provides reusable chart-building functions extracted from the Portal viewer
+  for generating histograms, scatter plots, and percentile charts."
+  (:require
+   [criterium.util.helpers :as util]
+   [criterium.util.invariant :refer [have have?]]
+   [criterium.util.probability :as probability]
+   [criterium.viewer.common :as viewer-common]))
+
+;;; Scatter plots
+
+(defn metric-layer
+  "Build a scatter plot layer showing samples with outlier coloring.
+
+  Returns a Vega-Lite layer spec."
+  [metric->values transforms outliers metric]
+  {:pre [(have? map? metric->values)]}
+  (let [path       (:path metric)
+        k          (first path)
+        field-name (name k)
+        data       (mapv
+                    #(let [outlier (get
+                                    (:outliers (get-in outliers path))
+                                    %2
+                                    "")]
+                       (assoc
+                        {k
+                         (util/transform-sample->
+                          %1
+                          transforms)}
+                        :index %2
+                        :outlier outlier))
+                    (have some?
+                          (metric->values path)
+                          {:path path :available (keys metric->values)})
+                    (range))]
+    {:data     {:values data}
+     :encoding {:x       {:field "index" :type "quantitative"}
+                :y       {:field field-name
+                          :type  "quantitative"
+                          :scale {:zero false}}
+                :tooltip [{:field "index" :type "quantitative"}
+                          {:field field-name :type "quantitative"}]
+                :color   {:field "outlier"}}
+     :mark     "point"}))
+
+;;; Histograms
+
+(defn metric-computed-histo-layer
+  "Build a histogram bar chart layer from pre-computed histogram data.
+
+  Returns a Vega-Lite layer spec for displaying histogram bins."
+  [transforms histogram metric _layer-num]
+  (let [path       (:path metric)
+        k          (first path)
+        field-name (name k)
+        {:keys [counts centers widths width density]}
+        histogram
+
+        tform   #(util/transform-sample-> % transforms)
+        centers (mapv tform centers)
+        widths  (when widths (mapv tform widths))
+        width   (when width (tform width))
+        data    (if widths
+                  ;; Variable width histogram
+                  (mapv (fn [_count ^double center ^double width density]
+                          (let [half-w (* 0.95 (/ width 2.0))]
+                            {field-name (- center half-w)
+                             "end"      (+ center half-w)
+                             "density"  density}))
+                        counts centers widths density)
+                  ;; Fixed width histogram
+                  (mapv (fn [_count ^double center ^double density]
+                          (let [half-w (* 0.95 (/ (double width) 2.0))]
+                            {field-name (- center half-w)
+                             "end"      (+ center half-w)
+                             "density"  density}))
+                        counts centers density))]
+    {:data      {:values data}
+     :transform [{:calculate (str "'" "Histogram " (:label metric) "'") :as "layer"}]
+     :encoding  {:y2    {:datum 0
+                         :type  "quantitative"}
+                 :y     {:field "density"
+                         :type  "quantitative"}
+                 :x     {:field field-name
+                         :type  "quantitative"
+                         :scale {:zero false}}
+                 :x2    {:field "end"
+                         :type  "quantitative"}
+                 :color {:field "layer" :type "nominal"}}
+     :mark      {:type       "bar"
+                 :binSpacing 0}}))
+
+;;; Normal distribution overlay
+
+(defn normal-pdf-points
+  "Generate points for a normal probability density function curve.
+
+  Returns a vector of {:z value :p probability} maps."
+  [min-val max-val mean variance transforms]
+  (let [sigma (Math/sqrt variance)
+        delta (/ (- (double max-val) (double min-val)) 120)
+        pdf   (probability/normal-pdf mean sigma)]
+    (mapv
+     (fn [z]
+       {:z (util/transform-sample-> z transforms)
+        :p (pdf z)})
+     (range min-val max-val delta))))
+
+(defn metric-sample-stats-layer
+  "Build a normal distribution overlay layer for histogram charts.
+
+  Returns a vector of Vega-Lite layer specs showing the fitted normal
+  distribution and mean line."
+  [transforms stats metric-config _layer-num]
+  (let [{:keys [mean-minus-3sigma mean-plus-3sigma mean variance]}
+        stats
+        path (:path metric-config)
+        k    (first path)
+        data (normal-pdf-points
+              mean-minus-3sigma
+              mean-plus-3sigma
+              mean
+              variance
+              transforms)]
+    [{:resolve {:scale {:y "shared"}}
+      :layer
+      [{:data      {:values data}
+        :transform [{:calculate
+                     (str "'" "LogNormal fit " (:label metric-config) "'")
+                     :as "layer"}]
+        :encoding  {:x       {:field "z"
+                              :type  "quantitative"
+                              :scale {:zero false}}
+                    :y       {:field "p"
+                              :type  "quantitative"}
+                    :tooltip [{:field (name k)
+                               :title "Normal"}]
+                    :color   {:field "layer" :type "nominal"}}
+        :mark      {:type "line"}}
+       {:data     {:values [{k
+                             (util/transform-sample-> mean transforms)
+                             :title "mean"}]}
+        :encoding {:x       {:field (name k)
+                             :type  "quantitative"
+                             :scale {:zero false}}
+                   :tooltip [{:field (name k)
+                              :title (str "Mean " (name k))}]}
+        :mark     "rule"}]}]))
+
+;;; Event markers
+
+(defn event-occurrence
+  "Extract event occurrence data for a single sample index.
+
+  Returns nil if no events occurred, otherwise a map of metric keys to values."
+  [events metrics index]
+  (reduce
+   (fn [res metric-config]
+     (let [path (:path metric-config)
+           v    (get (get events path) index)]
+       (if (pos? (long v))
+         (assoc res (viewer-common/composite-key path) v :index index)
+         res)))
+   nil
+   metrics))
+
+(defn event-layer
+  "Build an event marker layer showing when events occurred during sampling.
+
+  Returns a vector containing the Vega-Lite layer spec, or nil if no events."
+  [events [_k metrics]]
+  (let [data (->> (map
+                   (partial event-occurrence events (:values metrics))
+                   (range (-> events
+                              (get (:path (first (:values metrics))))
+                              count)))
+                  (filterv some?))]
+    (when (seq data)
+      [{:data     {:values data}
+        :encoding {:x       {:field "index"
+                             :type  "quantitative"}
+                   :color   {:vvalue "white"}
+                   :size    {:value 2},
+                   :tooltip (conj
+                             (mapv
+                              #(hash-map
+                                :field (name
+                                        (viewer-common/composite-key (:path %)))
+                                :type "quantitative"
+                                :title (str (:label metrics) " " (:label %)))
+                              (:values metrics))
+                             {:field "index" :type "quantitative"})}
+        :mark     {:type       "rule"
+                   :strokeDash [2 2]}}])))
+
+;;; Percentile charts
+
+(defn metric-percentile-layer
+  "Build a percentile distribution chart layer.
+
+  Uses a logarithmic scale on the x-axis to emphasize tail percentiles.
+  Returns a Vega-Lite layer spec."
+  [metric->values transforms metric]
+  (let [path        (:path metric)
+        k           (first path)
+        field-name  (name k)
+        vs          (->> (metric->values path)
+                         (map #(util/transform-sample-> % transforms))
+                         sort
+                         vec)
+        n           (count vs)
+        max-val     (Math/log10 (double n))
+        xs          (mapv
+                     #(/ (- max-val (Math/log10 (- n (double %)))) max-val)
+                     (range 0 n))
+        delta       (/ 100.0 (dec n))
+        percentiles (take n
+                          (iterate
+                           #(+ delta (double %)) 0))
+        data        (mapv
+                     #(hash-map k %1 :p %2 :x %3)
+                     vs
+                     percentiles
+                     xs)]
+    {:data   {:values data
+              :name   "vals"}
+     :height 800
+     :encoding
+     {:x
+      {:field "x" :type "quantitative"
+       :scale {:domain [0 1.0]}
+       :axis
+       {:labelExpr
+        ;; inverse of xs
+        (format
+         "format( (%d - pow(%d, 1 - min(datum.index, 1.0))) / %d,'.3%%')",
+         n,n,(dec n))
+        :tickCount 10}}
+      :y       {:field field-name
+                :type  "quantitative"
+                :scale {:zero false
+                        :type "log"}}
+      :tooltip [{:field "p" :type "quantitative"}
+                {:field field-name :type "quantitative"}]}
+     :mark   "point"}))
+
+;;; Sample diffs
+
+(defn metric-diff-layer
+  "Build a sample differences chart layer.
+
+  Shows sorted unique differences from minimum value.
+  Returns a Vega-Lite layer spec."
+  [samples metric]
+  (let [path       (:path metric)
+        k          (first path)
+        field-name (name k)
+        vs         (->> (get samples path)
+                        sort
+                        vec)
+        min-v      (double (first vs))
+        diffs      (-> (mapv
+                        #(- (double %) min-v)
+                        vs)
+                       sort
+                       distinct
+                       vec)
+        data       (mapv
+                    #(hash-map k %1 :x %2)
+                    diffs
+                    (range))]
+    {:data   {:values data
+              :name   "vals"}
+     :height 800
+     :encoding
+     {:x
+      {:field "x" :type "quantitative"}
+      :y       {:field field-name
+                :type  "quantitative"
+                :scale {:zero false}}
+      :tooltip [{:field field-name :type "quantitative"}]}
+     :mark   "point"}))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -230,7 +230,7 @@
               xs)]
     {:data {:values data
             :name "vals"}
-     :height 800
+
      :encoding
      {:x
       {:field "x" :type "quantitative"
@@ -277,7 +277,7 @@
               (range))]
     {:data {:values data
             :name "vals"}
-     :height 800
+
      :encoding
      {:x
       {:field "x" :type "quantitative"}

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -215,3 +215,64 @@
              (util/metric->values quant-samples)
              transforms
              (first metric-configs))]))}])})))
+
+(defmethod view/metrics* :kindly
+  [_ {:keys [samples-id]} data-map]
+  (let [samples-id      (or samples-id :samples)
+        metrics-samples (data-map samples-id)
+        metrics-defs    (:metrics-defs metrics-samples)
+        metric-configs  (metric/all-metric-configs metrics-defs)]
+    (kindly-heading "Metrics")
+    (kindly-table
+     (viewer-common/metrics-map
+      (util/metric->values metrics-samples)
+      metric-configs))))
+
+(defmethod view/event-stats* :kindly
+  [_ {:keys [event-stats-id]} data-map]
+  (let [event-stats-id  (or event-stats-id :event-stats)
+        event-stats-map (data-map event-stats-id)
+        metrics-defs    (have (:metrics-defs event-stats-map))]
+    (kindly-heading "Event stats")
+    (kindly-table
+     (viewer-common/event-stats
+      metrics-defs
+      (util/event-stats event-stats-map)))))
+
+(defmethod view/outlier-significance* :kindly
+  [_ {:keys [outlier-significance-id] :as _view} data-map]
+  (let [outlier-sig-id  (or outlier-significance-id :outlier-significance)
+        outlier-sig-map (data-map outlier-sig-id)
+        outlier-sig     (util/outlier-significance outlier-sig-map)
+        metrics-defs    (:metrics-defs outlier-sig-map)
+        metric-configs  (metric/all-metric-configs metrics-defs)]
+    (kindly-heading "Outlier Significance")
+    (kindly-table
+     (vec
+      (for [m metric-configs]
+        (get-in outlier-sig (:path m)))))))
+
+(defmethod view/sample-diffs* :kindly
+  [_ {:keys [] :as view} data-map]
+  (let [quant-samples-id (:samples-id view :samples)
+        quant-samples    (data-map quant-samples-id)
+        metric-configs   (:metric-configs quant-samples)]
+    (kindly-heading "Sample diffs")
+    (kindly-vega-lite
+     {:data    {:values []}
+      :resolve {:scale {:y "independent"}}
+      :vconcat
+      (into
+       [{:layer
+         (vec
+          (into
+           [(charts/metric-diff-layer
+             (util/metric->values quant-samples)
+             (first metric-configs))]))}])})))
+
+;;; Noop implementations for views not applicable to Kindly output
+
+(defmethod view/bootstrap-stats* :kindly [_ _ _])
+(defmethod view/final-gc-warnings* :kindly [_ _ _])
+(defmethod view/os* :kindly [_ _ _])
+(defmethod view/runtime* :kindly [_ _ _])

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -70,3 +70,35 @@
       (util/stats stats-map)
       metric-configs
       transforms))))
+
+(defmethod view/quantiles* :kindly
+  [_ {:keys [quantiles-id]} data-map]
+  (let [quantiles-id   (or quantiles-id :quantiles)
+        quantiles-map  (data-map quantiles-id)
+        metrics-defs   (:metrics-defs quantiles-map)
+        metric-configs (metric/all-metric-configs metrics-defs)
+        transforms     (util/get-transforms data-map quantiles-id)]
+    (kindly-heading "Quantiles")
+    (kindly-table
+     (viewer-common/quantiles
+      metric-configs
+      (util/quantiles quantiles-map)
+      transforms))))
+
+(defmethod view/outlier-counts* :kindly
+  [_ {:keys [outliers-id] :as _view} data-map]
+  (let [outliers-id    (or outliers-id :outliers)
+        outliers-map   (data-map outliers-id)
+        metrics-defs   (:metrics-defs outliers-map)
+        metric-configs (metric/all-metric-configs metrics-defs)]
+    (kindly-heading "Outliers")
+    (kindly-table
+     (viewer-common/outlier-counts
+      metric-configs
+      (util/outliers outliers-map)))))
+
+(defmethod view/collect-plan* :kindly
+  [_ _view data-map]
+  (kindly-heading "Collect plan")
+  (kindly-table
+   (viewer-common/collect-plan-data data-map)))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -129,7 +129,11 @@
                            (metric/filter-metrics
                             (metric/type-pred :event)))
         metric-configs (metric/all-metric-configs q-metrics-defs)
-        e-metric-configs (metric/all-metric-configs e-metrics-defs)
+        event-metric->values (util/metric->values event-samples)
+        e-metric-configs (->> (metric/all-metric-configs e-metrics-defs)
+                              (filterv #(not-every? zero?
+                                                    (get event-metric->values
+                                                         (:path %)))))
 
         transforms (util/get-transforms data-map quant-samples-id)]
     (kindly-heading "Samples")
@@ -150,15 +154,15 @@
              (when outliers (util/outliers outliers))
              (have (first metric-configs)))]
            (mapcat
-            #(charts/event-layer (util/metric->values event-samples) %)
+            #(charts/event-layer event-metric->values %)
             e-metrics-defs)))}]
        (mapv
         (fn [mc]
           {:height 350
            :layer [(charts/metric-layer
-                    (util/metric->values quant-samples)
+                    event-metric->values
                     transforms
-                    outliers mc)]})
+                    nil mc)]})
         e-metric-configs))})))
 
 (defmethod view/histogram* :kindly
@@ -245,12 +249,13 @@
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)
         event-stats-map (data-map event-stats-id)
-        metrics-defs (have (:metrics-defs event-stats-map))]
-    (kindly-heading "Event stats")
-    (kindly-table
-     (viewer-common/event-stats
-      metrics-defs
-      (util/event-stats event-stats-map)))))
+        metrics-defs (have (:metrics-defs event-stats-map))
+        stats (viewer-common/event-stats
+               metrics-defs
+               (util/event-stats event-stats-map))]
+    (when (seq stats)
+      (kindly-heading "Event stats")
+      (kindly-table stats))))
 
 (defmethod view/outlier-significance* :kindly
   [_ {:keys [outlier-significance-id] :as _view} data-map]

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -24,6 +24,14 @@
   last-fragment
   (atom nil))
 
+(def ^:private chart-width
+  "Width for Kindly vega-lite charts, sized for notebook display."
+  600)
+
+(def ^:private chart-height
+  "Height for Kindly vega-lite charts, sized for notebook display."
+  350)
+
 (defn kindly-add
   "Add a value to the accumulator."
   [value]
@@ -139,12 +147,12 @@
     (kindly-heading "Samples")
     (kindly-vega-lite
      {:data {:values [{}]}
-      :width 700
       :encoding {:x {:field "index" :type "quantitative"}}
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into
-       [{:height 350
+       [{:width chart-width
+         :height chart-height
          :layer
          (vec
           (into
@@ -158,7 +166,8 @@
             e-metrics-defs)))}]
        (mapv
         (fn [mc]
-          {:height 350
+          {:width chart-width
+           :height chart-height
            :layer [(charts/metric-layer
                     event-metric->values
                     transforms
@@ -184,14 +193,14 @@
     (kindly-heading "Histogram")
     (kindly-vega-lite
      {:data {:values []}
-      :width 700
       :resolve {:scale {:x "independent"
                         :y "independent"
                         :color "shared"}}
       :vconcat (mapv
                 (fn [metric-config]
                   {:resolve {:scale {:x "shared" :y "independent"}}
-                   :height 350
+                   :width chart-width
+                   :height chart-height
                    :layer
                    (into
                     [(charts/metric-computed-histo-layer
@@ -220,11 +229,11 @@
     (kindly-heading "Percentiles")
     (kindly-vega-lite
      {:data {:values []}
-      :width 700
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into
-       [{:height 350
+       [{:width chart-width
+         :height chart-height
          :layer
          (vec
           (into
@@ -278,11 +287,11 @@
     (kindly-heading "Sample diffs")
     (kindly-vega-lite
      {:data {:values []}
-      :width 700
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into
-       [{:height 350
+       [{:width chart-width
+         :height chart-height
          :layer
          (vec
           (into

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -9,7 +9,10 @@
   appropriate `:kindly/kind` metadata."
   (:refer-clojure :exclude [flush])
   (:require
-   [criterium.view :as view]))
+   [criterium.metric :as metric]
+   [criterium.util.helpers :as util]
+   [criterium.view :as view]
+   [criterium.viewer.common :as viewer-common]))
 
 (defonce ^{:doc "Accumulator for Kindly-annotated values."}
   accumulated
@@ -52,3 +55,18 @@
 
 (defmethod view/flush-viewer :kindly [_]
   (flush))
+
+(defmethod view/stats* :kindly
+  [_ {:keys [stats-id metric-ids]} data-map]
+  (let [stats-id       (or stats-id :stats)
+        stats-map      (data-map stats-id)
+        metrics-defs   (-> (:metrics-defs stats-map)
+                           (metric/select-metrics metric-ids))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        transforms     (util/get-transforms data-map stats-id)]
+    (kindly-heading "Summary stats")
+    (kindly-table
+     (viewer-common/stats-map
+      (util/stats stats-map)
+      metric-configs
+      transforms))))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -26,7 +26,7 @@
 
 (def ^:private chart-width
   "Width for Kindly vega-lite charts, sized for notebook display."
-  600)
+  700)
 
 (def ^:private chart-height
   "Height for Kindly vega-lite charts, sized for notebook display."

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -1,0 +1,54 @@
+(ns criterium.viewer.kindly
+  "A viewer that outputs Kindly-annotated data structures for Clay notebooks.
+
+  Uses an accumulator pattern where view functions append Kindly-annotated
+  values to an atom. The `flush-viewer` multimethod returns a `kind/fragment`
+  combining all accumulated values.
+
+  No runtime dependency on scicloj/kindly - produces plain maps with
+  appropriate `:kindly/kind` metadata."
+  (:refer-clojure :exclude [flush])
+  (:require
+   [criterium.view :as view]))
+
+(defonce ^{:doc "Accumulator for Kindly-annotated values."}
+  accumulated
+  (atom []))
+
+(defn kindly-add
+  "Add a value to the accumulator."
+  [value]
+  (swap! accumulated conj value)
+  nil)
+
+(defn kindly-heading
+  "Add a markdown heading to the accumulator."
+  [s]
+  (kindly-add
+   (with-meta
+     [(str "**" s "**")]
+     {:kindly/kind :kind/md})))
+
+(defn kindly-table
+  "Add a table to the accumulator."
+  [data]
+  (kindly-add
+   (with-meta data {:kindly/kind :kind/table})))
+
+(defn kindly-vega-lite
+  "Add a Vega-Lite chart to the accumulator."
+  [spec]
+  (kindly-add
+   (with-meta
+     (assoc spec :$schema "https://vega.github.io/schema/vega-lite/v5.json")
+     {:kindly/kind :kind/vega-lite})))
+
+(defn flush
+  "Return accumulated values as a kind/fragment and clear the accumulator."
+  []
+  (let [[values _] (swap-vals! accumulated (constantly []))]
+    (when (seq values)
+      (with-meta values {:kindly/kind :kind/fragment}))))
+
+(defmethod view/flush-viewer :kindly [_]
+  (flush))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -192,3 +192,26 @@
                         metric-config
                         (vswap! layer-num unchecked-inc)))))})
                 metric-configs)})))
+
+(defmethod view/sample-percentiles* :kindly
+  [_ view data-map]
+  (let [quant-samples-id (:samples-id view :samples)
+        quant-samples    (data-map quant-samples-id)
+        metrics-defs     (-> (:metrics-defs quant-samples)
+                             (metric/filter-metrics
+                              (metric/type-pred :quantitative)))
+        metric-configs   (metric/all-metric-configs metrics-defs)
+        transforms       (util/get-transforms data-map quant-samples-id)]
+    (kindly-heading "Percentiles")
+    (kindly-vega-lite
+     {:data    {:values []}
+      :resolve {:scale {:y "independent"}}
+      :vconcat
+      (into
+       [{:layer
+         (vec
+          (into
+           [(charts/metric-percentile-layer
+             (util/metric->values quant-samples)
+             transforms
+             (first metric-configs))]))}])})))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -11,8 +11,10 @@
   (:require
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
+   [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
-   [criterium.viewer.common :as viewer-common]))
+   [criterium.viewer.common :as viewer-common]
+   [criterium.viewer.common-charts :as charts]))
 
 (defonce ^{:doc "Accumulator for Kindly-annotated values."}
   accumulated
@@ -102,3 +104,91 @@
   (kindly-heading "Collect plan")
   (kindly-table
    (viewer-common/collect-plan-data data-map)))
+
+(defmethod view/samples* :kindly
+  [_ {:keys [] :as view} data-map]
+  (let [quant-samples-id     (:samples-id view :samples)
+        event-samples-id     (:event-samples-id view quant-samples-id)
+        outliers-analysis-id (:outliers-id view :outliers)
+
+        quant-samples (data-map quant-samples-id)
+        event-samples (data-map event-samples-id)
+        outliers      (data-map outliers-analysis-id)
+
+        q-metrics-defs   (-> (:metrics-defs quant-samples)
+                             (metric/filter-metrics
+                              (metric/type-pred :quantitative)))
+        e-metrics-defs   (-> (:metrics-defs event-samples)
+                             (metric/filter-metrics
+                              (metric/type-pred :event)))
+        metric-configs   (metric/all-metric-configs q-metrics-defs)
+        e-metric-configs (metric/all-metric-configs e-metrics-defs)
+
+        transforms (util/get-transforms data-map quant-samples-id)]
+    (kindly-heading "Samples")
+    (kindly-vega-lite
+     {:data     {:values [{}]}
+      :encoding {:x {:field "index" :type "quantitative"}}
+      :resolve  {:scale {:y "independent"}}
+      :vconcat
+      (into
+       [{:height 800
+         :layer
+         (vec
+          (into
+           [(charts/metric-layer
+             (util/metric->values quant-samples)
+             transforms
+             (when outliers (util/outliers outliers))
+             (have (first metric-configs)))]
+           (mapcat
+            #(charts/event-layer (util/metric->values event-samples) %)
+            e-metrics-defs)))}]
+       (mapv
+        #(charts/metric-layer
+          (util/metric->values quant-samples)
+          transforms
+          outliers %)
+        e-metric-configs))})))
+
+(defmethod view/histogram* :kindly
+  [_ {:keys [histogram-id samples-id stats-id]} data-map]
+  (let [histogram-id     (or histogram-id :histograms)
+        stats-id         (or stats-id :stats)
+        quant-samples-id (or samples-id :samples)
+        quant-samples    (data-map quant-samples-id)
+        stats            (data-map stats-id)
+        histograms-map   (util/lookup-data data-map histogram-id)
+        histograms       (:histograms histograms-map)
+        metrics-defs     (-> (:metrics-defs quant-samples)
+                             (metric/filter-metrics
+                              (metric/type-pred :quantitative)))
+        metric-configs   (metric/all-metric-configs metrics-defs)
+        hist-transforms  (util/get-transforms data-map histogram-id)
+        stats-transforms (util/get-transforms data-map (:source-id stats))
+        layer-num        (volatile! 0)]
+    (kindly-heading "Histogram")
+    (kindly-vega-lite
+     {:data    {:values []}
+      :resolve {:scale {:x     "independent"
+                        :y     "independent"
+                        :color "shared"}}
+      :vconcat (mapv
+                (fn [metric-config]
+                  {:resolve {:scale {:x "shared" :y "independent"}}
+                   :height  800
+                   :layer
+                   (into
+                    [(charts/metric-computed-histo-layer
+                      hist-transforms
+                      (histograms (:path metric-config))
+                      metric-config
+                      (vswap! layer-num unchecked-inc))]
+                    (when stats
+                      (->>
+                       (charts/metric-sample-stats-layer
+                        stats-transforms
+                        (get-in (util/stats stats) (:path metric-config))
+                        metric-config
+                        (vswap! layer-num unchecked-inc)))))})
+                metric-configs)})))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -67,12 +67,12 @@
 
 (defmethod view/stats* :kindly
   [_ {:keys [stats-id metric-ids]} data-map]
-  (let [stats-id       (or stats-id :stats)
-        stats-map      (data-map stats-id)
-        metrics-defs   (-> (:metrics-defs stats-map)
-                           (metric/select-metrics metric-ids))
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)
+        metrics-defs (-> (:metrics-defs stats-map)
+                         (metric/select-metrics metric-ids))
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map stats-id)]
+        transforms (util/get-transforms data-map stats-id)]
     (kindly-heading "Summary stats")
     (kindly-table
      (viewer-common/stats-map
@@ -82,11 +82,11 @@
 
 (defmethod view/quantiles* :kindly
   [_ {:keys [quantiles-id]} data-map]
-  (let [quantiles-id   (or quantiles-id :quantiles)
-        quantiles-map  (data-map quantiles-id)
-        metrics-defs   (:metrics-defs quantiles-map)
+  (let [quantiles-id (or quantiles-id :quantiles)
+        quantiles-map (data-map quantiles-id)
+        metrics-defs (:metrics-defs quantiles-map)
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map quantiles-id)]
+        transforms (util/get-transforms data-map quantiles-id)]
     (kindly-heading "Quantiles")
     (kindly-table
      (viewer-common/quantiles
@@ -96,9 +96,9 @@
 
 (defmethod view/outlier-counts* :kindly
   [_ {:keys [outliers-id] :as _view} data-map]
-  (let [outliers-id    (or outliers-id :outliers)
-        outliers-map   (data-map outliers-id)
-        metrics-defs   (:metrics-defs outliers-map)
+  (let [outliers-id (or outliers-id :outliers)
+        outliers-map (data-map outliers-id)
+        metrics-defs (:metrics-defs outliers-map)
         metric-configs (metric/all-metric-configs metrics-defs)]
     (kindly-heading "Outliers")
     (kindly-table
@@ -114,32 +114,33 @@
 
 (defmethod view/samples* :kindly
   [_ {:keys [] :as view} data-map]
-  (let [quant-samples-id     (:samples-id view :samples)
-        event-samples-id     (:event-samples-id view quant-samples-id)
+  (let [quant-samples-id (:samples-id view :samples)
+        event-samples-id (:event-samples-id view quant-samples-id)
         outliers-analysis-id (:outliers-id view :outliers)
 
         quant-samples (data-map quant-samples-id)
         event-samples (data-map event-samples-id)
-        outliers      (data-map outliers-analysis-id)
+        outliers (data-map outliers-analysis-id)
 
-        q-metrics-defs   (-> (:metrics-defs quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        e-metrics-defs   (-> (:metrics-defs event-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :event)))
-        metric-configs   (metric/all-metric-configs q-metrics-defs)
+        q-metrics-defs (-> (:metrics-defs quant-samples)
+                           (metric/filter-metrics
+                            (metric/type-pred :quantitative)))
+        e-metrics-defs (-> (:metrics-defs event-samples)
+                           (metric/filter-metrics
+                            (metric/type-pred :event)))
+        metric-configs (metric/all-metric-configs q-metrics-defs)
         e-metric-configs (metric/all-metric-configs e-metrics-defs)
 
         transforms (util/get-transforms data-map quant-samples-id)]
     (kindly-heading "Samples")
     (kindly-vega-lite
-     {:data     {:values [{}]}
+     {:data {:values [{}]}
+      :width 700
       :encoding {:x {:field "index" :type "quantitative"}}
-      :resolve  {:scale {:y "independent"}}
+      :resolve {:scale {:y "independent"}}
       :vconcat
       (into
-       [{:height 800
+       [{:height 350
          :layer
          (vec
           (into
@@ -152,38 +153,41 @@
             #(charts/event-layer (util/metric->values event-samples) %)
             e-metrics-defs)))}]
        (mapv
-        #(charts/metric-layer
-          (util/metric->values quant-samples)
-          transforms
-          outliers %)
+        (fn [mc]
+          {:height 350
+           :layer [(charts/metric-layer
+                    (util/metric->values quant-samples)
+                    transforms
+                    outliers mc)]})
         e-metric-configs))})))
 
 (defmethod view/histogram* :kindly
   [_ {:keys [histogram-id samples-id stats-id]} data-map]
-  (let [histogram-id     (or histogram-id :histograms)
-        stats-id         (or stats-id :stats)
+  (let [histogram-id (or histogram-id :histograms)
+        stats-id (or stats-id :stats)
         quant-samples-id (or samples-id :samples)
-        quant-samples    (data-map quant-samples-id)
-        stats            (data-map stats-id)
-        histograms-map   (util/lookup-data data-map histogram-id)
-        histograms       (:histograms histograms-map)
-        metrics-defs     (-> (:metrics-defs quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        metric-configs   (metric/all-metric-configs metrics-defs)
-        hist-transforms  (util/get-transforms data-map histogram-id)
+        quant-samples (data-map quant-samples-id)
+        stats (data-map stats-id)
+        histograms-map (util/lookup-data data-map histogram-id)
+        histograms (:histograms histograms-map)
+        metrics-defs (-> (:metrics-defs quant-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        hist-transforms (util/get-transforms data-map histogram-id)
         stats-transforms (util/get-transforms data-map (:source-id stats))
-        layer-num        (volatile! 0)]
+        layer-num (volatile! 0)]
     (kindly-heading "Histogram")
     (kindly-vega-lite
-     {:data    {:values []}
-      :resolve {:scale {:x     "independent"
-                        :y     "independent"
+     {:data {:values []}
+      :width 700
+      :resolve {:scale {:x "independent"
+                        :y "independent"
                         :color "shared"}}
       :vconcat (mapv
                 (fn [metric-config]
                   {:resolve {:scale {:x "shared" :y "independent"}}
-                   :height  800
+                   :height 350
                    :layer
                    (into
                     [(charts/metric-computed-histo-layer
@@ -203,19 +207,21 @@
 (defmethod view/sample-percentiles* :kindly
   [_ view data-map]
   (let [quant-samples-id (:samples-id view :samples)
-        quant-samples    (data-map quant-samples-id)
-        metrics-defs     (-> (:metrics-defs quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        metric-configs   (metric/all-metric-configs metrics-defs)
-        transforms       (util/get-transforms data-map quant-samples-id)]
+        quant-samples (data-map quant-samples-id)
+        metrics-defs (-> (:metrics-defs quant-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        transforms (util/get-transforms data-map quant-samples-id)]
     (kindly-heading "Percentiles")
     (kindly-vega-lite
-     {:data    {:values []}
+     {:data {:values []}
+      :width 700
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into
-       [{:layer
+       [{:height 350
+         :layer
          (vec
           (into
            [(charts/metric-percentile-layer
@@ -225,10 +231,10 @@
 
 (defmethod view/metrics* :kindly
   [_ {:keys [samples-id]} data-map]
-  (let [samples-id      (or samples-id :samples)
+  (let [samples-id (or samples-id :samples)
         metrics-samples (data-map samples-id)
-        metrics-defs    (:metrics-defs metrics-samples)
-        metric-configs  (metric/all-metric-configs metrics-defs)]
+        metrics-defs (:metrics-defs metrics-samples)
+        metric-configs (metric/all-metric-configs metrics-defs)]
     (kindly-heading "Metrics")
     (kindly-table
      (viewer-common/metrics-map
@@ -237,9 +243,9 @@
 
 (defmethod view/event-stats* :kindly
   [_ {:keys [event-stats-id]} data-map]
-  (let [event-stats-id  (or event-stats-id :event-stats)
+  (let [event-stats-id (or event-stats-id :event-stats)
         event-stats-map (data-map event-stats-id)
-        metrics-defs    (have (:metrics-defs event-stats-map))]
+        metrics-defs (have (:metrics-defs event-stats-map))]
     (kindly-heading "Event stats")
     (kindly-table
      (viewer-common/event-stats
@@ -248,11 +254,11 @@
 
 (defmethod view/outlier-significance* :kindly
   [_ {:keys [outlier-significance-id] :as _view} data-map]
-  (let [outlier-sig-id  (or outlier-significance-id :outlier-significance)
+  (let [outlier-sig-id (or outlier-significance-id :outlier-significance)
         outlier-sig-map (data-map outlier-sig-id)
-        outlier-sig     (util/outlier-significance outlier-sig-map)
-        metrics-defs    (:metrics-defs outlier-sig-map)
-        metric-configs  (metric/all-metric-configs metrics-defs)]
+        outlier-sig (util/outlier-significance outlier-sig-map)
+        metrics-defs (:metrics-defs outlier-sig-map)
+        metric-configs (metric/all-metric-configs metrics-defs)]
     (kindly-heading "Outlier Significance")
     (kindly-table
      (vec
@@ -262,15 +268,17 @@
 (defmethod view/sample-diffs* :kindly
   [_ {:keys [] :as view} data-map]
   (let [quant-samples-id (:samples-id view :samples)
-        quant-samples    (data-map quant-samples-id)
-        metric-configs   (:metric-configs quant-samples)]
+        quant-samples (data-map quant-samples-id)
+        metric-configs (:metric-configs quant-samples)]
     (kindly-heading "Sample diffs")
     (kindly-vega-lite
-     {:data    {:values []}
+     {:data {:values []}
+      :width 700
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into
-       [{:layer
+       [{:height 350
+         :layer
          (vec
           (into
            [(charts/metric-diff-layer

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -20,6 +20,10 @@
   accumulated
   (atom []))
 
+(defonce ^{:doc "Last flushed Kindly fragment for retrieval after bench completes."}
+  last-fragment
+  (atom nil))
+
 (defn kindly-add
   "Add a value to the accumulator."
   [value]
@@ -49,11 +53,14 @@
      {:kindly/kind :kind/vega-lite})))
 
 (defn flush
-  "Return accumulated values as a kind/fragment and clear the accumulator."
+  "Return accumulated values as a kind/fragment and clear the accumulator.
+  Also stores the fragment in `last-fragment` for retrieval after bench completes."
   []
   (let [[values _] (swap-vals! accumulated (constantly []))]
     (when (seq values)
-      (with-meta values {:kindly/kind :kind/fragment}))))
+      (let [fragment (with-meta values {:kindly/kind :kind/fragment})]
+        (reset! last-fragment fragment)
+        fragment))))
 
 (defmethod view/flush-viewer :kindly [_]
   (flush))

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -276,3 +276,11 @@
            [(charts/metric-diff-layer
              (util/metric->values quant-samples)
              (first metric-configs))]))}])})))
+
+(defmethod view/bootstrap-stats* :portal [_ _ _])
+
+(defmethod view/final-gc-warnings* :portal [_ _ _])
+
+(defmethod view/os* :portal [_ _ _])
+
+(defmethod view/runtime* :portal [_ _ _])

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -53,7 +53,7 @@
 
 (defn portal-vega-lite [s]
   (tap> (with-meta
-          (assoc s :$schema  "https://vega.github.io/schema/vega-lite/v5.json")
+          (assoc s :$schema "https://vega.github.io/schema/vega-lite/v5.json")
           {:portal.viewer/default :portal.viewer/vega-lite})))
 
 (defn heading [s]
@@ -61,10 +61,10 @@
 
 (defmethod view/metrics* :portal
   [_ {:keys [samples-id]} data-map]
-  (let [samples-id      (or samples-id :samples)
+  (let [samples-id (or samples-id :samples)
         metrics-samples (data-map samples-id)
-        metrics-defs    (:metrics-defs metrics-samples)
-        metric-configs  (metric/all-metric-configs metrics-defs)]
+        metrics-defs (:metrics-defs metrics-samples)
+        metric-configs (metric/all-metric-configs metrics-defs)]
     (portal-table
      (viewer-common/metrics-map
       (util/metric->values metrics-samples)
@@ -72,12 +72,12 @@
 
 (defmethod view/stats* :portal
   [_ {:keys [stats-id metric-ids]} data-map]
-  (let [stats-id       (or stats-id :stats)
-        stats-map      (data-map stats-id)
-        metrics-defs   (-> (:metrics-defs stats-map)
-                           (metric/select-metrics metric-ids))
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)
+        metrics-defs (-> (:metrics-defs stats-map)
+                         (metric/select-metrics metric-ids))
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map stats-id)]
+        transforms (util/get-transforms data-map stats-id)]
     (heading "Summary stats")
     (portal-table
      (viewer-common/stats-map
@@ -87,9 +87,9 @@
 
 (defmethod view/event-stats* :portal
   [_ {:keys [event-stats-id]} data-map]
-  (let [event-stats-id  (or event-stats-id :event-stats)
+  (let [event-stats-id (or event-stats-id :event-stats)
         event-stats-map (data-map event-stats-id)
-        metrics-defs    (have (:metrics-defs event-stats-map))]
+        metrics-defs (have (:metrics-defs event-stats-map))]
     (heading "Event stats")
     (portal-table
      (viewer-common/event-stats
@@ -98,11 +98,11 @@
 
 (defmethod view/quantiles* :portal
   [_ {:keys [quantiles-id]} data-map]
-  (let [quantiles-id   (or quantiles-id :quantiles)
-        quantiles-map  (data-map quantiles-id)
-        metrics-defs   (:metrics-defs quantiles-map)
+  (let [quantiles-id (or quantiles-id :quantiles)
+        quantiles-map (data-map quantiles-id)
+        metrics-defs (:metrics-defs quantiles-map)
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map quantiles-id)]
+        transforms (util/get-transforms data-map quantiles-id)]
     (heading "Quantiles")
     (portal-table
      (viewer-common/quantiles
@@ -112,9 +112,9 @@
 
 (defmethod view/outlier-counts* :portal
   [_ {:keys [outliers-id] :as _view} data-map]
-  (let [outliers-id    (or outliers-id :outliers)
-        outliers-map   (data-map outliers-id)
-        metrics-defs   (:metrics-defs outliers-map)
+  (let [outliers-id (or outliers-id :outliers)
+        outliers-map (data-map outliers-id)
+        metrics-defs (:metrics-defs outliers-map)
         metric-configs (metric/all-metric-configs metrics-defs)]
     (heading "Outliers")
     (portal-table
@@ -124,11 +124,11 @@
 
 (defmethod view/outlier-significance* :portal
   [_ {:keys [outlier-significance-id] :as _view} data-map]
-  (let [outlier-sig-id  (or outlier-significance-id :outlier-significance)
+  (let [outlier-sig-id (or outlier-significance-id :outlier-significance)
         outlier-sig-map (data-map outlier-sig-id)
-        outlier-sig     (util/outlier-significance outlier-sig-map)
-        metrics-defs    (:metrics-defs outlier-sig-map)
-        metric-configs  (metric/all-metric-configs metrics-defs)]
+        outlier-sig (util/outlier-significance outlier-sig-map)
+        metrics-defs (:metrics-defs outlier-sig-map)
+        metric-configs (metric/all-metric-configs metrics-defs)]
     (heading "Outlier Significance")
     (portal-table
      (vec
@@ -143,29 +143,29 @@
 
 (defmethod view/samples* :portal
   [_ {:keys [] :as view} data-map]
-  (let [quant-samples-id     (:samples-id view :samples)
-        event-samples-id     (:event-samples-id view quant-samples-id)
+  (let [quant-samples-id (:samples-id view :samples)
+        event-samples-id (:event-samples-id view quant-samples-id)
         outliers-analysis-id (:outliers-id view :outliers)
 
         quant-samples (data-map quant-samples-id)
         event-samples (data-map event-samples-id)
-        outliers      (data-map outliers-analysis-id)
+        outliers (data-map outliers-analysis-id)
 
-        q-metrics-defs   (-> (:metrics-defs  quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        e-metrics-defs   (-> (:metrics-defs event-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :event)))
-        metric-configs   (metric/all-metric-configs q-metrics-defs)
+        q-metrics-defs (-> (:metrics-defs quant-samples)
+                           (metric/filter-metrics
+                            (metric/type-pred :quantitative)))
+        e-metrics-defs (-> (:metrics-defs event-samples)
+                           (metric/filter-metrics
+                            (metric/type-pred :event)))
+        metric-configs (metric/all-metric-configs q-metrics-defs)
         e-metric-configs (metric/all-metric-configs e-metrics-defs)
 
         transforms (util/get-transforms data-map quant-samples-id)]
     (heading "Samples")
     (portal-vega-lite
-     {:data     {:values [{}]}
+     {:data {:values [{}]}
       :encoding {:x {:field "index" :type "quantitative"}}
-      :resolve  {:scale {:y "independent"}}
+      :resolve {:scale {:y "independent"}}
       :vconcat
       (into
        [{:height 800
@@ -189,30 +189,30 @@
 
 (defmethod view/histogram* :portal
   [_ {:keys [histogram-id samples-id stats-id]} data-map]
-  (let [histogram-id     (or histogram-id :histograms)
-        stats-id         (or stats-id :stats)
+  (let [histogram-id (or histogram-id :histograms)
+        stats-id (or stats-id :stats)
         quant-samples-id (or samples-id :samples)
-        quant-samples    (data-map quant-samples-id)
-        stats            (data-map stats-id)
-        histograms-map   (util/lookup-data data-map histogram-id)
-        histograms       (:histograms histograms-map)
-        metrics-defs     (-> (:metrics-defs quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        metric-configs   (metric/all-metric-configs metrics-defs)
-        hist-transforms  (util/get-transforms data-map histogram-id)
+        quant-samples (data-map quant-samples-id)
+        stats (data-map stats-id)
+        histograms-map (util/lookup-data data-map histogram-id)
+        histograms (:histograms histograms-map)
+        metrics-defs (-> (:metrics-defs quant-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        hist-transforms (util/get-transforms data-map histogram-id)
         stats-transforms (util/get-transforms data-map (:source-id stats))
-        layer-num        (volatile! 0)]
+        layer-num (volatile! 0)]
     (heading "Histogram")
     (portal-vega-lite
-     {:data    {:values []}
-      :resolve {:scale {:x     "independent"
-                        :y     "independent"
+     {:data {:values []}
+      :resolve {:scale {:x "independent"
+                        :y "independent"
                         :color "shared"}}
       :vconcat (mapv
                 (fn [metric-config]
                   {:resolve {:scale {:x "shared" :y "independent"}}
-                   :height  800
+                   :height 800
                    :layer
                    (into
                     [(charts/metric-computed-histo-layer
@@ -232,15 +232,16 @@
 (defmethod view/sample-percentiles* :portal
   [_ view data-map]
   (let [quant-samples-id (:samples-id view :samples)
-        quant-samples    (data-map quant-samples-id)
-        metrics-defs     (-> (:metrics-defs quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        metric-configs   (metric/all-metric-configs metrics-defs)
-        transforms       (util/get-transforms data-map quant-samples-id)]
+        quant-samples (data-map quant-samples-id)
+        metrics-defs (-> (:metrics-defs quant-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        transforms (util/get-transforms data-map quant-samples-id)]
     (heading "Percentiles")
     (portal-vega-lite
-     {:data    {:values [{}]} ; for portal
+     {:data {:values [{}]} ; for portal
+      :height 800
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into
@@ -255,11 +256,12 @@
 (defmethod view/sample-diffs* :portal
   [_ {:keys [] :as view} data-map]
   (let [quant-samples-id (:samples-id view :samples)
-        quant-samples    (data-map quant-samples-id)
-        metric-configs   (:metric-configs quant-samples)]
+        quant-samples (data-map quant-samples-id)
+        metric-configs (:metric-configs quant-samples)]
     (heading "Sample diffs")
     (portal-vega-lite
-     {:data    {:values [{}]} ; for portal
+     {:data {:values [{}]} ; for portal
+      :height 800
       :resolve {:scale {:y "independent"}}
       :vconcat
       (into

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -4,10 +4,10 @@
   (:require
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
-   [criterium.util.invariant :refer [have have?]]
-   [criterium.util.probability :as probability]
+   [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
-   [criterium.viewer.common :as viewer-common]))
+   [criterium.viewer.common :as viewer-common]
+   [criterium.viewer.common-charts :as charts]))
 
 (defonce tapped (atom {:values '()}))
 
@@ -141,167 +141,6 @@
   (portal-table
    (viewer-common/collect-plan-data data-map)))
 
-(defn metric-layer
-  [metric->values transforms outliers metric]
-  {:pre [(have? map? metric->values)]}
-  (let [path       (:path metric)
-        k          (first path)
-        field-name (name k)
-        data       (mapv
-                    #(let [outlier (get
-                                    (:outliers (get-in outliers path))
-                                    %2
-                                    "")]
-                       (assoc
-                        {k
-                         (util/transform-sample->
-                          %1
-                          transforms)}
-                        :index %2
-                        :outlier outlier))
-                    (have some?
-                          (metric->values path)
-                          {:path path :available (keys metric->values)})
-                    (range))]
-    {:data     {:values data}
-     :encoding {:x       {:field "index" :type "quantitative"}
-                :y       {:field field-name
-                          :type  "quantitative"
-                          :scale {:zero false}}
-                :tooltip [{:field "index" :type "quantitative"}
-                          {:field field-name :type "quantitative"}]
-                :color   {:field "outlier"}}
-     :mark     "point"}))
-
-(defn metric-computed-histo-layer
-  [transforms histogram metric _layer-num]
-  (let [path       (:path metric)
-        k          (first path)
-        field-name (name k)
-        {:keys [counts centers widths width density]}
-        histogram
-
-        tform   #(util/transform-sample-> % transforms)
-        centers (mapv tform centers)
-        widths  (when widths (mapv tform widths))
-        width   (when width (tform width))
-        data    (if widths
-                  ;; Variable width histogram
-                  (mapv (fn [_count ^double center ^double width density]
-                          (let [half-w (* 0.95 (/ width 2.0))]
-                            {field-name (- center half-w)
-                             "end"      (+ center half-w)
-                             "density"  density}))
-                        counts centers widths density)
-                  ;; Fixed width histogram
-                  (mapv (fn [_count ^double center ^double density]
-                          (let [half-w (* 0.95 (/ (double width) 2.0))]
-                            {field-name (- center half-w)
-                             "end"      (+ center half-w)
-                             "density"  density}))
-                        counts centers density))]
-    {:data      {:values data}
-     :transform [{:calculate (str "'" "Histogram " (:label metric) "'") :as "layer"}]
-     :encoding  {:y2    {:datum 0
-                         :type  "quantitative"}
-                 :y     {:field "density"
-                         :type  "quantitative"}
-                 :x     {:field field-name
-                         :type  "quantitative"
-                         :scale {:zero false}}
-                 :x2    {:field "end"
-                         :type  "quantitative"}
-                 :color {:field "layer" :type "nominal"}}
-     :mark      {:type       "bar"
-                 :binSpacing 0}}))
-
-(defn normal-pdf-points
-  [min-val max-val mean variance transforms]
-  (let [sigma (Math/sqrt variance)
-        delta (/ (- (double max-val) (double min-val)) 120)
-        pdf   (probability/normal-pdf mean sigma)]
-    (mapv
-     (fn [z]
-       {:z (util/transform-sample-> z transforms)
-        :p (pdf z)})
-     (range min-val max-val delta))))
-
-(defn metric-sample-stats-layer
-  [transforms stats metric-config _layer-num]
-  (let [{:keys [mean-minus-3sigma mean-plus-3sigma mean variance]}
-        stats
-        path (:path metric-config)
-        k    (first path)
-        data (normal-pdf-points
-              mean-minus-3sigma
-              mean-plus-3sigma
-              mean
-              variance
-              transforms)]
-    [{:resolve {:scale {:y "shared"}}
-      :layer
-      [{:data      {:values data}
-        :transform [{:calculate
-                     (str "'" "LogNormal fit " (:label metric-config) "'")
-                     :as "layer"}]
-        :encoding  {:x       {:field "z"
-                              :type  "quantitative"
-                              :scale {:zero false}}
-                    :y       {:field "p"
-                              :type  "quantitative"}
-                    :tooltip [{:field (name k)
-                               :title "Normal"}]
-                    :color   {:field "layer" :type "nominal"}}
-        :mark      {:type "line"}}
-       {:data     {:values [{k
-                             (util/transform-sample-> mean transforms)
-                             :title "mean"}]}
-        :encoding {:x       {:field (name k)
-                             :type  "quantitative"
-                             :scale {:zero false}}
-                   :tooltip [{:field (name k)
-                              :title (str "Mean " (name k))}]}
-        :mark     "rule"}]}]))
-
-(defn event-occurance [events metrics index]
-  (reduce
-   (fn [res metric-config]
-     (let [path (:path metric-config)
-           v    (get (get events path) index)]
-       (if (pos? (long v))
-         (assoc res (viewer-common/composite-key path) v :index index)
-         res)))
-   nil
-   metrics))
-
-(defn event-layer
-  [events [_k metrics]]
-  (let [data (->> (map
-                   (partial event-occurance events (:values metrics))
-                   (range (-> events
-                              (get (:path (first (:values metrics))))
-                              count)))
-                  (filterv some?))]
-    (when (seq data)
-      [{:data     {:values data}
-        :encoding {:x       {:field "index"
-                             :type  "quantitative"
-                             ;; :title title
-                             }
-                   :color   {:vvalue "white"}
-                   :size    {:value 2},
-                   :tooltip (conj
-                             (mapv
-                              #(hash-map
-                                :field (name
-                                        (viewer-common/composite-key (:path %)))
-                                :type "quantitative"
-                                :title (str (:label metrics) " " (:label %)))
-                              (:values metrics))
-                             {:field "index" :type "quantitative"})}
-        :mark     {:type       "rule"
-                   :strokeDash [2 2]}}])))
-
 (defmethod view/samples* :portal
   [_ {:keys [] :as view} data-map]
   (let [quant-samples-id     (:samples-id view :samples)
@@ -333,16 +172,16 @@
          :layer
          (vec
           (into
-           [(metric-layer
+           [(charts/metric-layer
              (util/metric->values quant-samples)
              transforms
              (when outliers (util/outliers outliers))
              (have (first metric-configs)))]
            (mapcat
-            #(event-layer (util/metric->values event-samples) %)
+            #(charts/event-layer (util/metric->values event-samples) %)
             e-metrics-defs)))}]
        (mapv
-        #(metric-layer
+        #(charts/metric-layer
           (util/metric->values quant-samples)
           transforms
           outliers %)
@@ -376,64 +215,19 @@
                    :height  800
                    :layer
                    (into
-                    [(metric-computed-histo-layer
+                    [(charts/metric-computed-histo-layer
                       hist-transforms
                       (histograms (:path metric-config))
                       metric-config
                       (vswap! layer-num unchecked-inc))]
                     (when stats
                       (->>
-                       (metric-sample-stats-layer
+                       (charts/metric-sample-stats-layer
                         stats-transforms
                         (get-in (util/stats stats) (:path metric-config))
                         metric-config
                         (vswap! layer-num unchecked-inc)))))})
                 metric-configs)})))
-
-(defn metric-percentile-layer
-  [matric->values transforms metric]
-  (let [path        (:path metric)
-        k           (first path)
-        field-name  (name k)
-        vs          (->> (matric->values path)
-                         (map #(util/transform-sample-> % transforms))
-                         sort
-                         vec)
-        n           (count vs)
-        max-val     (Math/log10 (double n))
-        xs          (mapv
-                     #(/ (- max-val (Math/log10 (- n (double %)))) max-val)
-                     (range 0 n))
-        delta       (/ 100.0 (dec n))
-        percentiles (take n
-                          (iterate
-                           #(+ delta (double %)) 0))
-        data        (mapv
-                     #(hash-map k %1 :p %2 :x %3)
-                     vs
-                     percentiles
-                     xs)]
-    {:data   {:values data
-              :name   "vals"}
-     :height 800
-     :encoding
-     {:x
-      {:field "x" :type "quantitative"
-       :scale {:domain [0 1.0]}
-       :axis
-       {:labelExpr
-        ;; inverse of xs
-        (format
-         "format( (%d - pow(%d, 1 - min(datum.index, 1.0))) / %d,'.3%%')",
-         n,n,(dec n))
-        :tickCount 10}}
-      :y       {:field field-name
-                :type  "quantitative"
-                :scale {:zero false
-                        :type "log"}}
-      :tooltip [{:field "p" :type "quantitative"}
-                {:field field-name :type "quantitative"}]}
-     :mark   "point"}))
 
 (defmethod view/sample-percentiles* :portal
   [_ view data-map]
@@ -453,41 +247,10 @@
        [{:layer
          (vec
           (into
-           [(metric-percentile-layer
+           [(charts/metric-percentile-layer
              (util/metric->values quant-samples)
              transforms
              (first metric-configs))]))}])})))
-
-(defn metric-diff-layer
-  [samples metric]
-  (let [path       (:path metric)
-        k          (first path)
-        field-name (name k)
-        vs         (->> (get samples path)
-                        sort
-                        vec)
-        min-v      (double (first vs))
-        diffs      (-> (mapv
-                        #(- (double %) min-v)
-                        vs)
-                       sort
-                       distinct
-                       vec)
-        data       (mapv
-                    #(hash-map k %1 :x %2)
-                    diffs
-                    (range))]
-    {:data   {:values data
-              :name   "vals"}
-     :height 800
-     :encoding
-     {:x
-      {:field "x" :type "quantitative"}
-      :y       {:field field-name
-                :type  "quantitative"
-                :scale {:zero false}}
-      :tooltip [{:field field-name :type "quantitative"}]}
-     :mark   "point"}))
 
 (defmethod view/sample-diffs* :portal
   [_ {:keys [] :as view} data-map]
@@ -503,6 +266,6 @@
        [{:layer
          (vec
           (into
-           [(metric-diff-layer
+           [(charts/metric-diff-layer
              (util/metric->values quant-samples)
              (first metric-configs))]))}])})))

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -89,12 +89,13 @@
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)
         event-stats-map (data-map event-stats-id)
-        metrics-defs (have (:metrics-defs event-stats-map))]
-    (heading "Event stats")
-    (portal-table
-     (viewer-common/event-stats
-      metrics-defs
-      (util/event-stats event-stats-map)))))
+        metrics-defs (have (:metrics-defs event-stats-map))
+        stats (viewer-common/event-stats
+               metrics-defs
+               (util/event-stats event-stats-map))]
+    (when (seq stats)
+      (heading "Event stats")
+      (portal-table stats))))
 
 (defmethod view/quantiles* :portal
   [_ {:keys [quantiles-id]} data-map]
@@ -158,7 +159,11 @@
                            (metric/filter-metrics
                             (metric/type-pred :event)))
         metric-configs (metric/all-metric-configs q-metrics-defs)
-        e-metric-configs (metric/all-metric-configs e-metrics-defs)
+        event-metric->values (util/metric->values event-samples)
+        e-metric-configs (->> (metric/all-metric-configs e-metrics-defs)
+                              (filterv #(not-every? zero?
+                                                    (get event-metric->values
+                                                         (:path %)))))
 
         transforms (util/get-transforms data-map quant-samples-id)]
     (heading "Samples")
@@ -178,13 +183,13 @@
              (when outliers (util/outliers outliers))
              (have (first metric-configs)))]
            (mapcat
-            #(charts/event-layer (util/metric->values event-samples) %)
+            #(charts/event-layer event-metric->values %)
             e-metrics-defs)))}]
        (mapv
         #(charts/metric-layer
-          (util/metric->values quant-samples)
+          event-metric->values
           transforms
-          outliers %)
+          nil %)
         e-metric-configs))})))
 
 (defmethod view/histogram* :portal

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -3,9 +3,9 @@
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse]
    [criterium.bench :as bench]
+   [criterium.bench-plans :as bench-plans]
    [criterium.bench.config :as bench-config]
    [criterium.bench.impl :as bench-impl]
-   [criterium.bench-plans :as bench-plans]
    [criterium.viewer.kindly :as kindly]))
 
 (deftest bench-test

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse]
    [criterium.bench :as bench]
+   [criterium.bench.config :as bench-config]
    [criterium.bench.impl :as bench-impl]
    [criterium.bench-plans :as bench-plans]
    [criterium.viewer.kindly :as kindly]))
@@ -115,3 +116,47 @@
                 "has at least one chart")
             (is (every? #(string? (:$schema %)) charts)
                 "charts have Vega-Lite schema")))))))
+
+(deftest default-viewer-test
+  ;; Test default viewer configuration and precedence.
+  ;; Verifies that:
+  ;; 1. Initial default is :print
+  ;; 2. set-default-viewer! changes the default
+  ;; 3. Explicit :viewer option overrides the default
+  (testing "default-viewer"
+    (testing "returns initial default of :print"
+      (bench/set-default-viewer! :print)
+      (is (= :print (bench/default-viewer))))
+
+    (testing "set-default-viewer! changes the default"
+      (let [original (bench/default-viewer)]
+        (try
+          (bench/set-default-viewer! :kindly)
+          (is (= :kindly (bench/default-viewer)))
+          (finally
+            (bench/set-default-viewer! original)))))
+
+    (testing "config-map uses default viewer when no explicit option"
+      (let [original (bench/default-viewer)]
+        (try
+          (bench/set-default-viewer! :pprint)
+          (let [config (bench-config/config-map {})]
+            (is (= :pprint (:viewer config))))
+          (finally
+            (bench/set-default-viewer! original)))))
+
+    (testing "explicit :viewer option overrides default"
+      (let [original (bench/default-viewer)]
+        (try
+          (bench/set-default-viewer! :kindly)
+          (let [config (bench-config/config-map {:viewer :portal})]
+            (is (= :portal (:viewer config))))
+          (finally
+            (bench/set-default-viewer! original)))))
+
+    (testing "dynamic var can be bound for local scope"
+      (is (= :print (bench/default-viewer)))
+      (binding [bench-config/*default-viewer* :kindly]
+        (let [config (bench-config/config-map {})]
+          (is (= :kindly (:viewer config)))))
+      (is (= :print (bench/default-viewer))))))

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -53,8 +53,10 @@
     (testing "with one-shot collect plan"
       (reset! kindly/accumulated [])
       (let [result (bench/bench (+ 1 1) :viewer :kindly :collect-plan :one-shot)]
-        (is (= 2 result)
-            "bench returns expression value"))
+        (is (= :kind/fragment (:kindly/kind (meta result)))
+            "bench returns kindly fragment")
+        (is (sequential? result)
+            "result is a sequence of views"))
       (is (empty? @kindly/accumulated)
           "accumulator is empty after flush"))
 
@@ -69,11 +71,14 @@
 
     (testing "view returns kindly fragment"
       ;; Use view directly to verify fragment is returned
-      (let [data-map (:data (do (with-out-str
-                                  (bench/bench (+ 1 1)
-                                               :viewer :print
-                                               :collect-plan :one-shot))
-                                (bench/last-bench)))]
+      ;; Strip :viewer key since it was added by the previous bench call
+      (let [data-map (dissoc
+                      (:data (do (with-out-str
+                                   (bench/bench (+ 1 1)
+                                                :viewer :print
+                                                :collect-plan :one-shot))
+                                 (bench/last-bench)))
+                      :viewer)]
         (reset! kindly/accumulated [])
         (let [fragment (bench/view [:metrics :collect-plan] :kindly data-map)]
           (is (= :kind/fragment (:kindly/kind (meta fragment)))
@@ -83,12 +88,15 @@
 
     (testing "with log-histogram plan produces full output"
       ;; Get benchmark data using :print viewer
-      (let [data-map (:data (do (with-out-str
-                                  (bench/bench (+ 1 1)
-                                               :viewer :print
-                                               :bench-plan bench-plans/log-histogram
-                                               :limit-time-s 0.5))
-                                (bench/last-bench)))]
+      ;; Strip :viewer key since it was added by the previous bench call
+      (let [data-map (dissoc
+                      (:data (do (with-out-str
+                                   (bench/bench (+ 1 1)
+                                                :viewer :print
+                                                :bench-plan bench-plans/log-histogram
+                                                :limit-time-s 0.5))
+                                 (bench/last-bench)))
+                      :viewer)]
         ;; View with :kindly - bench/view returns the fragment
         (reset! kindly/accumulated [])
         (let [fragment (bench/view (:view bench-plans/log-histogram) :kindly data-map)]

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -3,7 +3,9 @@
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse]
    [criterium.bench :as bench]
-   [criterium.bench.impl :as bench-impl]))
+   [criterium.bench.impl :as bench-impl]
+   [criterium.bench-plans :as bench-plans]
+   [criterium.viewer.kindly :as kindly]))
 
 (deftest bench-test
   (testing "bench"
@@ -41,3 +43,75 @@
                             :measured-args
                             :class-loader])]
         (is (= 1 v))))))
+
+(deftest kindly-viewer-integration-test
+  ;; Integration test for :kindly viewer with actual benchmark execution.
+  ;; Verifies that :viewer :kindly produces Kindly-annotated output
+  ;; suitable for Clay notebook rendering.
+  (testing ":kindly viewer"
+    (testing "with one-shot collect plan"
+      (reset! kindly/accumulated [])
+      (let [result (bench/bench (+ 1 1) :viewer :kindly :collect-plan :one-shot)]
+        (is (= 2 result)
+            "bench returns expression value"))
+      (is (empty? @kindly/accumulated)
+          "accumulator is empty after flush"))
+
+    (testing "with full benchmark and log-histogram plan"
+      (reset! kindly/accumulated [])
+      (bench/bench (+ 1 1)
+                   :viewer :kindly
+                   :bench-plan bench-plans/log-histogram
+                   :limit-time-s 0.5)
+      (is (empty? @kindly/accumulated)
+          "accumulator is empty after flush - fragment was returned by flush-viewer"))
+
+    (testing "view returns kindly fragment"
+      ;; Use view directly to verify fragment is returned
+      (let [data-map (:data (do (with-out-str
+                                  (bench/bench (+ 1 1)
+                                               :viewer :print
+                                               :collect-plan :one-shot))
+                                (bench/last-bench)))]
+        (reset! kindly/accumulated [])
+        (let [fragment (bench/view [:metrics :collect-plan] :kindly data-map)]
+          (is (= :kind/fragment (:kindly/kind (meta fragment)))
+              "view returns kind/fragment")
+          (is (pos? (count fragment))
+              "fragment contains accumulated views"))))
+
+    (testing "with log-histogram plan produces full output"
+      ;; Get benchmark data using :print viewer
+      (let [data-map (:data (do (with-out-str
+                                  (bench/bench (+ 1 1)
+                                               :viewer :print
+                                               :bench-plan bench-plans/log-histogram
+                                               :limit-time-s 0.5))
+                                (bench/last-bench)))]
+        ;; View with :kindly - bench/view returns the fragment
+        (reset! kindly/accumulated [])
+        (let [fragment (bench/view (:view bench-plans/log-histogram) :kindly data-map)]
+          (is (= :kind/fragment (:kindly/kind (meta fragment)))
+              "view returns kind/fragment for kindly viewer")
+          (is (>= (count fragment) 10)
+              "fragment contains multiple views (headings, tables, charts)")
+
+          (let [kinds (set (map #(:kindly/kind (meta %)) fragment))]
+            (is (contains? kinds :kind/md)
+                "contains markdown headings")
+            (is (contains? kinds :kind/table)
+                "contains tables")
+            (is (contains? kinds :kind/vega-lite)
+                "contains Vega-Lite charts"))
+
+          (let [tables (filter #(= :kind/table (:kindly/kind (meta %))) fragment)]
+            (is (pos? (count tables))
+                "has at least one table")
+            (is (every? sequential? tables)
+                "tables are sequences"))
+
+          (let [charts (filter #(= :kind/vega-lite (:kindly/kind (meta %))) fragment)]
+            (is (pos? (count charts))
+                "has at least one chart")
+            (is (every? #(string? (:$schema %)) charts)
+                "charts have Vega-Lite schema")))))))

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -163,3 +163,34 @@
        :batch-size     1
        :eval-count     1
        :expr-value     1}}}))
+
+(defn quantiles-map []
+  (let [metrics-defs       (select-keys (metrics/metrics) [:elapsed-time])
+        ;; Filter to only quantitative metrics (matches analyse.clj quantiles behavior)
+        quant-metrics-defs (metric/filter-metrics
+                            metrics-defs
+                            (metric/type-pred :quantitative))]
+    {:data
+     {:samples
+      {:type           :criterium/metrics-samples
+       :metrics-defs   metrics-defs
+       :metric->values {[:elapsed-time] [25 50 75]}
+       :transform      collect-plan/identity-transforms
+       :batch-size     1
+       :eval-count     3
+       :num-samples    3}
+      :quantiles
+      {:type         :criterium/quantiles
+       :metrics-defs quant-metrics-defs
+       :quantiles    {:elapsed-time {0.25 25.0 0.5 50.0 0.75 75.0}}
+       :source-id    :samples
+       :transform    collect-plan/identity-transforms}}}))
+
+(defn collect-plan-map []
+  {:data
+   {:samples    {:batch-size   10
+                 :num-samples  100}
+    :warmup     {:batch-size   5
+                 :num-samples  50}
+    :estimation {:batch-size   1
+                 :num-samples  10}}})

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -41,7 +41,8 @@
      {:samples
       {:type           :criterium/metrics-samples
        :metrics-defs   metrics-defs
-       :metric->values {[:elapsed-time] [1 1]}
+       :metric->values {[:elapsed-time] [1 1]
+                        [:expr-value]   [42 42]}
        :transform      collect-plan/identity-transforms
        :batch-size     1
        :eval-count     2
@@ -194,3 +195,4 @@
                  :num-samples  50}
     :estimation {:batch-size   1
                  :num-samples  10}}})
+

--- a/bases/criterium/test/criterium/viewer/kindly_clay_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_clay_test.clj
@@ -1,0 +1,80 @@
+(ns criterium.viewer.kindly-clay-test
+  ;; Integration test verifying Kindly viewer output renders correctly via Clay.
+  ;; Uses clay/make! to render benchmark results and verifies the HTML output
+  ;; contains expected tables, charts, and structure.
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [criterium.bench :as bench]
+   [criterium.bench-plans :as bench-plans]
+   [scicloj.clay.v2.api :as clay]))
+
+(defmacro with-temp-dir
+  "Creates a temporary directory, binds it to dir-sym, cleans up after body."
+  [[dir-sym] & body]
+  `(let [temp-dir# (io/file (System/getProperty "java.io.tmpdir")
+                            (str "criterium-clay-test-" (System/currentTimeMillis)))]
+     (.mkdirs temp-dir#)
+     (try
+       (let [~dir-sym temp-dir#]
+         ~@body)
+       (finally
+         (doseq [^java.io.File file# (reverse (file-seq temp-dir#))]
+           (.delete file#))))))
+
+(deftest ^:slow kindly-clay-rendering-test
+  ;; Verifies that Kindly viewer output renders correctly through Clay.
+  ;; Tests the full pipeline: benchmark -> Kindly fragment -> HTML via Clay.
+  (testing "Kindly viewer Clay rendering"
+    (testing "renders one-shot benchmark as HTML"
+      (with-temp-dir [temp-dir]
+        (let [fragment (bench/bench (reduce + (range 100))
+                                    :viewer :kindly
+                                    :collect-plan :one-shot)]
+          (is (= :kind/fragment (:kindly/kind (meta fragment)))
+              "bench returns Kindly fragment")
+
+          (clay/make! {:single-value fragment
+                       :base-target-path (str temp-dir)
+                       :format [:html]
+                       :show false
+                       :browse false})
+
+          (is (.exists (io/file temp-dir ".clay.html"))
+              "Clay creates HTML output")
+
+          (let [html (slurp (io/file temp-dir ".clay.html"))]
+            (is (str/includes? html "<table")
+                "HTML contains table elements")
+            (is (str/includes? html "Elapsed Time")
+                "HTML contains elapsed time metric")))))
+
+    (testing "renders log-histogram benchmark with charts"
+      (with-temp-dir [temp-dir]
+        (let [fragment (bench/bench (reduce + (range 100))
+                                    :viewer :kindly
+                                    :bench-plan bench-plans/log-histogram
+                                    :limit-time-s 0.5)]
+          (is (= :kind/fragment (:kindly/kind (meta fragment)))
+              "bench returns Kindly fragment")
+
+          (clay/make! {:single-value fragment
+                       :base-target-path (str temp-dir)
+                       :format [:html]
+                       :show false
+                       :browse false})
+
+          (let [html (slurp (io/file temp-dir ".clay.html"))]
+            (is (str/includes? html "<table")
+                "HTML contains table elements")
+            (is (str/includes? html "Summary stats")
+                "HTML contains stats heading")
+            (is (str/includes? html "Quantiles")
+                "HTML contains quantiles heading")
+            (is (str/includes? html "Histogram")
+                "HTML contains histogram heading")
+            (is (str/includes? html "vegaEmbed")
+                "HTML contains Vega-Lite chart embedding")
+            (is (str/includes? html "vega-lite")
+                "HTML references Vega-Lite")))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -81,6 +81,15 @@
       (kindly/flush)
       (is (= [] @kindly/accumulated)))
 
+    (testing "stores fragment in last-fragment atom"
+      (reset! kindly/accumulated [])
+      (reset! kindly/last-fragment nil)
+      (kindly/kindly-add {:a 1})
+      (kindly/kindly-add {:b 2})
+      (kindly/flush)
+      (is (= [{:a 1} {:b 2}] @kindly/last-fragment))
+      (is (= :kind/fragment (:kindly/kind (meta @kindly/last-fragment)))))
+
     (testing "returns nil when accumulator is empty"
       (reset! kindly/accumulated [])
       (is (nil? (kindly/flush))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -1,0 +1,95 @@
+(ns criterium.viewer.kindly-test
+  ;; Tests for the Kindly viewer accumulator and flush mechanism.
+  ;; Verifies that values accumulate correctly, flush returns a kind/fragment,
+  ;; and the accumulator clears after flush.
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.view :as view]
+   [criterium.viewer.kindly :as kindly]))
+
+(deftest kindly-add-test
+  (testing "kindly-add"
+    (testing "appends values to the accumulator"
+      (reset! kindly/accumulated [])
+      (kindly/kindly-add {:a 1})
+      (kindly/kindly-add {:b 2})
+      (is (= [{:a 1} {:b 2}] @kindly/accumulated)))
+
+    (testing "returns nil"
+      (reset! kindly/accumulated [])
+      (is (nil? (kindly/kindly-add {:x 1}))))))
+
+(deftest kindly-heading-test
+  (testing "kindly-heading"
+    (testing "adds markdown heading with :kind/md metadata"
+      (reset! kindly/accumulated [])
+      (kindly/kindly-heading "Test Section")
+      (let [result (first @kindly/accumulated)]
+        (is (= ["**Test Section**"] result))
+        (is (= :kind/md (:kindly/kind (meta result))))))
+
+    (testing "returns nil"
+      (reset! kindly/accumulated [])
+      (is (nil? (kindly/kindly-heading "Heading"))))))
+
+(deftest kindly-table-test
+  (testing "kindly-table"
+    (testing "adds table data with :kind/table metadata"
+      (reset! kindly/accumulated [])
+      (let [table-data [{:col1 "a" :col2 1}]]
+        (kindly/kindly-table table-data)
+        (let [result (first @kindly/accumulated)]
+          (is (= table-data result))
+          (is (= :kind/table (:kindly/kind (meta result)))))))
+
+    (testing "returns nil"
+      (reset! kindly/accumulated [])
+      (is (nil? (kindly/kindly-table []))))))
+
+(deftest kindly-vega-lite-test
+  (testing "kindly-vega-lite"
+    (testing "adds Vega-Lite spec with :kind/vega-lite metadata and schema"
+      (reset! kindly/accumulated [])
+      (let [spec {:data {:values []} :mark "point"}]
+        (kindly/kindly-vega-lite spec)
+        (let [result (first @kindly/accumulated)]
+          (is (= "https://vega.github.io/schema/vega-lite/v5.json"
+                 (:$schema result)))
+          (is (= {:values []} (:data result)))
+          (is (= "point" (:mark result)))
+          (is (= :kind/vega-lite (:kindly/kind (meta result)))))))
+
+    (testing "returns nil"
+      (reset! kindly/accumulated [])
+      (is (nil? (kindly/kindly-vega-lite {}))))))
+
+(deftest flush-test
+  (testing "flush"
+    (testing "returns accumulated values as kind/fragment"
+      (reset! kindly/accumulated [])
+      (kindly/kindly-add {:a 1})
+      (kindly/kindly-add {:b 2})
+      (let [result (kindly/flush)]
+        (is (= [{:a 1} {:b 2}] result))
+        (is (= :kind/fragment (:kindly/kind (meta result))))))
+
+    (testing "clears accumulator after flush"
+      (reset! kindly/accumulated [])
+      (kindly/kindly-add {:x 1})
+      (kindly/flush)
+      (is (= [] @kindly/accumulated)))
+
+    (testing "returns nil when accumulator is empty"
+      (reset! kindly/accumulated [])
+      (is (nil? (kindly/flush))))))
+
+(deftest flush-viewer-test
+  (testing "flush-viewer :kindly"
+    (testing "dispatches to flush function"
+      (reset! kindly/accumulated [])
+      (kindly/kindly-heading "Section")
+      (kindly/kindly-table [{:a 1}])
+      (let [result (view/flush-viewer :kindly)]
+        (is (= 2 (count result)))
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= [] @kindly/accumulated))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -140,3 +140,71 @@
                      :mean-plus-3sigma  1.00,
                      :max-val           1.00}]
                    table))))))))
+
+(deftest quantiles-view-test
+  ;; Tests the view/quantiles* multimethod for :kindly viewer.
+  ;; Verifies that quantiles data is rendered as a heading and table with correct
+  ;; Kindly metadata and structure.
+  (testing "view/quantiles* :kindly"
+    (testing "renders quantiles as heading and table"
+      (reset! kindly/accumulated [])
+      (view/quantiles* :kindly {} (:data (test-data/quantiles-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Quantiles**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 1 (count table))
+              "Expected one metric row")
+          (is (string? (:metric (first table)))
+              "Expected :metric column")
+          (is (number? (get (first table) 0.5))
+              "Expected numeric 0.5 quantile"))))))
+
+(deftest outlier-counts-view-test
+  ;; Tests the view/outlier-counts* multimethod for :kindly viewer.
+  ;; Verifies that outlier counts data is rendered as heading and table with
+  ;; correct Kindly metadata and outlier type columns.
+  (testing "view/outlier-counts* :kindly"
+    (testing "renders outliers as heading and table"
+      (reset! kindly/accumulated [])
+      (view/outlier-counts* :kindly {} (:data (test-data/outlier-count-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Outliers**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= [{:_metric     "Elapsed Time"
+                   :low-severe  0
+                   :low-mild    2
+                   :high-mild   3
+                   :high-severe 0}]
+                 table)))))))
+
+(deftest collect-plan-view-test
+  ;; Tests the view/collect-plan* multimethod for :kindly viewer.
+  ;; Verifies that collect plan data is rendered as heading and table with
+  ;; correct Kindly metadata and phase information.
+  (testing "view/collect-plan* :kindly"
+    (testing "renders collect plan as heading and table"
+      (reset! kindly/accumulated [])
+      (view/collect-plan* :kindly {} (:data (test-data/collect-plan-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Collect plan**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 3 (count table))
+              "Expected 3 phases: sample, warmup, estimation")
+          (is (= #{:sample :warmup :estimation}
+                 (set (map :phase table)))
+              "Expected all phases present"))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -342,3 +342,120 @@
               "Expected numeric percentile value")
           (is (number? (:x (first percentile-data)))
               "Expected numeric x value"))))))
+
+(deftest metrics-view-test
+  ;; Tests the view/metrics* multimethod for :kindly viewer.
+  ;; Verifies that metrics data is rendered as a heading and table.
+  (testing "view/metrics* :kindly"
+    (testing "renders metrics as heading and table"
+      (reset! kindly/accumulated [])
+      (view/metrics* :kindly {} (:data (test-data/samples-with-2-values-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Metrics**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 2 (count table))
+              "Expected two metric rows (elapsed-time and expr-value)")
+          (is (every? #(string? (:metric %)) table)
+              "Expected :metric column in all rows")
+          (is (every? #(string? (:value %)) table)
+              "Expected :value column in all rows"))))))
+
+(deftest event-stats-view-test
+  ;; Tests the view/event-stats* multimethod for :kindly viewer.
+  ;; Verifies that event stats data is rendered as a heading and table.
+  (testing "view/event-stats* :kindly"
+    (testing "renders event stats as heading and table via analyse pipeline"
+      (reset! kindly/accumulated [])
+      (let [data-map    (:data (test-data/samples-for-event-stats-map))
+            event-stats (analyse/event-stats)
+            view        (view/event-stats)]
+        (->> data-map
+             event-stats
+             (view :kindly))
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result))
+              "Expected heading and table")
+          (let [[heading table] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Event stats**"] heading))
+            (is (= :kind/table (:kindly/kind (meta table))))
+            (is (pos? (count table))
+                "Expected at least one event stats row")
+            (is (every? #(contains? % :metric) table)
+                "Expected :metric column in all rows")))))))
+
+(deftest outlier-significance-view-test
+  ;; Tests the view/outlier-significance* multimethod for :kindly viewer.
+  ;; Verifies that outlier significance data is rendered as heading and table.
+  (testing "view/outlier-significance* :kindly"
+    (testing "renders outlier significance as heading and table"
+      (reset! kindly/accumulated [])
+      (view/outlier-significance* :kindly {} (:data (test-data/outlier-significance-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Outlier Significance**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 1 (count table))
+              "Expected one metric row")
+          (let [row (first table)]
+            (is (= :moderate (:effect row))
+                "Expected moderate effect")
+            (is (= 0.25 (:significance row))
+                "Expected 0.25 significance")))))))
+
+(deftest sample-diffs-view-test
+  ;; Tests the view/sample-diffs* multimethod for :kindly viewer.
+  ;; Verifies that sample diffs data is rendered as heading and Vega-Lite chart.
+  (testing "view/sample-diffs* :kindly"
+    (testing "renders sample diffs as heading and Vega-Lite chart"
+      (reset! kindly/accumulated [])
+      (let [data-map (:data (test-data/samples-with-2-values-map))
+            ;; Add metric-configs needed by sample-diffs
+            data-map (assoc-in data-map [:samples :metric-configs]
+                               [{:path  [:elapsed-time]
+                                 :label "Elapsed Time"
+                                 :scale 1}])]
+        (view/sample-diffs* :kindly {} data-map)
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result))
+              "Expected heading and chart")
+          (let [[heading chart] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Sample diffs**"] heading))
+            (is (= :kind/vega-lite (:kindly/kind (meta chart))))
+            (is (string? (:$schema chart))
+                "Expected Vega-Lite schema")))))))
+
+(deftest noop-views-test
+  ;; Tests that noop multimethods do not add anything to the accumulator.
+  (testing "noop views"
+    (testing "bootstrap-stats* produces no output"
+      (reset! kindly/accumulated [])
+      (view/bootstrap-stats* :kindly {} {})
+      (is (empty? @kindly/accumulated)))
+
+    (testing "final-gc-warnings* produces no output"
+      (reset! kindly/accumulated [])
+      (view/final-gc-warnings* :kindly {} {})
+      (is (empty? @kindly/accumulated)))
+
+    (testing "os* produces no output"
+      (reset! kindly/accumulated [])
+      (view/os* :kindly {} {})
+      (is (empty? @kindly/accumulated)))
+
+    (testing "runtime* produces no output"
+      (reset! kindly/accumulated [])
+      (view/runtime* :kindly {} {})
+      (is (empty? @kindly/accumulated)))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -236,8 +236,7 @@
           (is (= :kind/vega-lite (:kindly/kind (meta chart))))
           (is (string? (:$schema chart))
               "Expected Vega-Lite schema")
-          (is (= 700 (:width chart))
-              "Expected notebook-friendly width")
+          (is (= 700 (-> chart :vconcat first :width)) "Expected notebook-friendly width")
           (is (= 350 (-> chart :vconcat first :height))
               "Expected notebook-friendly height")
           (is (= [{:elapsed-time 1.0 :index 0 :outlier ""}
@@ -306,8 +305,7 @@
             (is (= :kind/vega-lite (:kindly/kind (meta chart))))
             (is (string? (:$schema chart))
                 "Expected Vega-Lite schema")
-            (is (= 700 (:width chart))
-                "Expected notebook-friendly width")
+            (is (= 700 (-> chart :vconcat first :width)) "Expected notebook-friendly width")
             (is (= 350 (-> chart :vconcat first :height))
                 "Expected notebook-friendly height")
             (let [histogram-data (-> chart :vconcat first :layer first :data :values)]
@@ -336,8 +334,7 @@
           (is (= :kind/vega-lite (:kindly/kind (meta chart))))
           (is (string? (:$schema chart))
               "Expected Vega-Lite schema")
-          (is (= 700 (:width chart))
-              "Expected notebook-friendly width")
+          (is (= 700 (-> chart :vconcat first :width)) "Expected notebook-friendly width")
           (is (= 350 (-> chart :vconcat first :height))
               "Expected notebook-friendly height")
           (let [percentile-data (-> chart :vconcat first :layer first :data :values)]
@@ -458,8 +455,7 @@
             (is (= :kind/vega-lite (:kindly/kind (meta chart))))
             (is (string? (:$schema chart))
                 "Expected Vega-Lite schema")
-            (is (= 700 (:width chart))
-                "Expected notebook-friendly width")
+            (is (= 700 (-> chart :vconcat first :width)) "Expected notebook-friendly width")
             (is (= 350 (-> chart :vconcat first :height))
                 "Expected notebook-friendly height")))))))
 

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -208,3 +208,95 @@
           (is (= #{:sample :warmup :estimation}
                  (set (map :phase table)))
               "Expected all phases present"))))))
+
+(deftest samples-view-test
+  ;; Tests the view/samples* multimethod for :kindly viewer.
+  ;; Verifies that samples data is rendered as a heading and Vega-Lite scatter
+  ;; plot with outlier coloring.
+  (testing "view/samples* :kindly"
+    (testing "renders samples as heading and Vega-Lite chart"
+      (reset! kindly/accumulated [])
+      (view/samples* :kindly {} (:data (test-data/samples-with-2-values-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and chart")
+        (let [[heading chart] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Samples**"] heading))
+          (is (= :kind/vega-lite (:kindly/kind (meta chart))))
+          (is (string? (:$schema chart))
+              "Expected Vega-Lite schema")
+          (is (= [{:elapsed-time 1.0 :index 0 :outlier ""}
+                  {:elapsed-time 1.0 :index 1 :outlier ""}]
+                 (-> chart :vconcat first :layer first :data :values))))))
+
+    (testing "renders samples with transformed data"
+      (reset! kindly/accumulated [])
+      (view/samples* :kindly {} (:data (test-data/samples-with-transformed-values-map)))
+      (let [result (kindly/flush)
+            [_heading chart] result]
+        (is (= [{:elapsed-time 1.0 :index 0 :outlier ""}
+                {:elapsed-time 2.0 :index 1 :outlier ""}
+                {:elapsed-time 4.0 :index 2 :outlier ""}]
+               (-> chart :vconcat first :layer first :data :values)))))
+
+    (testing "renders samples with outlier coloring via analyse pipeline"
+      (reset! kindly/accumulated [])
+      (let [data-map  (:data (test-data/samples-with-outliers-values-map))
+            quantiles (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
+            outliers  (analyse/outliers)
+            stats     (analyse/stats)
+            view      (view/samples)]
+        (->> data-map
+             quantiles
+             outliers
+             stats
+             (view :kindly))
+        (let [result (kindly/flush)
+              [_heading chart] result]
+          (is (= [{:elapsed-time 9.0 :index 0 :outlier ""}
+                  {:elapsed-time 10.0 :index 1 :outlier ""}
+                  {:elapsed-time 9.0 :index 2 :outlier ""}
+                  {:elapsed-time 10.0 :index 3 :outlier ""}
+                  {:elapsed-time 9.0 :index 4 :outlier ""}
+                  {:elapsed-time 10.0 :index 5 :outlier ""}
+                  {:elapsed-time 10000.0 :index 6 :outlier :high-severe}]
+                 (-> chart :vconcat first :layer first :data :values))))))))
+
+(deftest histogram-view-test
+  ;; Tests the view/histogram* multimethod for :kindly viewer.
+  ;; Verifies that histogram data is rendered as a heading and Vega-Lite bar
+  ;; chart with optional normal PDF overlay.
+  (testing "view/histogram* :kindly"
+    (testing "renders histogram as heading and Vega-Lite chart"
+      (reset! kindly/accumulated [])
+      (let [data-map       (:data (test-data/samples-with-outliers-values-map))
+            quantiles      (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
+            outliers       (analyse/outliers)
+            stats          (analyse/stats)
+            histogram      (analyse/histogram)
+            view-histogram (view/histogram)]
+        (->> data-map
+             quantiles
+             outliers
+             stats
+             histogram
+             (view-histogram :kindly))
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result))
+              "Expected heading and chart")
+          (let [[heading chart] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Histogram**"] heading))
+            (is (= :kind/vega-lite (:kindly/kind (meta chart))))
+            (is (string? (:$schema chart))
+                "Expected Vega-Lite schema")
+            (let [histogram-data (-> chart :vconcat first :layer first :data :values)]
+              (is (vector? histogram-data))
+              (is (pos? (count histogram-data)))
+              (is (every? #(and (contains? % "elapsed-time")
+                                (contains? % "end")
+                                (contains? % "density"))
+                          histogram-data)))))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -4,6 +4,8 @@
   ;; and the accumulator clears after flush.
   (:require
    [clojure.test :refer [deftest is testing]]
+   [criterium.analyse :as analyse]
+   [criterium.test-data :as test-data]
    [criterium.view :as view]
    [criterium.viewer.kindly :as kindly]))
 
@@ -93,3 +95,48 @@
         (is (= 2 (count result)))
         (is (= :kind/fragment (:kindly/kind (meta result))))
         (is (= [] @kindly/accumulated))))))
+
+(deftest stats-view-test
+  ;; Tests the view/stats* multimethod for :kindly viewer.
+  ;; Verifies that stats data is rendered as a heading and table with correct
+  ;; Kindly metadata and column structure.
+  (testing "view/stats* :kindly"
+    (testing "renders stats as heading and table with bench-stats-map"
+      (reset! kindly/accumulated [])
+      (view/stats* :kindly {} (:data (test-data/bench-stats-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Summary stats**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= [{:_metric           "Elapsed Time ns",
+                   :mean              100.0
+                   :min-val           89.0
+                   :mean-minus-3sigma 88.0
+                   :mean-plus-3sigma  112.0
+                   :max-val           114.0}]
+                 table)))))
+
+    (testing "renders stats via analyse pipeline"
+      (reset! kindly/accumulated [])
+      (let [data-map   (:data (test-data/samples-with-2-values-map))
+            stats      (analyse/stats)
+            view-stats (view/stats)]
+        (->> data-map
+             stats
+             (view-stats :kindly))
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (let [[heading table] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= :kind/table (:kindly/kind (meta table))))
+            (is (= [{:_metric           "Elapsed Time ns",
+                     :mean              1.00,
+                     :min-val           1.00,
+                     :mean-minus-3sigma 1.00,
+                     :mean-plus-3sigma  1.00,
+                     :max-val           1.00}]
+                   table))))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -121,18 +121,18 @@
           (is (= :kind/md (:kindly/kind (meta heading))))
           (is (= ["**Summary stats**"] heading))
           (is (= :kind/table (:kindly/kind (meta table))))
-          (is (= [{:_metric           "Elapsed Time ns",
-                   :mean              100.0
-                   :min-val           89.0
+          (is (= [{:_metric "Elapsed Time ns",
+                   :mean 100.0
+                   :min-val 89.0
                    :mean-minus-3sigma 88.0
-                   :mean-plus-3sigma  112.0
-                   :max-val           114.0}]
+                   :mean-plus-3sigma 112.0
+                   :max-val 114.0}]
                  table)))))
 
     (testing "renders stats via analyse pipeline"
       (reset! kindly/accumulated [])
-      (let [data-map   (:data (test-data/samples-with-2-values-map))
-            stats      (analyse/stats)
+      (let [data-map (:data (test-data/samples-with-2-values-map))
+            stats (analyse/stats)
             view-stats (view/stats)]
         (->> data-map
              stats
@@ -142,12 +142,12 @@
           (let [[heading table] result]
             (is (= :kind/md (:kindly/kind (meta heading))))
             (is (= :kind/table (:kindly/kind (meta table))))
-            (is (= [{:_metric           "Elapsed Time ns",
-                     :mean              1.00,
-                     :min-val           1.00,
+            (is (= [{:_metric "Elapsed Time ns",
+                     :mean 1.00,
+                     :min-val 1.00,
                      :mean-minus-3sigma 1.00,
-                     :mean-plus-3sigma  1.00,
-                     :max-val           1.00}]
+                     :mean-plus-3sigma 1.00,
+                     :max-val 1.00}]
                    table))))))))
 
 (deftest quantiles-view-test
@@ -189,10 +189,10 @@
           (is (= :kind/md (:kindly/kind (meta heading))))
           (is (= ["**Outliers**"] heading))
           (is (= :kind/table (:kindly/kind (meta table))))
-          (is (= [{:_metric     "Elapsed Time"
-                   :low-severe  0
-                   :low-mild    2
-                   :high-mild   3
+          (is (= [{:_metric "Elapsed Time"
+                   :low-severe 0
+                   :low-mild 2
+                   :high-mild 3
                    :high-severe 0}]
                  table)))))))
 
@@ -221,7 +221,7 @@
 (deftest samples-view-test
   ;; Tests the view/samples* multimethod for :kindly viewer.
   ;; Verifies that samples data is rendered as a heading and Vega-Lite scatter
-  ;; plot with outlier coloring.
+  ;; plot with outlier coloring and notebook-friendly dimensions.
   (testing "view/samples* :kindly"
     (testing "renders samples as heading and Vega-Lite chart"
       (reset! kindly/accumulated [])
@@ -236,6 +236,10 @@
           (is (= :kind/vega-lite (:kindly/kind (meta chart))))
           (is (string? (:$schema chart))
               "Expected Vega-Lite schema")
+          (is (= 700 (:width chart))
+              "Expected notebook-friendly width")
+          (is (= 350 (-> chart :vconcat first :height))
+              "Expected notebook-friendly height")
           (is (= [{:elapsed-time 1.0 :index 0 :outlier ""}
                   {:elapsed-time 1.0 :index 1 :outlier ""}]
                  (-> chart :vconcat first :layer first :data :values))))))
@@ -252,11 +256,11 @@
 
     (testing "renders samples with outlier coloring via analyse pipeline"
       (reset! kindly/accumulated [])
-      (let [data-map  (:data (test-data/samples-with-outliers-values-map))
+      (let [data-map (:data (test-data/samples-with-outliers-values-map))
             quantiles (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
-            outliers  (analyse/outliers)
-            stats     (analyse/stats)
-            view      (view/samples)]
+            outliers (analyse/outliers)
+            stats (analyse/stats)
+            view (view/samples)]
         (->> data-map
              quantiles
              outliers
@@ -276,15 +280,15 @@
 (deftest histogram-view-test
   ;; Tests the view/histogram* multimethod for :kindly viewer.
   ;; Verifies that histogram data is rendered as a heading and Vega-Lite bar
-  ;; chart with optional normal PDF overlay.
+  ;; chart with optional normal PDF overlay and notebook-friendly dimensions.
   (testing "view/histogram* :kindly"
     (testing "renders histogram as heading and Vega-Lite chart"
       (reset! kindly/accumulated [])
-      (let [data-map       (:data (test-data/samples-with-outliers-values-map))
-            quantiles      (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
-            outliers       (analyse/outliers)
-            stats          (analyse/stats)
-            histogram      (analyse/histogram)
+      (let [data-map (:data (test-data/samples-with-outliers-values-map))
+            quantiles (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
+            outliers (analyse/outliers)
+            stats (analyse/stats)
+            histogram (analyse/histogram)
             view-histogram (view/histogram)]
         (->> data-map
              quantiles
@@ -302,6 +306,10 @@
             (is (= :kind/vega-lite (:kindly/kind (meta chart))))
             (is (string? (:$schema chart))
                 "Expected Vega-Lite schema")
+            (is (= 700 (:width chart))
+                "Expected notebook-friendly width")
+            (is (= 350 (-> chart :vconcat first :height))
+                "Expected notebook-friendly height")
             (let [histogram-data (-> chart :vconcat first :layer first :data :values)]
               (is (vector? histogram-data))
               (is (pos? (count histogram-data)))
@@ -313,7 +321,7 @@
 (deftest sample-percentiles-view-test
   ;; Tests the view/sample-percentiles* multimethod for :kindly viewer.
   ;; Verifies that sample percentiles data is rendered as a heading and
-  ;; Vega-Lite percentile distribution chart.
+  ;; Vega-Lite percentile distribution chart with notebook-friendly dimensions.
   (testing "view/sample-percentiles* :kindly"
     (testing "renders percentiles as heading and Vega-Lite chart"
       (reset! kindly/accumulated [])
@@ -328,6 +336,10 @@
           (is (= :kind/vega-lite (:kindly/kind (meta chart))))
           (is (string? (:$schema chart))
               "Expected Vega-Lite schema")
+          (is (= 700 (:width chart))
+              "Expected notebook-friendly width")
+          (is (= 350 (-> chart :vconcat first :height))
+              "Expected notebook-friendly height")
           (let [percentile-data (-> chart :vconcat first :layer first :data :values)]
             (is (vector? percentile-data))
             (is (= 2 (count percentile-data))
@@ -339,7 +351,7 @@
 
     (testing "renders percentiles with transformed data via analyse pipeline"
       (reset! kindly/accumulated [])
-      (let [data-map            (:data (test-data/samples-with-outliers-values-map))
+      (let [data-map (:data (test-data/samples-with-outliers-values-map))
             view-sample-percent (view/sample-percentiles)]
         (view-sample-percent :kindly data-map)
         (let [result (kindly/flush)
@@ -380,9 +392,9 @@
   (testing "view/event-stats* :kindly"
     (testing "renders event stats as heading and table via analyse pipeline"
       (reset! kindly/accumulated [])
-      (let [data-map    (:data (test-data/samples-for-event-stats-map))
+      (let [data-map (:data (test-data/samples-for-event-stats-map))
             event-stats (analyse/event-stats)
-            view        (view/event-stats)]
+            view (view/event-stats)]
         (->> data-map
              event-stats
              (view :kindly))
@@ -424,14 +436,15 @@
 
 (deftest sample-diffs-view-test
   ;; Tests the view/sample-diffs* multimethod for :kindly viewer.
-  ;; Verifies that sample diffs data is rendered as heading and Vega-Lite chart.
+  ;; Verifies that sample diffs data is rendered as heading and Vega-Lite chart
+  ;; with notebook-friendly dimensions.
   (testing "view/sample-diffs* :kindly"
     (testing "renders sample diffs as heading and Vega-Lite chart"
       (reset! kindly/accumulated [])
       (let [data-map (:data (test-data/samples-with-2-values-map))
             ;; Add metric-configs needed by sample-diffs
             data-map (assoc-in data-map [:samples :metric-configs]
-                               [{:path  [:elapsed-time]
+                               [{:path [:elapsed-time]
                                  :label "Elapsed Time"
                                  :scale 1}])]
         (view/sample-diffs* :kindly {} data-map)
@@ -444,7 +457,11 @@
             (is (= ["**Sample diffs**"] heading))
             (is (= :kind/vega-lite (:kindly/kind (meta chart))))
             (is (string? (:$schema chart))
-                "Expected Vega-Lite schema")))))))
+                "Expected Vega-Lite schema")
+            (is (= 700 (:width chart))
+                "Expected notebook-friendly width")
+            (is (= 350 (-> chart :vconcat first :height))
+                "Expected notebook-friendly height")))))))
 
 (deftest noop-views-test
   ;; Tests that noop multimethods do not add anything to the accumulator.

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -300,3 +300,45 @@
                                 (contains? % "end")
                                 (contains? % "density"))
                           histogram-data)))))))))
+
+(deftest sample-percentiles-view-test
+  ;; Tests the view/sample-percentiles* multimethod for :kindly viewer.
+  ;; Verifies that sample percentiles data is rendered as a heading and
+  ;; Vega-Lite percentile distribution chart.
+  (testing "view/sample-percentiles* :kindly"
+    (testing "renders percentiles as heading and Vega-Lite chart"
+      (reset! kindly/accumulated [])
+      (view/sample-percentiles* :kindly {} (:data (test-data/samples-with-2-values-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and chart")
+        (let [[heading chart] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Percentiles**"] heading))
+          (is (= :kind/vega-lite (:kindly/kind (meta chart))))
+          (is (string? (:$schema chart))
+              "Expected Vega-Lite schema")
+          (let [percentile-data (-> chart :vconcat first :layer first :data :values)]
+            (is (vector? percentile-data))
+            (is (= 2 (count percentile-data))
+                "Expected 2 data points for 2 samples")
+            (is (every? #(and (contains? % :elapsed-time)
+                              (contains? % :p)
+                              (contains? % :x))
+                        percentile-data))))))
+
+    (testing "renders percentiles with transformed data via analyse pipeline"
+      (reset! kindly/accumulated [])
+      (let [data-map            (:data (test-data/samples-with-outliers-values-map))
+            view-sample-percent (view/sample-percentiles)]
+        (view-sample-percent :kindly data-map)
+        (let [result (kindly/flush)
+              [_heading chart] result
+              percentile-data (-> chart :vconcat first :layer first :data :values)]
+          (is (= 7 (count percentile-data))
+              "Expected 7 data points for 7 samples")
+          (is (number? (:p (first percentile-data)))
+              "Expected numeric percentile value")
+          (is (number? (:x (first percentile-data)))
+              "Expected numeric x value"))))))

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -3,7 +3,7 @@
   (:require
    [criterium.bench :as bench]
    [criterium.bench-plans :as bench-plans]
-   [criterium.notebook.helpers :refer [bench-display bench-kindly]]
+   [criterium.notebook.helpers :refer [bench-display]]
    [scicloj.kindly.v4.kind :as kind]))
 
 ;; # Bench Options
@@ -133,22 +133,18 @@ bench-plans/log-histogram
 ;; ### :kindly
 ;;
 ;; The Kindly viewer outputs Kindly-annotated data structures for rendering
-;; in Clay notebooks. Use the `bench-kindly` helper macro to run benchmarks
-;; that return Kindly fragments directly:
+;; in Clay notebooks. When using `:viewer :kindly`, `bench` returns the Kindly
+;; fragment directly, so it can be rendered by Clay:
 
-(bench-kindly (reduce + (range 1000))
-              :bench-plan bench-plans/log-histogram)
+(bench/bench (reduce + (range 1000))
+             :viewer :kindly
+             :bench-plan bench-plans/log-histogram)
 
 ;; Kindly viewer features:
 ;; - Tables with `:kind/table` metadata for stats, quantiles, outliers
 ;; - Vega-Lite charts with `:kind/vega-lite` metadata for samples, histograms
 ;; - Markdown headings with `:kind/md` metadata for sections
 ;; - All wrapped in a `:kind/fragment` for Clay rendering
-;;
-;; The `bench-kindly` macro returns the Kindly fragment so Clay can render it.
-;; The underlying `:viewer :kindly` option can also be used directly with
-;; `criterium.bench/bench`, with the output accessible via
-;; `criterium.viewer.kindly/flush`.
 
 ;; ### Setting a Default Viewer
 ;;
@@ -158,7 +154,7 @@ bench-plans/log-histogram
 ;; each time.
 
 (kind/code "(bench/set-default-viewer! :kindly)
-(bench/bench (+ 1 1))  ; Now uses :kindly viewer
+(bench/bench (+ 1 1))  ; Now uses :kindly viewer and returns Kindly fragment
 
 ;; Check current default
 (bench/default-viewer)  ; => :kindly
@@ -174,8 +170,18 @@ bench-plans/log-histogram
 ;; An explicit `:viewer` option always overrides the default:
 
 (kind/code "(bench/set-default-viewer! :kindly)
-(bench/bench (+ 1 1))              ; Uses :kindly (default)
-(bench/bench (+ 1 1) :viewer :print)  ; Uses :print (explicit)")
+(bench/bench (+ 1 1))              ; Uses :kindly, returns Kindly fragment
+(bench/bench (+ 1 1) :viewer :print)  ; Uses :print, returns expr value")
+
+;; When using `:kindly` viewer, the return value behavior changes:
+;; - Default: returns the Kindly fragment (for Clay rendering)
+;; - Explicit `:return-value [:samples :expr-value]`: returns expression value
+
+(kind/code "(bench/bench (+ 1 1) :viewer :kindly)
+;; => ^{:kindly/kind :kind/fragment} [...]  ; Returns Kindly fragment
+
+(bench/bench (+ 1 1) :viewer :kindly :return-value [:samples :expr-value])
+;; => 2  ; Returns expression value")
 
 ;; ## Customizing Collection Parameters
 ;;

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -3,7 +3,7 @@
   (:require
    [criterium.bench :as bench]
    [criterium.bench-plans :as bench-plans]
-   [criterium.notebook.helpers :refer [bench-display]]
+   [criterium.notebook.helpers :refer [bench-display bench-kindly]]
    [scicloj.kindly.v4.kind :as kind]))
 
 ;; # Bench Options
@@ -85,11 +85,12 @@ bench-plans/log-histogram
 ;; ## Viewer Options
 ;;
 ;; The `:viewer` option controls how benchmark results are displayed.
-;; Criterium provides three viewer modes:
+;; Criterium provides four viewer modes:
 ;;
 ;; - `:print` - Human-readable text output (default)
 ;; - `:pprint` - Clojure data structure with pretty printing
 ;; - `:portal` - Interactive visualization (requires Portal)
+;; - `:kindly` - Kindly-annotated output for Clay notebooks
 
 ;; ### :print (Default)
 ;;
@@ -128,6 +129,26 @@ bench-plans/log-histogram
 ;; - Interactive histograms
 ;; - Clickable data exploration
 ;; - Tables for statistical summaries
+
+;; ### :kindly
+;;
+;; The Kindly viewer outputs Kindly-annotated data structures for rendering
+;; in Clay notebooks. Use the `bench-kindly` helper macro to run benchmarks
+;; that return Kindly fragments directly:
+
+(bench-kindly (reduce + (range 1000))
+              :bench-plan bench-plans/log-histogram)
+
+;; Kindly viewer features:
+;; - Tables with `:kind/table` metadata for stats, quantiles, outliers
+;; - Vega-Lite charts with `:kind/vega-lite` metadata for samples, histograms
+;; - Markdown headings with `:kind/md` metadata for sections
+;; - All wrapped in a `:kind/fragment` for Clay rendering
+;;
+;; The `bench-kindly` macro returns the Kindly fragment so Clay can render it.
+;; The underlying `:viewer :kindly` option can also be used directly with
+;; `criterium.bench/bench`, with the output accessible via
+;; `criterium.viewer.kindly/flush`.
 
 ;; ## Customizing Collection Parameters
 ;;

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -150,6 +150,33 @@ bench-plans/log-histogram
 ;; `criterium.bench/bench`, with the output accessible via
 ;; `criterium.viewer.kindly/flush`.
 
+;; ### Setting a Default Viewer
+;;
+;; You can set a default viewer for all subsequent bench calls using
+;; `set-default-viewer!`. This is useful when you want all benchmarks
+;; in a session to use a specific viewer without specifying `:viewer`
+;; each time.
+
+(kind/code "(bench/set-default-viewer! :kindly)
+(bench/bench (+ 1 1))  ; Now uses :kindly viewer
+
+;; Check current default
+(bench/default-viewer)  ; => :kindly
+
+;; Reset to default
+(bench/set-default-viewer! :print)")
+
+;; The precedence for viewer selection is:
+;; 1. Explicit `:viewer` option on bench call
+;; 2. Global default viewer (set via `set-default-viewer!`)
+;; 3. Built-in default `:print`
+;;
+;; An explicit `:viewer` option always overrides the default:
+
+(kind/code "(bench/set-default-viewer! :kindly)
+(bench/bench (+ 1 1))              ; Uses :kindly (default)
+(bench/bench (+ 1 1) :viewer :print)  ; Uses :print (explicit)")
+
 ;; ## Customizing Collection Parameters
 ;;
 ;; The `:with-jit-warmup` collect plan accepts configuration options:

--- a/bases/notebooks/src/criterium/notebook/helpers.clj
+++ b/bases/notebooks/src/criterium/notebook/helpers.clj
@@ -1,6 +1,8 @@
 (ns criterium.notebook.helpers
   "Helper utilities for criterium notebooks."
   (:require
+   [criterium.bench :as bench]
+   [criterium.viewer.kindly :as kindly]
    [scicloj.kindly.v4.kind :as kind]))
 
 (defmacro bench-display
@@ -10,3 +12,18 @@
   `(kind/fragment
     [(kind/code ~(pr-str expr))
      (kind/code (with-out-str ~expr))]))
+
+(defmacro bench-kindly
+  "Run a benchmark with Kindly viewer and return the Kindly fragment.
+
+  This macro is designed for Clay notebooks where the cell's return value
+  is rendered. The benchmark results are formatted as Kindly-annotated
+  tables and Vega-Lite charts.
+
+  Example:
+    (bench-kindly (reduce + (range 1000)))
+    (bench-kindly (reduce + (range 1000)) :limit-time-s 1)"
+  [expr & options]
+  `(do
+     (bench/bench ~expr :viewer :kindly ~@options)
+     @kindly/last-fragment))

--- a/bases/notebooks/src/criterium/notebook/helpers.clj
+++ b/bases/notebooks/src/criterium/notebook/helpers.clj
@@ -1,7 +1,6 @@
 (ns criterium.notebook.helpers
   "Helper utilities for criterium notebooks."
   (:require
-   [criterium.bench :as bench]
    [scicloj.kindly.v4.kind :as kind]))
 
 (defmacro bench-display

--- a/bases/notebooks/src/criterium/notebook/helpers.clj
+++ b/bases/notebooks/src/criterium/notebook/helpers.clj
@@ -2,7 +2,6 @@
   "Helper utilities for criterium notebooks."
   (:require
    [criterium.bench :as bench]
-   [criterium.viewer.kindly :as kindly]
    [scicloj.kindly.v4.kind :as kind]))
 
 (defmacro bench-display
@@ -12,18 +11,3 @@
   `(kind/fragment
     [(kind/code ~(pr-str expr))
      (kind/code (with-out-str ~expr))]))
-
-(defmacro bench-kindly
-  "Run a benchmark with Kindly viewer and return the Kindly fragment.
-
-  This macro is designed for Clay notebooks where the cell's return value
-  is rendered. The benchmark results are formatted as Kindly-annotated
-  tables and Vega-Lite charts.
-
-  Example:
-    (bench-kindly (reduce + (range 1000)))
-    (bench-kindly (reduce + (range 1000)) :limit-time-s 1)"
-  [expr & options]
-  `(do
-     (bench/bench ~expr :viewer :kindly ~@options)
-     @kindly/last-fragment))


### PR DESCRIPTION
## Summary

Add a `:kindly` viewer that outputs benchmark results in Kindly format for Clay notebooks. The viewer produces a mix of tables and Vega-Lite charts similar to the Portal viewer output, enabling rich visualization of criterium benchmark pipelines in Clay-based computational notebooks.

## Changes

### New Features
- **Kindly viewer** (`criterium.viewer.kindly`) - accumulator-based viewer producing `kind/fragment` output with Kindly-annotated tables and Vega-Lite charts
- **Default viewer configuration** - `*default-viewer*` dynamic var and `set-default-viewer!` function in `criterium.bench.config`
- **Direct fragment return** - `:kindly` viewer returns Kindly fragment directly from `bench` for seamless Clay integration

### Refactoring
- **Common charts extraction** (`criterium.viewer.common-charts`) - extracted Vega-Lite chart functions from Portal viewer for reuse
- **Portal viewer refactored** to use common-charts namespace, removing ~240 lines of duplicated code

### Implementation Details
- All 15 view multimethods implemented for `:kindly` dispatch
- Tables use `:kind/table` metadata with columns matching Portal viewer
- Charts use `:kind/vega-lite` metadata compatible with Vega-Lite v5
- Chart dimensions optimized for notebooks (700x350) vs Portal (800 height)
- Legends positioned inside chart area for better display
- Event stats hidden when empty to reduce visual clutter

### Testing
- Unit tests for all view multimethods
- Integration test verifying Clay rendering pipeline

## Commits

- Extract common Vega-Lite chart functions to common-charts namespace
- Refactor Portal viewer to use common-charts
- Add Kindly viewer with accumulator pattern
- Implement all table and chart views
- Add configurable default viewer
- Return Kindly fragment directly from bench
- Add Clay rendering integration test

## Usage

```clojure
;; In Clay notebook
(require '[criterium.bench :as b])

;; Returns Kindly fragment directly for Clay rendering
(b/bench (reduce + (range 1000)) {:viewer :kindly})

;; Or set as default
(b/config/set-default-viewer! :kindly)
(b/bench (reduce + (range 1000)))
```