### PR TITLE
fix(test): Fix test runs clearing Java source compilation

### DIFF
--- a/build/test/build/tasks/smoke_test.clj
+++ b/build/test/build/tasks/smoke_test.clj
@@ -1,192 +1,176 @@
 (ns build.tasks.smoke-test
-    (:require
-     [babashka.fs :as fs]
-     [clojure.java.shell :as shell]
-     [clojure.test :refer [deftest is testing]]
-     [clojure.xml :as xml])
-    (:import
-     [java.util.jar JarFile]))
-
-;;; Test utilities
-
-(defmacro with-clean-dir
-  "Execute body with a clean directory. Deletes dir before and after execution."
-  [dir & body]
-  `(let [dir# ~dir]
-     (try
-       (when (fs/exists? dir#)
-         (fs/delete-tree dir#))
-       ~@body
-       (finally
-         (when (fs/exists? dir#)
-           (fs/delete-tree dir#))))))
+  (:require
+   [babashka.fs :as fs]
+   [build.tasks.javac :as javac]
+   [clojure.test :refer [deftest is testing]]
+   [clojure.xml :as xml])
+  (:import
+   [java.util.jar JarFile]))
 
 ;;; JAR validation
 
 (defn- jar-exists?
-       "Check if JAR file exists at the expected location."
-       [project-root jar-name]
-       (let [jar-path (fs/path project-root "target" jar-name)]
-            (fs/exists? jar-path)))
+  "Check if JAR file exists at the expected location."
+  [project-root jar-name]
+  (let [jar-path (fs/path project-root "target" jar-name)]
+    (fs/exists? jar-path)))
 
 (defn- read-jar-manifest
-       "Read the manifest from a JAR file."
-       [jar-path]
-       (with-open [jar (JarFile. (str jar-path))]
-                  (when-let [manifest (.getManifest jar)]
-                            (let [attrs (.getMainAttributes manifest)]
-                                 (into {} (map (fn [[k v]] [(str k) (str v)]) attrs))))))
+  "Read the manifest from a JAR file."
+  [jar-path]
+  (with-open [jar (JarFile. (str jar-path))]
+    (when-let [manifest (.getManifest jar)]
+      (let [attrs (.getMainAttributes manifest)]
+        (into {} (map (fn [[k v]] [(str k) (str v)]) attrs))))))
 
 (defn- list-jar-entries
-       "List all entries in a JAR file."
-       [jar-path]
-       (with-open [jar (JarFile. (str jar-path))]
-                  (vec (map #(.getName ^java.util.jar.JarEntry %) (enumeration-seq (.entries jar))))))
+  "List all entries in a JAR file."
+  [jar-path]
+  (with-open [jar (JarFile. (str jar-path))]
+    (vec (map #(.getName ^java.util.jar.JarEntry %) (enumeration-seq (.entries jar))))))
 
 (defn- jar-contains-pom?
-       "Check if JAR contains a POM file."
-       [jar-path]
-       (let [entries (list-jar-entries jar-path)]
-            (some #(and (.startsWith ^String % "META-INF/maven/")
-                        (.endsWith ^String % "/pom.xml"))
-                  entries)))
+  "Check if JAR contains a POM file."
+  [jar-path]
+  (let [entries (list-jar-entries jar-path)]
+    (some #(and (.startsWith ^String % "META-INF/maven/")
+                (.endsWith ^String % "/pom.xml"))
+          entries)))
 
 (defn- read-pom-from-jar
-       "Extract and parse POM XML from JAR."
-       [jar-path]
-       (with-open [jar (JarFile. (str jar-path))]
-                  (let [entries (enumeration-seq (.entries jar))
-                        pom-entry (first (filter #(and (.startsWith (.getName ^java.util.jar.JarEntry %) "META-INF/maven/")
-                                                       (.endsWith (.getName ^java.util.jar.JarEntry %) "/pom.xml"))
-                                                 entries))]
-                       (when pom-entry
-                             (with-open [is (.getInputStream jar pom-entry)]
-                                        (xml/parse is))))))
+  "Extract and parse POM XML from JAR."
+  [jar-path]
+  (with-open [jar (JarFile. (str jar-path))]
+    (let [entries (enumeration-seq (.entries jar))
+          pom-entry (first (filter #(and (.startsWith (.getName ^java.util.jar.JarEntry %) "META-INF/maven/")
+                                         (.endsWith (.getName ^java.util.jar.JarEntry %) "/pom.xml"))
+                                   entries))]
+      (when pom-entry
+        (with-open [is (.getInputStream jar pom-entry)]
+          (xml/parse is))))))
 
 ;;; POM validation
 
 (defn- find-element
-       "Find first child element with given tag."
-       [xml-node tag]
-       (->> (:content xml-node)
-            (filter map?)
-            (filter #(= (:tag %) tag))
-            first))
+  "Find first child element with given tag."
+  [xml-node tag]
+  (->> (:content xml-node)
+       (filter map?)
+       (filter #(= (:tag %) tag))
+       first))
 
 (defn- element-text
-       "Extract text content from XML element."
-       [element]
-       (when element
-             (first (filter string? (:content element)))))
+  "Extract text content from XML element."
+  [element]
+  (when element
+    (first (filter string? (:content element)))))
 
 (defn- verify-pom-required-fields
-       "Verify POM contains all required Maven Central/Clojars fields."
-       [pom-xml]
-       (let [group-id (element-text (find-element pom-xml :groupId))
-             artifact-id (element-text (find-element pom-xml :artifactId))
-             version (element-text (find-element pom-xml :version))
-             description (element-text (find-element pom-xml :description))
-             url (element-text (find-element pom-xml :url))
-             licenses (find-element pom-xml :licenses)
-             scm (find-element pom-xml :scm)
-             developers (find-element pom-xml :developers)]
-            {:group-id group-id
-             :artifact-id artifact-id
-             :version version
-             :description description
-             :url url
-             :has-license? (some? licenses)
-             :has-scm? (some? scm)
-             :has-developers? (some? developers)
-             :all-required-present? (and group-id artifact-id version description
-                                         url licenses scm developers)}))
+  "Verify POM contains all required Maven Central/Clojars fields."
+  [pom-xml]
+  (let [group-id (element-text (find-element pom-xml :groupId))
+        artifact-id (element-text (find-element pom-xml :artifactId))
+        version (element-text (find-element pom-xml :version))
+        description (element-text (find-element pom-xml :description))
+        url (element-text (find-element pom-xml :url))
+        licenses (find-element pom-xml :licenses)
+        scm (find-element pom-xml :scm)
+        developers (find-element pom-xml :developers)]
+    {:group-id group-id
+     :artifact-id artifact-id
+     :version version
+     :description description
+     :url url
+     :has-license? (some? licenses)
+     :has-scm? (some? scm)
+     :has-developers? (some? developers)
+     :all-required-present? (and group-id artifact-id version description
+                                 url licenses scm developers)}))
 
 ;;; Smoke tests
 
 (deftest ^:requires-build-artifacts criterium-jar-smoke-test
   ;; Test validates the criterium JAR artifact produced by the build system
-         (testing "criterium JAR"
-                  (testing "exists in target directory"
-                           (is (jar-exists? "projects/criterium" "criterium.jar")))
+  (testing "criterium JAR"
+    (testing "exists in target directory"
+      (is (jar-exists? "projects/criterium" "criterium.jar")))
 
-                  (let [jar-path (fs/path "projects/criterium/target/criterium.jar")]
-                       (testing "contains POM file"
-                                (is (jar-contains-pom? jar-path)))
+    (let [jar-path (fs/path "projects/criterium/target/criterium.jar")]
+      (testing "contains POM file"
+        (is (jar-contains-pom? jar-path)))
 
-                       (testing "POM has all required metadata"
-                                (let [pom-xml (read-pom-from-jar jar-path)
-                                      validation (verify-pom-required-fields pom-xml)]
-                                     (is (= "criterium" (:group-id validation)))
-                                     (is (= "criterium" (:artifact-id validation)))
-                                     (is (some? (:version validation)))
-                                     (is (= "Benchmarking library for Clojure with statistical rigor"
-                                            (:description validation)))
-                                     (is (= "https://github.com/hugoduncan/criterium"
-                                            (:url validation)))
-                                     (is (:has-license? validation))
-                                     (is (:has-scm? validation))
-                                     (is (:has-developers? validation))
-                                     (is (:all-required-present? validation))))
+      (testing "POM has all required metadata"
+        (let [pom-xml (read-pom-from-jar jar-path)
+              validation (verify-pom-required-fields pom-xml)]
+          (is (= "criterium" (:group-id validation)))
+          (is (= "criterium" (:artifact-id validation)))
+          (is (some? (:version validation)))
+          (is (= "Benchmarking library for Clojure with statistical rigor"
+                 (:description validation)))
+          (is (= "https://github.com/hugoduncan/criterium"
+                 (:url validation)))
+          (is (:has-license? validation))
+          (is (:has-scm? validation))
+          (is (:has-developers? validation))
+          (is (:all-required-present? validation))))
 
-                       (testing "contains expected entries"
-                                (let [entries (list-jar-entries jar-path)]
-                                     (is (some #(.startsWith ^String % "criterium/") entries)
-                                         "JAR should contain criterium namespace files"))))))
+      (testing "contains expected entries"
+        (let [entries (list-jar-entries jar-path)]
+          (is (some #(.startsWith ^String % "criterium/") entries)
+              "JAR should contain criterium namespace files"))))))
 
 (deftest ^:requires-build-artifacts agent-jar-smoke-test
   ;; Test validates the agent JAR artifact including Java compilation and manifest
-         (testing "agent JAR"
-                  (testing "exists in target directory"
-                           (is (jar-exists? "projects/agent" "agent.jar")))
+  (testing "agent JAR"
+    (testing "exists in target directory"
+      (is (jar-exists? "projects/agent" "agent.jar")))
 
-                  (let [jar-path (fs/path "projects/agent/target/agent.jar")]
-                       (testing "contains POM file"
-                                (is (jar-contains-pom? jar-path)))
+    (let [jar-path (fs/path "projects/agent/target/agent.jar")]
+      (testing "contains POM file"
+        (is (jar-contains-pom? jar-path)))
 
-                       (testing "POM has all required metadata"
-                                (let [pom-xml (read-pom-from-jar jar-path)
-                                      validation (verify-pom-required-fields pom-xml)]
-                                     (is (= "criterium" (:group-id validation)))
-                                     (is (= "criterium.agent" (:artifact-id validation)))
-                                     (is (some? (:version validation)))
-                                     (is (= "JVM agent for allocation tracking in Criterium benchmarks"
-                                            (:description validation)))
-                                     (is (= "https://github.com/hugoduncan/criterium"
-                                            (:url validation)))
-                                     (is (:has-license? validation))
-                                     (is (:has-scm? validation))
-                                     (is (:has-developers? validation))
-                                     (is (:all-required-present? validation))))
+      (testing "POM has all required metadata"
+        (let [pom-xml (read-pom-from-jar jar-path)
+              validation (verify-pom-required-fields pom-xml)]
+          (is (= "criterium" (:group-id validation)))
+          (is (= "criterium.agent" (:artifact-id validation)))
+          (is (some? (:version validation)))
+          (is (= "JVM agent for allocation tracking in Criterium benchmarks"
+                 (:description validation)))
+          (is (= "https://github.com/hugoduncan/criterium"
+                 (:url validation)))
+          (is (:has-license? validation))
+          (is (:has-scm? validation))
+          (is (:has-developers? validation))
+          (is (:all-required-present? validation))))
 
-                       (testing "manifest contains Agent-Class"
-                                (let [manifest (read-jar-manifest jar-path)]
-                                     (is (= "criterium.agent" (get manifest "Agent-Class")))))
+      (testing "manifest contains Agent-Class"
+        (let [manifest (read-jar-manifest jar-path)]
+          (is (= "criterium.agent" (get manifest "Agent-Class")))))
 
-                       (testing "contains compiled Java classes"
-                                (let [entries (list-jar-entries jar-path)]
-                                     (is (some #(= "criterium/agent/Agent.class" %) entries))
-                                     (is (some #(= "criterium/agent/Allocation.class" %) entries)))))))
+      (testing "contains compiled Java classes"
+        (let [entries (list-jar-entries jar-path)]
+          (is (some #(= "criterium/agent/Agent.class" %) entries))
+          (is (some #(= "criterium/agent/Allocation.class" %) entries)))))))
 
-(deftest deps-prep-agent-test
-  ;; Test validates that deps prep works for agent project
-  ;; Ensures no regression of the truss assertion error
-  (testing "deps prep for agent project"
-    (let [agent-project-dir "projects/agent"
-          class-dir (fs/path "bases" "agent" "target" "classes")]
-      (with-clean-dir class-dir
-        (testing "runs without truss assertion error"
-          (let [result (shell/sh "clojure" "-X:deps" "prep"
-                                 :dir agent-project-dir)]
-            (is (zero? (:exit result))
-                (str "deps prep failed with exit code " (:exit result)
-                     "\nstdout: " (:out result)
-                     "\nstderr: " (:err result)))
-            (is (not (re-find #"Invariant failed.*:project.*params"
-                              (:err result)))
-                "Should not have truss assertion error about missing :project param")))
+(deftest javac-agent-compile-test
+  ;; Test validates that the agent Java sources compile correctly using javac
+  ;; Uses temp directory to avoid modifying production target/classes
+  (testing "agent Java compilation"
+    (let [temp-dir (fs/create-temp-dir {:prefix "agent-javac-test"})
+          class-dir (fs/path temp-dir "classes")]
+      (try
+        (fs/create-dirs class-dir)
+
+        (testing "compiles agent Java sources"
+          (javac/javac {:project :agent
+                        :class-dir (str class-dir)}))
 
         (testing "creates .class files"
           (is (fs/exists? (fs/path class-dir "criterium" "agent" "Agent.class"))
               "Agent.class should exist")
           (is (fs/exists? (fs/path class-dir "criterium" "agent" "Allocation.class"))
-              "Allocation.class should exist"))))))
+              "Allocation.class should exist"))
+
+        (finally
+          (fs/delete-tree temp-dir))))))


### PR DESCRIPTION
## Summary

Running tests was causing the tree to clear compiled Java sources, requiring manual `deps prep` after each test run. This PR fixes the issue by modifying the agent compilation test to use a temporary directory instead of the production path.

## Problem

The `deps-prep-agent-test` in `build/test/build/tasks/smoke_test.clj` used `with-clean-dir` on `bases/agent/target/classes`, which deleted the directory before and after the test, clearing the compiled Java classes.

## Solution

Replaced `deps-prep-agent-test` with `javac-agent-compile-test` that:
- Uses `babashka.fs/create-temp-dir` for class output
- Calls `javac` directly instead of going through `deps prep`
- Verifies compilation works without touching production `bases/agent/target/classes`

## Acceptance Criteria

- ✓ Running `clojure -M:kaocha:dev:test` does not delete or modify `bases/agent/target/classes` or `bases/blackhole/target/classes`
- ✓ The test still validates that javac compilation works correctly
- ✓ No manual `deps prep` required after running tests