### PR TITLE
fix: suppress empty summary stats headings in viewers

### DIFF
--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -81,12 +81,13 @@
                          (metric/select-metrics metric-ids))
         metric-configs (metric/all-metric-configs metrics-defs)
         transforms (util/get-transforms data-map stats-id)]
-    (kindly-heading "Summary stats")
-    (kindly-table
-     (viewer-common/stats-map
-      (util/stats stats-map)
-      metric-configs
-      transforms))))
+    (when (seq metric-configs)
+      (kindly-heading "Summary stats")
+      (kindly-table
+       (viewer-common/stats-map
+        (util/stats stats-map)
+        metric-configs
+        transforms)))))
 
 (defmethod view/quantiles* :kindly
   [_ {:keys [quantiles-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -77,13 +77,14 @@
         metrics-defs (-> (:metrics-defs stats-map)
                          (metric/select-metrics metric-ids))
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms (util/get-transforms data-map stats-id)]
-    (heading "Summary stats")
-    (portal-table
-     (viewer-common/stats-map
-      (util/stats stats-map)
-      metric-configs
-      transforms))))
+        transforms     (util/get-transforms data-map stats-id)]
+    (when (seq metric-configs)
+      (heading "Summary stats")
+      (portal-table
+       (viewer-common/stats-map
+        (util/stats stats-map)
+        metric-configs
+        transforms)))))
 
 (defmethod view/event-stats* :portal
   [_ {:keys [event-stats-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -10,10 +10,10 @@
 
 (defmethod view/metrics* :pprint
   [_ {:keys [samples-id]} data-map]
-  (let [samples-id      (or samples-id :samples)
+  (let [samples-id (or samples-id :samples)
         metrics-samples (data-map samples-id)
-        metrics-defs    (:metrics-defs metrics-samples)
-        metric-configs  (metric/all-metric-configs metrics-defs)]
+        metrics-defs (:metrics-defs metrics-samples)
+        metric-configs (metric/all-metric-configs metrics-defs)]
     (pprint/print-table
      [:metric :value]
      (viewer-common/metrics-map
@@ -22,12 +22,12 @@
 
 (defmethod view/stats* :pprint
   [_ {:keys [stats-id metric-ids]} data-map]
-  (let [stats-id       (or stats-id :stats)
-        stats-map      (data-map stats-id)
-        metrics-defs   (-> (:metrics-defs stats-map)
-                           (metric/select-metrics metric-ids))
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)
+        metrics-defs (-> (:metrics-defs stats-map)
+                         (metric/select-metrics metric-ids))
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map stats-id)]
+        transforms (util/get-transforms data-map stats-id)]
     (when (seq metric-configs)
       (pprint/print-table
        [:_metric :mean-minus-3sigma :mean :mean-plus-3sigma :min-val :max-val]
@@ -38,15 +38,15 @@
 
 (defmethod view/quantiles* :pprint
   [_ {:keys [quantiles-id]} data-map]
-  (let [quantiles-id   (or quantiles-id :quantiles)
-        quantiles-map  (data-map quantiles-id)
-        metrics-defs   (:metrics-defs quantiles-map)
+  (let [quantiles-id (or quantiles-id :quantiles)
+        quantiles-map (data-map quantiles-id)
+        metrics-defs (:metrics-defs quantiles-map)
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map quantiles-id)
-        table          (viewer-common/quantiles
-                        metric-configs
-                        (util/quantiles quantiles-map)
-                        transforms)]
+        transforms (util/get-transforms data-map quantiles-id)
+        table (viewer-common/quantiles
+               metric-configs
+               (util/quantiles quantiles-map)
+               transforms)]
     (pprint/print-table
      (into [:metric]
            (->> table first keys (filter #(not= % :metric)) sort))
@@ -54,20 +54,21 @@
 
 (defmethod view/event-stats* :pprint
   [_ {:keys [event-stats-id]} data-map]
-  (let [event-stats-id  (or event-stats-id :event-stats)
+  (let [event-stats-id (or event-stats-id :event-stats)
         event-stats-map (data-map event-stats-id)
-        metrics-defs    (:metrics-defs event-stats-map)
-        res             (viewer-common/event-stats
-                         metrics-defs
-                         (util/event-stats event-stats-map))
-        ks              (reduce into [] (map keys res))]
-    (pprint/print-table (distinct ks) res)))
+        metrics-defs (:metrics-defs event-stats-map)
+        res (viewer-common/event-stats
+             metrics-defs
+             (util/event-stats event-stats-map))
+        ks (reduce into [] (map keys res))]
+    (when (seq res)
+      (pprint/print-table (distinct ks) res))))
 
 (defmethod view/outlier-counts* :pprint
   [_ {:keys [outliers-id] :as _view} data-map]
-  (let [outliers-id    (or outliers-id :outliers)
-        outliers-map   (data-map outliers-id)
-        metrics-defs   (:metrics-defs outliers-map)
+  (let [outliers-id (or outliers-id :outliers)
+        outliers-map (data-map outliers-id)
+        metrics-defs (:metrics-defs outliers-map)
         metric-configs (metric/all-metric-configs metrics-defs)]
     (pprint/print-table
      [:_metric :low-severe :low-mild :high-mild :high-severe]
@@ -77,11 +78,11 @@
 
 (defn print-outlier-significances
   [{:keys [outlier-significance-id] :as _view} data-map]
-  (let [outlier-sig-id  (or outlier-significance-id :outlier-significance)
+  (let [outlier-sig-id (or outlier-significance-id :outlier-significance)
         outlier-sig-map (data-map outlier-sig-id)
-        outlier-sig     (util/outlier-significance outlier-sig-map)
-        metrics-defs    (:metrics-defs outlier-sig-map)
-        metric-configs  (metric/all-metric-configs metrics-defs)]
+        outlier-sig (util/outlier-significance outlier-sig-map)
+        metrics-defs (:metrics-defs outlier-sig-map)
+        metric-configs (metric/all-metric-configs metrics-defs)]
     (pprint/print-table
      (for [m metric-configs]
        (get-in outlier-sig (:path m))))))
@@ -95,7 +96,7 @@
    (fn [res k metric-group]
      (reduce
       (fn [res metric-config]
-        (let [v (get (get sample  (:path metric-config)) index)]
+        (let [v (get (get sample (:path metric-config)) index)]
           (if (pos? (long v))
             (assoc res
                    (viewer-common/composite-key
@@ -127,88 +128,88 @@
 
 (defmethod view/samples* :pprint
   [_ {:keys [] :as view} banech-map]
-  (let [quant-samples-id    (:samples-id view :samples)
-        event-samples-id    (:event-samples-id view quant-samples-id)
+  (let [quant-samples-id (:samples-id view :samples)
+        event-samples-id (:event-samples-id view quant-samples-id)
         outlier-analysis-id (:outlier-id view :outliers)
-        quant-samples       (banech-map quant-samples-id)
-        event-samples       (banech-map event-samples-id)
-        outlier-analysis    (banech-map outlier-analysis-id)
+        quant-samples (banech-map quant-samples-id)
+        event-samples (banech-map event-samples-id)
+        outlier-analysis (banech-map outlier-analysis-id)
 
-        metric-defs        (metric/filter-metrics
-                            (:metrics-defs quant-samples)
-                            (metric/type-pred :quantitative))
+        metric-defs (metric/filter-metrics
+                     (:metrics-defs quant-samples)
+                     (metric/type-pred :quantitative))
         event-metrics-defs (metric/filter-metrics
                             (:metrics-defs event-samples)
                             (metric/type-pred :event))
 
         metric-configs (metric/all-metric-configs metric-defs)
-        transforms     (util/get-transforms banech-map quant-samples-id)
+        transforms (util/get-transforms banech-map quant-samples-id)
 
-        quant-ids    (mapv (comp last :path) metric-configs)
-        event-keys   (into
-                      []
-                      (mapcat
-                       (fn [[k metric-group]]
-                         (reduce
-                          (fn [res metric-config]
-                            (conj res
-                                  (viewer-common/composite-key
-                                   [(if-let [group (:group metric-config)]
-                                      group
-                                      k)
-                                    (last (:path metric-config))])))
-                          []
-                          (or (:values metric-group)
-                              (mapcat :values
-                                      (vals (:groups metric-group)))))))
-                      event-metrics-defs)
+        quant-ids (mapv (comp last :path) metric-configs)
+        event-keys (into
+                    []
+                    (mapcat
+                     (fn [[k metric-group]]
+                       (reduce
+                        (fn [res metric-config]
+                          (conj res
+                                (viewer-common/composite-key
+                                 [(if-let [group (:group metric-config)]
+                                    group
+                                    k)
+                                  (last (:path metric-config))])))
+                        []
+                        (or (:values metric-group)
+                            (mapcat :values
+                                    (vals (:groups metric-group)))))))
+                    event-metrics-defs)
         outlier-keys (when outlier-analysis
                        (mapv
                         #(viewer-common/composite-key [(last %) :outlier])
                         (mapv :path metric-configs)))
 
         all-keys (reduce into [:index] [quant-ids outlier-keys event-keys])
-        data     (mapv
-                  (fn [index]
-                    (reduce
-                     merge
-                     {:index index}
-                     [(reduce
-                       (fn [res path]
-                         (into
-                          (assoc res (last path)
-                                 (util/transform-sample->
-                                  (get (get quant-samples path) index)
-                                  transforms))
-                          (outlier-values outlier-analysis path index)))
-                       {}
-                       (mapv :path metric-configs))
-                      (flatten-events
-                       event-samples event-metrics-defs index)]))
-                  (range (-> quant-samples
-                             (get (:path (first metric-configs)))
-                             count)))]
+        data (mapv
+              (fn [index]
+                (reduce
+                 merge
+                 {:index index}
+                 [(reduce
+                   (fn [res path]
+                     (into
+                      (assoc res (last path)
+                             (util/transform-sample->
+                              (get (get quant-samples path) index)
+                              transforms))
+                      (outlier-values outlier-analysis path index)))
+                   {}
+                   (mapv :path metric-configs))
+                  (flatten-events
+                   event-samples event-metrics-defs index)]))
+              (range (-> quant-samples
+                         (get (:path (first metric-configs)))
+                         count)))]
     (pprint/print-table all-keys data)))
 
 (defmethod view/histogram* :pprint
   [_ {:keys [histogram-id] :as _view} data-map]
-  (let [histogram-id   (or histogram-id :histograms)
-        histograms     (util/lookup-data data-map histogram-id)
-        metrics-defs   (-> (:metrics-defs histograms)
-                           (metric/filter-metrics
-                            (metric/type-pred :quantitative)))
+  (let [histogram-id (or histogram-id :histograms)
+        histograms (util/lookup-data data-map histogram-id)
+        metrics-defs (-> (:metrics-defs histograms)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
         metric-configs (metric/all-metric-configs metrics-defs)
-        transforms     (util/get-transforms data-map histogram-id)
-        histograms     (->> metric-configs
-                            (mapv
-                             #(viewer-common/histogram
-                               (have
-                                some?
-                                ((:histograms histograms) (:path %))
-                                {:keys (keys (:histograms histograms))
-                                 :path %})
-                               transforms
-                               %)))]
+        transforms (util/get-transforms data-map histogram-id)
+        histograms (->> metric-configs
+                        (mapv
+                         #(viewer-common/histogram
+                           (have
+                            some?
+                            ((:histograms histograms) (:path %))
+                            {:keys (keys (:histograms histograms))
+                             :path %})
+                           transforms
+                           %)))]
     (doseq [h histograms]
       (println (format "\nHistogram of %s %s"
                        (-> h :metric-config :label)

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -28,12 +28,13 @@
                            (metric/select-metrics metric-ids))
         metric-configs (metric/all-metric-configs metrics-defs)
         transforms     (util/get-transforms data-map stats-id)]
-    (pprint/print-table
-     [:_metric :mean-minus-3sigma :mean :mean-plus-3sigma :min-val :max-val]
-     (viewer-common/stats-map
-      (util/stats stats-map)
-      metric-configs
-      transforms))))
+    (when (seq metric-configs)
+      (pprint/print-table
+       [:_metric :mean-minus-3sigma :mean :mean-plus-3sigma :min-val :max-val]
+       (viewer-common/stats-map
+        (util/stats stats-map)
+        metric-configs
+        transforms)))))
 
 (defmethod view/quantiles* :pprint
   [_ {:keys [quantiles-id]} data-map]

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -148,7 +148,14 @@
                      :mean-minus-3sigma 1.00,
                      :mean-plus-3sigma 1.00,
                      :max-val 1.00}]
-                   table))))))))
+                   table))))))
+
+    (testing "outputs nothing when metric-ids filter yields no matching metrics"
+      (reset! kindly/accumulated [])
+      (view/stats* :kindly
+                   {:metric-ids [:nonexistent-metric]}
+                   (:data (test-data/bench-stats-map)))
+      (is (nil? (kindly/flush))))))
 
 (deftest quantiles-view-test
   ;; Tests the view/quantiles* multimethod for :kindly viewer.

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -115,8 +115,9 @@
         (is (= [:b "Histogram"] title))))))
 
 (deftest portal-stats-test
-  (testing "print-stats"
-    (testing "prints via output-view"
+  ;; Verifies stats display with conditional heading behavior.
+  (testing "view/stats*"
+    (testing "displays stats when metrics match"
       (is (= [[:b "Summary stats"]
               [{:_metric           "Elapsed Time ns",
                 :mean              100.0
@@ -144,7 +145,20 @@
                (with-tap-out
                  (->> data-map
                       stats
-                      (view-stats :portal)))))))))
+                      (view-stats :portal)))))))
+    (testing "outputs nothing when metric-ids filter yields no matching metrics"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/stats*
+           :portal
+           {:metric-ids [:nonexistent-metric]}
+           (:data (test-data/bench-stats-map)))
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))
 
 (deftest portal-outlier-count-test
   (testing "print-outlier-count"

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -20,8 +20,9 @@
    "| Elapsed Time ns |                1.0 |   1.0 |               1.0 |      1.0 |      1.0 |"])
 
 (deftest pprint-stats-test
-  (testing "print-stats"
-    (testing "prints via output-view"
+  ;; Verifies stats display with conditional output behavior.
+  (testing "view/stats*"
+    (testing "displays stats when metrics match"
       (is (= expected-stats-1
              (trimmed-lines
               (with-out-str
@@ -38,7 +39,14 @@
                 (with-out-str
                   (->> data-map
                        stats
-                       (view-stats :pprint))))))))))
+                       (view-stats :pprint))))))))
+    (testing "outputs nothing when metric-ids filter yields no matching metrics"
+      (is (= ""
+             (with-out-str
+               (view/stats*
+                :pprint
+                {:metric-ids [:nonexistent-metric]}
+                (:data (test-data/bench-stats-map)))))))))
 
 (def expected-counts
   [""


### PR DESCRIPTION
## Summary

Fix duplicate/empty "Summary stats" headers appearing in portal, pprint, and kindly viewers when metric filters result in no matching stats to display.

## Changes

- **portal viewer**: Wrap `view/stats*` heading and table output with `(when (seq metric-configs) ...)` check
- **pprint viewer**: Apply same conditional check to `view/stats*` and `event-stats*` methods  
- **kindly viewer**: Apply same conditional check to `view/stats*` method

## Commits

- `dd9ffa8` fix(portal): suppress empty summary stats heading
- `d2e0aef` fix(pprint): suppress stats output when no metrics match
- `5d7295c` fix(kindly): suppress stats output when no metrics match
- `aa3491e` fix(pprint): suppress event-stats output when no stats match

## Testing

Each fix includes a test verifying empty/nil output when metric-ids filter matches nothing.