### PR TITLE
feat(allocation): integrate allocation tracing into benchmarking pipeline

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,7 +2,7 @@
   (clojure-indent-style . 'always-align)
   (clojure-special-arg-indent-factor . 1) ; for cljfmt equivalence
   (cider-preferred-build-tool . "clojure-cli")
-  (cider-clojure-cli-aliases . "dev:test")
+  (cider-clojure-cli-aliases . "dev:test:with-agent-mac")
   (eval .
         (define-clojure-indent
           ;; Please keep this list sorted

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1013,7 +1013,7 @@ public:
     std::array<jvmtiFrameInfo, MAX_FRAMES> frames = {};
     jint count=0;
 
-    if (!internal) {
+    if (internal) {
       if (!agent_context.get_stack_trace(event.thread, frames.data(), &count)) {
       	return;
       }
@@ -1021,10 +1021,10 @@ public:
 
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     auto rec = internal ? allocation_record(env, class_sig, event.size,
-                                            event.thread, event.tag)
-                        : allocation_record(env, class_sig, event.size,
                                             event.thread, count,
-                                            frames.data(), event.tag);
+                                            frames.data(), event.tag)
+                        : allocation_record(env, class_sig, event.size,
+                                            event.thread, event.tag);
 
     if (starting) {
       // DEBUG_PRINT("Start marker seen\n");

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -182,6 +182,8 @@ struct AllocationEvent {
   jthread thread;
   jlong size;
   jlong tag;
+  std::array<jvmtiFrameInfo, MAX_FRAMES> frames;
+  jint frame_count;
 
   void delete_global_refs(JNIEnv* env) const {
     env->DeleteGlobalRef(object_klass);
@@ -556,13 +558,27 @@ public:
       std::cout << "Failed to tag object: " << err << '\n';
       debug_print_jvmti_err(err);
     }
+
+    // Capture stack trace synchronously while still on the allocating thread
+    std::array<jvmtiFrameInfo, MAX_FRAMES> frames = {};
+    jint frame_count = 0;
+    auto stack_err = jvmti->GetStackTrace(thread, 0, MAX_FRAMES,
+                                          frames.data(), &frame_count);
+    if (stack_err != JVMTI_ERROR_NONE) {
+      DEBUG_PRINTLN("Failed to get stack trace: " << stack_err);
+      debug_print_jvmti_err(stack_err);
+      frame_count = 0;
+    }
+
     message_queue.push(AllocationEvent{
 	env->NewGlobalRef(object),
 	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 	reinterpret_cast<jclass>(env->NewGlobalRef(object_klass)),
 	static_cast<jthread>(env->NewGlobalRef(thread)),
 	size,
-	tag
+	tag,
+	frames,
+	frame_count
       });
   }
 
@@ -1010,21 +1026,16 @@ public:
 
     auto internal = !(starting || stopping);
 
-    std::array<jvmtiFrameInfo, MAX_FRAMES> frames = {};
-    jint count=0;
-
-    if (internal) {
-      if (!agent_context.get_stack_trace(event.thread, frames.data(), &count)) {
-      	return;
-      }
-    }
-
+    // Use the pre-captured stack frames from the allocation event
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-    auto rec = internal ? allocation_record(env, class_sig, event.size,
-                                            event.thread, count,
-                                            frames.data(), event.tag)
-                        : allocation_record(env, class_sig, event.size,
-                                            event.thread, event.tag);
+    auto rec = (internal && event.frame_count > 0)
+                   ? allocation_record(env, class_sig, event.size,
+                                       event.thread, event.frame_count,
+                                       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                                       const_cast<jvmtiFrameInfo*>(event.frames.data()),
+                                       event.tag)
+                   : allocation_record(env, class_sig, event.size,
+                                       event.thread, event.tag);
 
     if (starting) {
       // DEBUG_PRINT("Start marker seen\n");

--- a/bases/agent/src/clj/criterium/agent/core.clj
+++ b/bases/agent/src/clj/criterium/agent/core.clj
@@ -181,7 +181,7 @@
                  :alloc-file (.get alloc-file object)
                  :alloc-line (.get alloc-line object)
                  :thread (.get thread-field object)
-                 :freed (.get freed object)})))
+                 :freed (pos? (long (.get freed object)))})))
 
      :else
      (prn :received object (type object))))
@@ -196,7 +196,7 @@
              :size (Long/parseLong e)
              :thread (Long/parseLong f)
              :line (Long/parseLong g)
-             :freed (Long/parseLong h)}))))
+             :freed (pos? (Long/parseLong h))}))))
 
 ;;; Lazy Agent Initialization
 
@@ -450,7 +450,7 @@
 
   Returns true if the record indicates the object was freed during tracking."
   [record]
-  (pos? (long (:freed record))))
+  (:freed record))
 
 (defn allocations-summary
   "Returns a summary of allocation statistics for the given records.

--- a/bases/agent/src/clj/criterium/agent/core.clj
+++ b/bases/agent/src/clj/criterium/agent/core.clj
@@ -286,9 +286,9 @@
   - Thread-safe but uncoordinated
   - Returns state keywords from states map"
   []
-  (let [^clojure.lang.IFn$L f @wrapper-read-state]
-    (assert f "Agent not loaded")
-    (get states (.invokePrim f) :not-attached)))
+  (if-let [^clojure.lang.IFn$L f @wrapper-read-state]
+    (get states (.invokePrim f) :not-attached)
+    :not-attached))
 
 (defn attached?
   "Returns true if the Criterium native agent is currently loaded.

--- a/bases/agent/test/criterium/agent/core_test.clj
+++ b/bases/agent/test/criterium/agent/core_test.clj
@@ -111,9 +111,9 @@
           "Should not match other thread")))
 
   (testing "Freed allocation detection"
-    (is (agent-core/allocation-freed? {:freed 1})
+    (is (agent-core/allocation-freed? {:freed true})
         "Should detect freed allocation")
-    (is (not (agent-core/allocation-freed? {:freed 0}))
+    (is (not (agent-core/allocation-freed? {:freed false}))
         "Should detect non-freed allocation")))
 
 ;; Integration Tests

--- a/bases/agent/test/criterium/agent_test.clj
+++ b/bases/agent/test/criterium/agent_test.clj
@@ -194,9 +194,9 @@
 
 (deftest allocation-freed?-test
   (testing "Freed allocation detection"
-    (is (agent/allocation-freed? {:freed 1})
+    (is (agent/allocation-freed? {:freed true})
         "Should identify freed allocation")
-    (is (not (agent/allocation-freed? {:freed 0}))
+    (is (not (agent/allocation-freed? {:freed false}))
         "Should identify non-freed allocation")))
 
 (deftest allocations-summary-test
@@ -210,9 +210,9 @@
           "Should return zero summary for empty input")))
 
   (testing "Allocation summary with records"
-    (let [records [{:object_size 100 :freed 1}
-                   {:object_size 200 :freed 0}
-                   {:object_size 300 :freed 1}]
+    (let [records [{:object_size 100 :freed true}
+                   {:object_size 200 :freed false}
+                   {:object_size 300 :freed true}]
           summary (agent/allocations-summary records)]
       (is (= {:num-allocated 3
               :num-freed 2

--- a/bases/criterium/src/criterium/allocation.clj
+++ b/bases/criterium/src/criterium/allocation.clj
@@ -1,0 +1,72 @@
+(ns criterium.allocation
+  "Allocation tracing for benchmarks.
+
+  Provides a wrapper around the native agent's allocation tracing that
+  produces allocation trace maps conforming to :criterium/allocation-trace.
+
+  This namespace bridges the low-level agent API with the criterium
+  pipeline architecture, capturing thread context and timing metadata
+  alongside raw allocation records."
+  (:require
+   [criterium.agent :as agent]
+   [criterium.jvm :as jvm]
+   [criterium.types :as types]))
+
+(def trace?
+  "Check if x is an allocation trace map with :type :criterium/allocation-trace.
+  Re-exported from criterium.types."
+  types/allocation-trace?)
+
+(defn filter-thread
+  "Filter allocation records to those from a specific thread.
+
+  Parameters:
+    records   - Sequence of allocation records from the agent
+    thread-id - Optional thread ID to filter by. Defaults to current thread.
+
+  Returns filtered sequence of records where :thread matches thread-id."
+  ([records]
+   (filter-thread records (jvm/current-thread-id)))
+  ([records thread-id]
+   (filter (agent/allocation-on-thread? thread-id) records)))
+
+(defmacro with-allocation-trace
+  "Execute body while tracing allocations, returning an allocation trace map.
+
+  Wraps the native agent's allocation tracing and packages the results
+  into a :criterium/allocation-trace map suitable for the analysis pipeline.
+
+  Parameters:
+    opts - Options map with:
+           :eval-count - Number of evaluations (default 1)
+    body - Forms to execute while tracing
+
+  Returns a vector of [allocation-trace result] where:
+    allocation-trace - Map with :type :criterium/allocation-trace containing:
+                       :records      - Raw allocation records from agent
+                       :thread-id    - Thread ID where body executed
+                       :eval-count   - Number of evaluations
+                       :elapsed-time - Execution time in nanoseconds
+                       Returns nil if agent not attached.
+    result           - Value returned by body forms
+
+  Example:
+    (with-allocation-trace {:eval-count 100}
+      (dotimes [_ 100] (make-string)))
+    => [{:type :criterium/allocation-trace
+         :records [...] :thread-id 1 :eval-count 100 :elapsed-time 12345}
+        nil]"
+  [opts & body]
+  `(let [thread-id#  (jvm/current-thread-id)
+         eval-count# (:eval-count ~opts 1)
+         start#      (jvm/timestamp)
+         [records# result#] (agent/with-allocation-tracing ~@body)
+         elapsed#    (jvm/elapsed-time start# (jvm/timestamp))]
+     (if records#
+       [{:type         :criterium/allocation-trace
+         :records      records#
+         :thread-id    thread-id#
+         :eval-count   eval-count#
+         :elapsed-time elapsed#}
+        result#]
+       [nil result#])))

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -69,33 +69,33 @@
   ([{:keys [id trace-id]}]
    (fn [data-map]
      (let [trace-id (or trace-id [:samples :allocation-trace])
-           id       (or id :allocation-summary)
-           trace    (get-in data-map trace-id)]
+           id (or id :allocation-summary)
+           trace (get-in data-map trace-id)]
        (if-not trace
          data-map
-         (let [records         (:records trace)
-               result          (reduce
-                                (fn [acc record]
-                                  (let [size   (long (:object_size record 0))
-                                        freed? (:freed record)]
-                                    (-> acc
-                                        (update :total-allocated + size)
-                                        (update :num-allocations inc)
-                                        (cond->
-                                          freed? (-> (update :total-freed + size)
-                                                     (update :num-freed inc))))))
-                                {:type            :criterium/allocation-summary
-                                 :transform       {:sample-> identity :->sample identity}
-                                 :total-allocated 0
-                                 :total-freed     0
-                                 :num-allocations 0
-                                 :num-freed       0}
-                                records)
+         (let [records (:records trace)
+               result (reduce
+                       (fn [acc record]
+                         (let [size (long (:object_size record 0))
+                               freed? (:freed record)]
+                           (-> acc
+                               (update :total-allocated + size)
+                               (update :num-allocations inc)
+                               (cond->
+                                 freed? (-> (update :total-freed + size)
+                                            (update :num-freed inc))))))
+                       {:type :criterium/allocation-summary
+                        :transform {:sample-> identity :->sample identity}
+                        :total-allocated 0
+                        :total-freed 0
+                        :num-allocations 0
+                        :num-freed 0}
+                       records)
                total-allocated (long (:total-allocated result))
-               total-freed     (:total-freed result)
-               freed-ratio     (if (pos? total-allocated)
-                                 (/ (double total-freed) (double total-allocated))
-                                 0.0)]
+               total-freed (:total-freed result)
+               freed-ratio (if (pos? total-allocated)
+                             (/ (double total-freed) (double total-allocated))
+                             0.0)]
            (assoc data-map id (assoc result :freed-ratio freed-ratio))))))))
 
 (defn hotspots-fn
@@ -227,6 +227,134 @@
     (if (sequential? x)
       (apply (util/maybe-var-get (first x) options) (rest x))
       ((util/maybe-var-get x options)))))
+
+(defn- filter-records
+  "Filter allocation records based on freed status."
+  [records filter-by]
+  (case filter-by
+    :freed (filterv :freed records)
+    :not-freed (filterv (complement :freed) records)
+    :all records
+    records))
+
+(defn- compute-value
+  "Compute the value for a node based on size-by option."
+  [^long count ^long bytes size-by]
+  (case size-by
+    :count count
+    :bytes bytes
+    :bytes-per-allocation (if (pos? count)
+                            (/ (double bytes) (double count))
+                            0.0)
+    bytes))
+
+(defn- build-treemap-node
+  "Build a treemap node with children, computing values bottom-up.
+  Leaf nodes in the hierarchy have {:count N :bytes M} structure."
+  [name children-map size-by]
+  (if (empty? children-map)
+    {:name name :value 0}
+    (let [children (mapv (fn [[child-name child-data]]
+                           (if (and (map? child-data)
+                                    (contains? child-data :count)
+                                    (contains? child-data :bytes))
+                             ;; Leaf node with :count/:bytes
+                             {:name child-name
+                              :value (compute-value (long (:count child-data))
+                                                    (long (:bytes child-data))
+                                                    size-by)}
+                             ;; Intermediate node - recurse
+                             (build-treemap-node child-name child-data size-by)))
+                         children-map)
+          total-value (reduce + 0.0 (map :value children))]
+      (cond-> {:name name :value (if (every? integer? (map :value children))
+                                   (long total-value)
+                                   total-value)}
+        (seq children) (assoc :children children)))))
+
+(defn- group-by-hierarchy
+  "Group records into nested maps according to hierarchy.
+  Returns nested maps where leaves have {:count N :bytes M}."
+  [records group-by-opt]
+  (let [extract-keys (case group-by-opt
+                       :class→line→type
+                       (fn [r]
+                         (let [site (call-site-key r)]
+                           [(:call-class site)
+                            (str "L" (:call-line site))
+                            (:object-type r)]))
+
+                       :type→class→line
+                       (fn [r]
+                         (let [site (call-site-key r)]
+                           [(:object-type r)
+                            (:call-class site)
+                            (str "L" (:call-line site))]))
+
+                       ;; Default to :class→line→type
+                       (fn [r]
+                         (let [site (call-site-key r)]
+                           [(:call-class site)
+                            (str "L" (:call-line site))
+                            (:object-type r)])))]
+    (reduce
+     (fn [tree record]
+       (let [[k1 k2 k3] (extract-keys record)
+             size (long (:object_size record 0))]
+         (update-in tree [k1 k2 k3]
+                    (fn [stats]
+                      (let [cnt (long (get stats :count 0))
+                            bts (long (get stats :bytes 0))]
+                        {:count (inc cnt) :bytes (+ bts size)})))))
+     {}
+     records)))
+
+(defn treemap-fn
+  "Returns a function that transforms allocation records into hierarchical treemap data.
+
+  Parameters:
+    opts - Map with keys:
+      :id        - Key for result in output (default: :allocation-treemap)
+      :trace-id  - Path for source allocation trace (default: [:samples :allocation-trace])
+      :group-by  - Hierarchy option:
+                   :class→line→type (default): calling-class → calling-line → object-type
+                   :type→class→line: object-type → calling-class → calling-line
+      :size-by   - Value for node sizing: :count, :bytes, :bytes-per-allocation (default: :bytes)
+      :filter-by - Filter records: :freed, :not-freed, :all (default: :all)
+
+  The returned function:
+  - Takes a data-map containing an allocation trace at :trace-id path
+  - Returns the data-map with treemap added under :id
+  - Returns data-map unchanged if trace is not present (no-op)
+
+  Treemap result contains:
+    :type     - :criterium/allocation-treemap
+    :group-by - The grouping option used
+    :size-by  - The sizing option used
+    :root     - Root node with :name, :value, and optional :children
+                Leaf nodes have no :children key
+                Values at each level are sum of children values"
+  ([] (treemap-fn {}))
+  ([{:keys [id trace-id group-by size-by filter-by]}]
+   (fn [data-map]
+     (let [trace-id (or trace-id [:samples :allocation-trace])
+           id (or id :allocation-treemap)
+           group-by (or group-by :class→line→type)
+           size-by (or size-by :bytes)
+           filter-by (or filter-by :all)
+           trace (get-in data-map trace-id)]
+       (if-not trace
+         data-map
+         (let [records (:records trace)
+               filtered (filter-records records filter-by)
+               hierarchy (group-by-hierarchy filtered group-by)
+               root (build-treemap-node "allocations" hierarchy size-by)]
+           (assoc data-map id
+                  {:type :criterium/allocation-treemap
+                   :transform {:sample-> identity :->sample identity}
+                   :group-by group-by
+                   :size-by size-by
+                   :root root})))))))
 
 (defn ->allocation-analyse
   "Creates a composite analysis function from a sequence of analysis specs.

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -1,0 +1,201 @@
+(ns criterium.allocation.analysis
+  "Analysis functions for allocation trace data.
+
+  Provides functions for summarizing allocations, detecting hotspots,
+  and grouping by object type. Functions follow the pipeline pattern
+  where each takes options and returns a transformer function that
+  operates on a data-map."
+  (:require
+   [criterium.util.helpers :as util]))
+
+;;; Helper functions
+
+(defn- call-site
+  "Extract call-site map from an allocation record."
+  [record]
+  {:call-class  (:call-class record)
+   :call-method (:call-method record)
+   :call-file   (:call-file record)
+   :call-line   (:call-line record)})
+
+;;; Analysis Functions
+
+(defn summary-fn
+  "Returns a function that computes allocation summary statistics.
+
+  Parameters:
+    opts - Map with keys:
+      :id       - Key for result in output (default: :allocation-summary)
+      :trace-id - Key for source allocation trace in input (default: :allocation-trace)
+
+  The returned function:
+  - Takes a data-map containing an allocation trace under :trace-id
+  - Returns the data-map with summary added under :id
+
+  Summary contains:
+    :type            - :criterium/allocation-summary
+    :total-allocated - Total bytes allocated
+    :total-freed     - Total bytes from freed objects
+    :num-allocations - Total number of allocations
+    :num-freed       - Number of allocations that were freed"
+  ([] (summary-fn {}))
+  ([{:keys [id trace-id]}]
+   (fn [data-map]
+     (let [trace-id (or trace-id :allocation-trace)
+           id (or id :allocation-summary)
+           trace (get data-map trace-id)
+           records (:records trace)
+           result (reduce
+                   (fn [acc record]
+                     (let [size (long (:object_size record 0))
+                           freed? (:freed record)]
+                       (-> acc
+                           (update :total-allocated + size)
+                           (update :num-allocations inc)
+                           (cond->
+                             freed? (-> (update :total-freed + size)
+                                        (update :num-freed inc))))))
+                   {:type :criterium/allocation-summary
+                    :total-allocated 0
+                    :total-freed 0
+                    :num-allocations 0
+                    :num-freed 0}
+                   records)]
+       (assoc data-map id result)))))
+
+(defn hotspots-fn
+  "Returns a function that identifies allocation hotspots by call-site.
+
+  Parameters:
+    opts - Map with keys:
+      :id       - Key for result in output (default: :allocation-hotspots)
+      :trace-id - Key for source allocation trace in input (default: :allocation-trace)
+      :limit    - Maximum number of hotspots to return (default: 10)
+      :order-by - Sort key, :bytes or :count (default: :bytes)
+
+  The returned function:
+  - Takes a data-map containing an allocation trace under :trace-id
+  - Returns the data-map with hotspots added under :id
+
+  Hotspots result contains:
+    :type     - :criterium/allocation-hotspots
+    :hotspots - Vector of maps sorted by bytes descending:
+                [{:call-site {:call-class ... :call-method ... :call-file ... :call-line ...}
+                  :count N
+                  :bytes M
+                  :freed-count K
+                  :freed-bytes L} ...]"
+  ([] (hotspots-fn {}))
+  ([{:keys [id trace-id limit order-by]}]
+   (fn [data-map]
+     (let [trace-id (or trace-id :allocation-trace)
+           id (or id :allocation-hotspots)
+           limit (or limit 10)
+           sort-key (or order-by :bytes)
+           trace (get data-map trace-id)
+           records (:records trace)
+           ;; Group by call-site and aggregate
+           grouped (reduce
+                    (fn [acc record]
+                      (let [site (call-site record)
+                            size (long (:object_size record 0))
+                            freed? (:freed record)]
+                        (update acc site
+                                (fn [stats]
+                                  (let [stats (or stats {:count 0 :bytes 0
+                                                         :freed-count 0 :freed-bytes 0})]
+                                    (-> stats
+                                        (update :count inc)
+                                        (update :bytes + size)
+                                        (cond->
+                                          freed? (-> (update :freed-count inc)
+                                                     (update :freed-bytes + size)))))))))
+                    {}
+                    records)
+           ;; Convert to vector and sort
+           hotspots (->> grouped
+                         (mapv (fn [[site stats]]
+                                 (assoc stats :call-site site)))
+                         (sort-by sort-key >)
+                         (take limit)
+                         vec)]
+       (assoc data-map id {:type :criterium/allocation-hotspots
+                           :hotspots hotspots})))))
+
+(defn by-type-fn
+  "Returns a function that groups allocations by object type.
+
+  Parameters:
+    opts - Map with keys:
+      :id       - Key for result in output (default: :allocation-by-type)
+      :trace-id - Key for source allocation trace in input (default: :allocation-trace)
+
+  The returned function:
+  - Takes a data-map containing an allocation trace under :trace-id
+  - Returns the data-map with by-type grouping added under :id
+
+  Result contains:
+    :type    - :criterium/allocation-by-type
+    :by-type - Map of object-type to stats:
+               {\"Ljava/lang/String;\" {:count N :bytes M :freed-count K :freed-bytes L} ...}"
+  ([] (by-type-fn {}))
+  ([{:keys [id trace-id]}]
+   (fn [data-map]
+     (let [trace-id (or trace-id :allocation-trace)
+           id (or id :allocation-by-type)
+           trace (get data-map trace-id)
+           records (:records trace)
+           by-type (reduce
+                    (fn [acc record]
+                      (let [obj-type (:object-type record)
+                            size (long (:object_size record 0))
+                            freed? (:freed record)]
+                        (update acc obj-type
+                                (fn [stats]
+                                  (let [stats (or stats {:count 0 :bytes 0
+                                                         :freed-count 0 :freed-bytes 0})]
+                                    (-> stats
+                                        (update :count inc)
+                                        (update :bytes + size)
+                                        (cond->
+                                          freed? (-> (update :freed-count inc)
+                                                     (update :freed-bytes + size)))))))))
+                    {}
+                    records)]
+       (assoc data-map id {:type :criterium/allocation-by-type
+                           :by-type by-type})))))
+
+;;; Analysis Pipeline
+
+(defn- resolve-allocation-analyse-fn
+  "Resolves a single allocation analysis function specification.
+  If x is a sequence, treats first element as function and rest as args.
+  Otherwise treats x as a function name to resolve.
+  Returns a function of one argument (the data-map)."
+  [x]
+  (let [options {:default-ns 'criterium.allocation.analysis}]
+    (if (sequential? x)
+      (apply (util/maybe-var-get (first x) options) (rest x))
+      ((util/maybe-var-get x options)))))
+
+(defn ->allocation-analyse
+  "Creates a composite analysis function from a sequence of analysis specs.
+
+  Each spec is either a keyword/symbol to resolve a function, or a vector
+  with a keyword/symbol first element followed by an options map.
+
+  Analysis functions are resolved from the criterium.allocation.analysis namespace.
+  They are composed in sequence, each taking and returning a data-map.
+
+  Example specs:
+    [[:summary-fn {:id :summary}]
+     [:hotspots-fn {:limit 5}]
+     [:by-type-fn {}]]
+
+  Returns a function that takes a data-map and returns the analyzed data-map."
+  [analyse-plan]
+  (when-not (or (nil? analyse-plan) (sequential? analyse-plan))
+    (throw
+     (ex-info "analyse must be a sequence of specs" {:analyse analyse-plan})))
+  (let [fns (mapv resolve-allocation-analyse-fn analyse-plan)]
+    (reduce comp (reverse fns))))

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -31,6 +31,7 @@
   The returned function:
   - Takes a data-map containing an allocation trace under :trace-id
   - Returns the data-map with summary added under :id
+  - Returns data-map unchanged if trace is not present (no-op)
 
   Summary contains:
     :type            - :criterium/allocation-summary
@@ -43,25 +44,27 @@
    (fn [data-map]
      (let [trace-id (or trace-id :allocation-trace)
            id (or id :allocation-summary)
-           trace (get data-map trace-id)
-           records (:records trace)
-           result (reduce
-                   (fn [acc record]
-                     (let [size (long (:object_size record 0))
-                           freed? (:freed record)]
-                       (-> acc
-                           (update :total-allocated + size)
-                           (update :num-allocations inc)
-                           (cond->
-                             freed? (-> (update :total-freed + size)
-                                        (update :num-freed inc))))))
-                   {:type :criterium/allocation-summary
-                    :total-allocated 0
-                    :total-freed 0
-                    :num-allocations 0
-                    :num-freed 0}
-                   records)]
-       (assoc data-map id result)))))
+           trace (get data-map trace-id)]
+       (if-not trace
+         data-map
+         (let [records (:records trace)
+               result (reduce
+                       (fn [acc record]
+                         (let [size (long (:object_size record 0))
+                               freed? (:freed record)]
+                           (-> acc
+                               (update :total-allocated + size)
+                               (update :num-allocations inc)
+                               (cond->
+                                 freed? (-> (update :total-freed + size)
+                                            (update :num-freed inc))))))
+                       {:type :criterium/allocation-summary
+                        :total-allocated 0
+                        :total-freed 0
+                        :num-allocations 0
+                        :num-freed 0}
+                       records)]
+           (assoc data-map id result)))))))
 
 (defn hotspots-fn
   "Returns a function that identifies allocation hotspots by call-site.
@@ -76,6 +79,7 @@
   The returned function:
   - Takes a data-map containing an allocation trace under :trace-id
   - Returns the data-map with hotspots added under :id
+  - Returns data-map unchanged if trace is not present (no-op)
 
   Hotspots result contains:
     :type     - :criterium/allocation-hotspots
@@ -90,37 +94,39 @@
    (fn [data-map]
      (let [trace-id (or trace-id :allocation-trace)
            id (or id :allocation-hotspots)
-           limit (or limit 10)
-           sort-key (or order-by :bytes)
-           trace (get data-map trace-id)
-           records (:records trace)
-           ;; Group by call-site and aggregate
-           grouped (reduce
-                    (fn [acc record]
-                      (let [site (call-site record)
-                            size (long (:object_size record 0))
-                            freed? (:freed record)]
-                        (update acc site
-                                (fn [stats]
-                                  (let [stats (or stats {:count 0 :bytes 0
-                                                         :freed-count 0 :freed-bytes 0})]
-                                    (-> stats
-                                        (update :count inc)
-                                        (update :bytes + size)
-                                        (cond->
-                                          freed? (-> (update :freed-count inc)
-                                                     (update :freed-bytes + size)))))))))
-                    {}
-                    records)
-           ;; Convert to vector and sort
-           hotspots (->> grouped
-                         (mapv (fn [[site stats]]
-                                 (assoc stats :call-site site)))
-                         (sort-by sort-key >)
-                         (take limit)
-                         vec)]
-       (assoc data-map id {:type :criterium/allocation-hotspots
-                           :hotspots hotspots})))))
+           trace (get data-map trace-id)]
+       (if-not trace
+         data-map
+         (let [limit (or limit 10)
+               sort-key (or order-by :bytes)
+               records (:records trace)
+               ;; Group by call-site and aggregate
+               grouped (reduce
+                        (fn [acc record]
+                          (let [site (call-site record)
+                                size (long (:object_size record 0))
+                                freed? (:freed record)]
+                            (update acc site
+                                    (fn [stats]
+                                      (let [stats (or stats {:count 0 :bytes 0
+                                                             :freed-count 0 :freed-bytes 0})]
+                                        (-> stats
+                                            (update :count inc)
+                                            (update :bytes + size)
+                                            (cond->
+                                              freed? (-> (update :freed-count inc)
+                                                         (update :freed-bytes + size)))))))))
+                        {}
+                        records)
+               ;; Convert to vector and sort
+               hotspots (->> grouped
+                             (mapv (fn [[site stats]]
+                                     (assoc stats :call-site site)))
+                             (sort-by sort-key >)
+                             (take limit)
+                             vec)]
+           (assoc data-map id {:type :criterium/allocation-hotspots
+                               :hotspots hotspots})))))))
 
 (defn by-type-fn
   "Returns a function that groups allocations by object type.
@@ -133,6 +139,7 @@
   The returned function:
   - Takes a data-map containing an allocation trace under :trace-id
   - Returns the data-map with by-type grouping added under :id
+  - Returns data-map unchanged if trace is not present (no-op)
 
   Result contains:
     :type    - :criterium/allocation-by-type
@@ -143,27 +150,29 @@
    (fn [data-map]
      (let [trace-id (or trace-id :allocation-trace)
            id (or id :allocation-by-type)
-           trace (get data-map trace-id)
-           records (:records trace)
-           by-type (reduce
-                    (fn [acc record]
-                      (let [obj-type (:object-type record)
-                            size (long (:object_size record 0))
-                            freed? (:freed record)]
-                        (update acc obj-type
-                                (fn [stats]
-                                  (let [stats (or stats {:count 0 :bytes 0
-                                                         :freed-count 0 :freed-bytes 0})]
-                                    (-> stats
-                                        (update :count inc)
-                                        (update :bytes + size)
-                                        (cond->
-                                          freed? (-> (update :freed-count inc)
-                                                     (update :freed-bytes + size)))))))))
-                    {}
-                    records)]
-       (assoc data-map id {:type :criterium/allocation-by-type
-                           :by-type by-type})))))
+           trace (get data-map trace-id)]
+       (if-not trace
+         data-map
+         (let [records (:records trace)
+               by-type (reduce
+                        (fn [acc record]
+                          (let [obj-type (:object-type record)
+                                size (long (:object_size record 0))
+                                freed? (:freed record)]
+                            (update acc obj-type
+                                    (fn [stats]
+                                      (let [stats (or stats {:count 0 :bytes 0
+                                                             :freed-count 0 :freed-bytes 0})]
+                                        (-> stats
+                                            (update :count inc)
+                                            (update :bytes + size)
+                                            (cond->
+                                              freed? (-> (update :freed-count inc)
+                                                         (update :freed-bytes + size)))))))))
+                        {}
+                        records)]
+           (assoc data-map id {:type :criterium/allocation-by-type
+                               :by-type by-type})))))))
 
 ;;; Analysis Pipeline
 

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -26,22 +26,22 @@
         alloc-useful? (useful-string? alloc-class)]
     (cond
       call-useful?
-      {:call-class  call-class
+      {:call-class call-class
        :call-method (:call-method record)
-       :call-file   (:call-file record)
-       :call-line   (:call-line record)}
+       :call-file (:call-file record)
+       :call-line (:call-line record)}
 
       alloc-useful?
-      {:call-class  alloc-class
+      {:call-class alloc-class
        :call-method (:alloc-method record)
-       :call-file   (:alloc-file record)
-       :call-line   (:alloc-line record)}
+       :call-file (:alloc-file record)
+       :call-line (:alloc-line record)}
 
       :else
-      {:call-class  (:object-type record)
+      {:call-class (:object-type record)
        :call-method nil
-       :call-file   nil
-       :call-line   nil})))
+       :call-file nil
+       :call-line nil})))
 
 ;;; Analysis Functions
 
@@ -93,7 +93,7 @@
            (assoc data-map id result)))))))
 
 (defn hotspots-fn
-  "Returns a function that identifies allocation hotspots by call-site.
+  "Returns a function that identifies allocation hotspots by call-site and object type.
 
   Parameters:
     opts - Map with keys:
@@ -111,7 +111,7 @@
     :type     - :criterium/allocation-hotspots
     :hotspots - Vector of maps sorted by bytes descending:
                 [{:call-site {:call-class ... :call-method ... :call-file ... :call-line ...}
-                  :object-types #{\"Ljava/lang/String;\" ...}
+                  :object-type \"Ljava/lang/String;\"
                   :count N
                   :bytes M
                   :freed-count K
@@ -129,22 +129,21 @@
          (let [limit (or limit 10)
                sort-key (or order-by :bytes)
                records (:records trace)
-               ;; Group by call-site and aggregate
+               ;; Group by (call-site, object-type) pair
                grouped (reduce
                         (fn [acc record]
                           (let [site (call-site-key record)
                                 obj-type (:object-type record)
+                                key [site obj-type]
                                 size (long (:object_size record 0))
                                 freed? (:freed record)]
-                            (update acc site
+                            (update acc key
                                     (fn [stats]
                                       (let [stats (or stats {:count 0 :bytes 0
-                                                             :freed-count 0 :freed-bytes 0
-                                                             :object-types #{}})]
+                                                             :freed-count 0 :freed-bytes 0})]
                                         (-> stats
                                             (update :count inc)
                                             (update :bytes + size)
-                                            (update :object-types conj obj-type)
                                             (cond->
                                               freed? (-> (update :freed-count inc)
                                                          (update :freed-bytes + size)))))))))
@@ -152,8 +151,10 @@
                         records)
                ;; Convert to vector and sort
                hotspots (->> grouped
-                             (mapv (fn [[site stats]]
-                                     (assoc stats :call-site site)))
+                             (mapv (fn [[[site obj-type] stats]]
+                                     (assoc stats
+                                            :call-site site
+                                            :object-type obj-type)))
                              (sort-by sort-key >)
                              (take limit)
                              vec)]

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -26,10 +26,10 @@
   Parameters:
     opts - Map with keys:
       :id       - Key for result in output (default: :allocation-summary)
-      :trace-id - Key for source allocation trace in input (default: :allocation-trace)
+      :trace-id - Path for source allocation trace (default: [:samples :allocation-trace])
 
   The returned function:
-  - Takes a data-map containing an allocation trace under :trace-id
+  - Takes a data-map containing an allocation trace at :trace-id path
   - Returns the data-map with summary added under :id
   - Returns data-map unchanged if trace is not present (no-op)
 
@@ -42,9 +42,9 @@
   ([] (summary-fn {}))
   ([{:keys [id trace-id]}]
    (fn [data-map]
-     (let [trace-id (or trace-id :allocation-trace)
+     (let [trace-id (or trace-id [:samples :allocation-trace])
            id (or id :allocation-summary)
-           trace (get data-map trace-id)]
+           trace (get-in data-map trace-id)]
        (if-not trace
          data-map
          (let [records (:records trace)
@@ -59,6 +59,7 @@
                                  freed? (-> (update :total-freed + size)
                                             (update :num-freed inc))))))
                        {:type :criterium/allocation-summary
+                        :transform {:sample-> identity :->sample identity}
                         :total-allocated 0
                         :total-freed 0
                         :num-allocations 0
@@ -72,12 +73,12 @@
   Parameters:
     opts - Map with keys:
       :id       - Key for result in output (default: :allocation-hotspots)
-      :trace-id - Key for source allocation trace in input (default: :allocation-trace)
+      :trace-id - Path for source allocation trace (default: [:samples :allocation-trace])
       :limit    - Maximum number of hotspots to return (default: 10)
       :order-by - Sort key, :bytes or :count (default: :bytes)
 
   The returned function:
-  - Takes a data-map containing an allocation trace under :trace-id
+  - Takes a data-map containing an allocation trace at :trace-id path
   - Returns the data-map with hotspots added under :id
   - Returns data-map unchanged if trace is not present (no-op)
 
@@ -92,9 +93,9 @@
   ([] (hotspots-fn {}))
   ([{:keys [id trace-id limit order-by]}]
    (fn [data-map]
-     (let [trace-id (or trace-id :allocation-trace)
+     (let [trace-id (or trace-id [:samples :allocation-trace])
            id (or id :allocation-hotspots)
-           trace (get data-map trace-id)]
+           trace (get-in data-map trace-id)]
        (if-not trace
          data-map
          (let [limit (or limit 10)
@@ -126,6 +127,7 @@
                              (take limit)
                              vec)]
            (assoc data-map id {:type :criterium/allocation-hotspots
+                               :transform {:sample-> identity :->sample identity}
                                :hotspots hotspots})))))))
 
 (defn by-type-fn
@@ -134,10 +136,10 @@
   Parameters:
     opts - Map with keys:
       :id       - Key for result in output (default: :allocation-by-type)
-      :trace-id - Key for source allocation trace in input (default: :allocation-trace)
+      :trace-id - Path for source allocation trace (default: [:samples :allocation-trace])
 
   The returned function:
-  - Takes a data-map containing an allocation trace under :trace-id
+  - Takes a data-map containing an allocation trace at :trace-id path
   - Returns the data-map with by-type grouping added under :id
   - Returns data-map unchanged if trace is not present (no-op)
 
@@ -148,9 +150,9 @@
   ([] (by-type-fn {}))
   ([{:keys [id trace-id]}]
    (fn [data-map]
-     (let [trace-id (or trace-id :allocation-trace)
+     (let [trace-id (or trace-id [:samples :allocation-trace])
            id (or id :allocation-by-type)
-           trace (get data-map trace-id)]
+           trace (get-in data-map trace-id)]
        (if-not trace
          data-map
          (let [records (:records trace)
@@ -172,6 +174,7 @@
                         {}
                         records)]
            (assoc data-map id {:type :criterium/allocation-by-type
+                               :transform {:sample-> identity :->sample identity}
                                :by-type by-type})))))))
 
 ;;; Analysis Pipeline

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -69,33 +69,33 @@
   ([{:keys [id trace-id]}]
    (fn [data-map]
      (let [trace-id (or trace-id [:samples :allocation-trace])
-           id (or id :allocation-summary)
-           trace (get-in data-map trace-id)]
+           id       (or id :allocation-summary)
+           trace    (get-in data-map trace-id)]
        (if-not trace
          data-map
-         (let [records (:records trace)
-               result (reduce
-                       (fn [acc record]
-                         (let [size (long (:object_size record 0))
-                               freed? (:freed record)]
-                           (-> acc
-                               (update :total-allocated + size)
-                               (update :num-allocations inc)
-                               (cond->
-                                 freed? (-> (update :total-freed + size)
-                                            (update :num-freed inc))))))
-                       {:type :criterium/allocation-summary
-                        :transform {:sample-> identity :->sample identity}
-                        :total-allocated 0
-                        :total-freed 0
-                        :num-allocations 0
-                        :num-freed 0}
-                       records)
-               total-allocated (:total-allocated result)
-               total-freed (:total-freed result)
-               freed-ratio (if (pos? total-allocated)
-                             (/ (double total-freed) (double total-allocated))
-                             0.0)]
+         (let [records         (:records trace)
+               result          (reduce
+                                (fn [acc record]
+                                  (let [size   (long (:object_size record 0))
+                                        freed? (:freed record)]
+                                    (-> acc
+                                        (update :total-allocated + size)
+                                        (update :num-allocations inc)
+                                        (cond->
+                                          freed? (-> (update :total-freed + size)
+                                                     (update :num-freed inc))))))
+                                {:type            :criterium/allocation-summary
+                                 :transform       {:sample-> identity :->sample identity}
+                                 :total-allocated 0
+                                 :total-freed     0
+                                 :num-allocations 0
+                                 :num-freed       0}
+                                records)
+               total-allocated (long (:total-allocated result))
+               total-freed     (:total-freed result)
+               freed-ratio     (if (pos? total-allocated)
+                                 (/ (double total-freed) (double total-allocated))
+                                 0.0)]
            (assoc data-map id (assoc result :freed-ratio freed-ratio))))))))
 
 (defn hotspots-fn

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -63,7 +63,8 @@
     :total-allocated - Total bytes allocated
     :total-freed     - Total bytes from freed objects
     :num-allocations - Total number of allocations
-    :num-freed       - Number of allocations that were freed"
+    :num-freed       - Number of allocations that were freed
+    :freed-ratio     - Ratio of bytes freed to bytes allocated (0.0 to 1.0)"
   ([] (summary-fn {}))
   ([{:keys [id trace-id]}]
    (fn [data-map]
@@ -89,8 +90,13 @@
                         :total-freed 0
                         :num-allocations 0
                         :num-freed 0}
-                       records)]
-           (assoc data-map id result)))))))
+                       records)
+               total-allocated (:total-allocated result)
+               total-freed (:total-freed result)
+               freed-ratio (if (pos? total-allocated)
+                             (/ (double total-freed) (double total-allocated))
+                             0.0)]
+           (assoc data-map id (assoc result :freed-ratio freed-ratio))))))))
 
 (defn hotspots-fn
   "Returns a function that identifies allocation hotspots by call-site and object type.

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -250,7 +250,8 @@
 
 (defn- build-treemap-node
   "Build a treemap node with children, computing values bottom-up.
-  Leaf nodes in the hierarchy have {:count N :bytes M} structure."
+  Leaf nodes in the hierarchy have {:count N :bytes M :freed-count K :freed-bytes L}.
+  Leaf nodes in output preserve all stats for tooltips."
   [name children-map size-by]
   (if (empty? children-map)
     {:name name :value 0}
@@ -258,11 +259,15 @@
                            (if (and (map? child-data)
                                     (contains? child-data :count)
                                     (contains? child-data :bytes))
-                             ;; Leaf node with :count/:bytes
+                             ;; Leaf node with stats - preserve them
                              {:name child-name
                               :value (compute-value (long (:count child-data))
                                                     (long (:bytes child-data))
-                                                    size-by)}
+                                                    size-by)
+                              :bytes (:bytes child-data)
+                              :count (:count child-data)
+                              :freed-bytes (:freed-bytes child-data 0)
+                              :freed-count (:freed-count child-data 0)}
                              ;; Intermediate node - recurse
                              (build-treemap-node child-name child-data size-by)))
                          children-map)
@@ -274,7 +279,7 @@
 
 (defn- group-by-hierarchy
   "Group records into nested maps according to hierarchy.
-  Returns nested maps where leaves have {:count N :bytes M}."
+  Returns nested maps where leaves have {:count N :bytes M :freed-count K :freed-bytes L}."
   [records group-by-opt]
   (let [extract-keys (case group-by-opt
                        :class→line→type
@@ -300,12 +305,18 @@
     (reduce
      (fn [tree record]
        (let [[k1 k2 k3] (extract-keys record)
-             size (long (:object_size record 0))]
+             size (long (:object_size record 0))
+             freed? (:freed record)]
          (update-in tree [k1 k2 k3]
                     (fn [stats]
-                      (let [cnt (long (get stats :count 0))
-                            bts (long (get stats :bytes 0))]
-                        {:count (inc cnt) :bytes (+ bts size)})))))
+                      (let [stats (or stats {:count 0 :bytes 0
+                                             :freed-count 0 :freed-bytes 0})]
+                        (-> stats
+                            (update :count inc)
+                            (update :bytes + size)
+                            (cond->
+                              freed? (-> (update :freed-count inc)
+                                         (update :freed-bytes + size)))))))))
      {}
      records)))
 

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -10,13 +10,38 @@
 
 ;;; Helper functions
 
-(defn- call-site
-  "Extract call-site map from an allocation record."
+(defn- useful-string?
+  "Check if a string contains useful information."
+  [s]
+  (and (string? s) (seq s)))
+
+(defn- call-site-key
+  "Extract call-site key for grouping from an allocation record.
+  Falls back to alloc-* fields when call-* fields are not useful.
+  When neither has useful class info, uses object-type as fallback."
   [record]
-  {:call-class  (:call-class record)
-   :call-method (:call-method record)
-   :call-file   (:call-file record)
-   :call-line   (:call-line record)})
+  (let [call-class (:call-class record)
+        alloc-class (:alloc-class record)
+        call-useful? (useful-string? call-class)
+        alloc-useful? (useful-string? alloc-class)]
+    (cond
+      call-useful?
+      {:call-class  call-class
+       :call-method (:call-method record)
+       :call-file   (:call-file record)
+       :call-line   (:call-line record)}
+
+      alloc-useful?
+      {:call-class  alloc-class
+       :call-method (:alloc-method record)
+       :call-file   (:alloc-file record)
+       :call-line   (:alloc-line record)}
+
+      :else
+      {:call-class  (:object-type record)
+       :call-method nil
+       :call-file   nil
+       :call-line   nil})))
 
 ;;; Analysis Functions
 
@@ -51,7 +76,7 @@
                result (reduce
                        (fn [acc record]
                          (let [size (long (:object_size record 0))
-                               freed? (:freed record)]
+                               freed? (pos? (long (:freed record 0)))]
                            (-> acc
                                (update :total-allocated + size)
                                (update :num-allocations inc)
@@ -86,10 +111,13 @@
     :type     - :criterium/allocation-hotspots
     :hotspots - Vector of maps sorted by bytes descending:
                 [{:call-site {:call-class ... :call-method ... :call-file ... :call-line ...}
+                  :object-types #{\"Ljava/lang/String;\" ...}
                   :count N
                   :bytes M
                   :freed-count K
-                  :freed-bytes L} ...]"
+                  :freed-bytes L} ...]
+
+  Note: When call-* fields are empty, alloc-* fields are used as fallback."
   ([] (hotspots-fn {}))
   ([{:keys [id trace-id limit order-by]}]
    (fn [data-map]
@@ -104,16 +132,19 @@
                ;; Group by call-site and aggregate
                grouped (reduce
                         (fn [acc record]
-                          (let [site (call-site record)
+                          (let [site (call-site-key record)
+                                obj-type (:object-type record)
                                 size (long (:object_size record 0))
-                                freed? (:freed record)]
+                                freed? (pos? (long (:freed record 0)))]
                             (update acc site
                                     (fn [stats]
                                       (let [stats (or stats {:count 0 :bytes 0
-                                                             :freed-count 0 :freed-bytes 0})]
+                                                             :freed-count 0 :freed-bytes 0
+                                                             :object-types #{}})]
                                         (-> stats
                                             (update :count inc)
                                             (update :bytes + size)
+                                            (update :object-types conj obj-type)
                                             (cond->
                                               freed? (-> (update :freed-count inc)
                                                          (update :freed-bytes + size)))))))))
@@ -160,7 +191,7 @@
                         (fn [acc record]
                           (let [obj-type (:object-type record)
                                 size (long (:object_size record 0))
-                                freed? (:freed record)]
+                                freed? (pos? (long (:freed record 0)))]
                             (update acc obj-type
                                     (fn [stats]
                                       (let [stats (or stats {:count 0 :bytes 0

--- a/bases/criterium/src/criterium/allocation/analysis.clj
+++ b/bases/criterium/src/criterium/allocation/analysis.clj
@@ -76,7 +76,7 @@
                result (reduce
                        (fn [acc record]
                          (let [size (long (:object_size record 0))
-                               freed? (pos? (long (:freed record 0)))]
+                               freed? (:freed record)]
                            (-> acc
                                (update :total-allocated + size)
                                (update :num-allocations inc)
@@ -135,7 +135,7 @@
                           (let [site (call-site-key record)
                                 obj-type (:object-type record)
                                 size (long (:object_size record 0))
-                                freed? (pos? (long (:freed record 0)))]
+                                freed? (:freed record)]
                             (update acc site
                                     (fn [stats]
                                       (let [stats (or stats {:count 0 :bytes 0
@@ -191,7 +191,7 @@
                         (fn [acc record]
                           (let [obj-type (:object-type record)
                                 size (long (:object_size record 0))
-                                freed? (pos? (long (:freed record 0)))]
+                                freed? (:freed record)]
                             (update acc obj-type
                                     (fn [stats]
                                       (let [stats (or stats {:count 0 :bytes 0

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -44,25 +44,25 @@
   ([] (transform-log {}))
   ([{:keys [id samples-id metric-ids] :as options}]
    (fn transform-log [data-map]
-     (let [samples-id      (or samples-id :samples)
-           id              (or id (keyword (str "log-" (name samples-id))))
+     (let [samples-id (or samples-id :samples)
+           id (or id (keyword (str "log-" (name samples-id))))
            metrics-samples (have types/generic-data-map? (data-map samples-id))
-           metrics-defs    (-> (:metrics-defs metrics-samples)
-                               (metric/select-metrics metric-ids)
-                               (metric/filter-metrics
-                                (every-pred
-                                 (metric/type-pred :quantitative)
-                                 (metric/dimension-pred :time))))
-           metric-configs  (metric/all-metric-configs metrics-defs)
-           transformed     (->
-                            (methods/transform
-                             metrics-samples
-                             metric-configs
-                             log
-                             exp
-                             options)
-                            (merge
-                             {:source-id samples-id :metrics-defs metrics-defs}))]
+           metrics-defs (-> (:metrics-defs metrics-samples)
+                            (metric/select-metrics metric-ids)
+                            (metric/filter-metrics
+                             (every-pred
+                              (metric/type-pred :quantitative)
+                              (metric/dimension-pred :time))))
+           metric-configs (metric/all-metric-configs metrics-defs)
+           transformed (->
+                        (methods/transform
+                         metrics-samples
+                         metric-configs
+                         log
+                         exp
+                         options)
+                        (merge
+                         {:source-id samples-id :metrics-defs metrics-defs}))]
        (assoc data-map id transformed)))))
 
 (defn quantiles
@@ -93,25 +93,25 @@
   ([{:keys [id samples-id metric-ids] :as analysis}]
    (fn quantiles [data-map]
      {:pre [(have? types/result-map? data-map)]}
-     (let [samples-id      (or samples-id :samples)
-           id              (or id :quantiles)
+     (let [samples-id (or samples-id :samples)
+           id (or id :quantiles)
            metrics-samples (data-map samples-id)
-           metrics-defs    (-> (:metrics-defs metrics-samples)
-                               (metric/select-metrics metric-ids)
-                               (metric/filter-metrics
-                                (metric/type-pred :quantitative)))
-           metric-configs  (metric/all-metric-configs metrics-defs)
-           quantiles       (methods/quantiles
-                            metrics-samples
-                            metric-configs
-                            analysis)
-           quantiles-map   (have
-                            types/quantiles-map?
-                            (merge
-                             {:type         :criterium/quantiles
-                              :source-id    samples-id
-                              :metrics-defs metrics-defs}
-                             quantiles))]
+           metrics-defs (-> (:metrics-defs metrics-samples)
+                            (metric/select-metrics metric-ids)
+                            (metric/filter-metrics
+                             (metric/type-pred :quantitative)))
+           metric-configs (metric/all-metric-configs metrics-defs)
+           quantiles (methods/quantiles
+                      metrics-samples
+                      metric-configs
+                      analysis)
+           quantiles-map (have
+                          types/quantiles-map?
+                          (merge
+                           {:type :criterium/quantiles
+                            :source-id samples-id
+                            :metrics-defs metrics-defs}
+                           quantiles))]
        (assoc data-map id quantiles-map)))))
 
 (defn outliers
@@ -150,29 +150,29 @@
   ([] (outliers {}))
   ([{:keys [id samples-id quantiles-id metric-ids]}]
    (fn [data-map]
-     (let [id              (or id :outliers)
-           quantiles-id    (or quantiles-id :quantiles)
-           samples-id      (or samples-id :samples)
-           all-quantiles   (have (data-map quantiles-id))
+     (let [id (or id :outliers)
+           quantiles-id (or quantiles-id :quantiles)
+           samples-id (or samples-id :samples)
+           all-quantiles (have (data-map quantiles-id))
            metrics-samples (have (data-map samples-id))
-           metrics-defs    (-> (:metrics-defs all-quantiles)
-                               (metric/select-metrics metric-ids))
-           metric-configs  (metric/all-metric-configs metrics-defs)]
+           metrics-defs (-> (:metrics-defs all-quantiles)
+                            (metric/select-metrics metric-ids))
+           metric-configs (metric/all-metric-configs metrics-defs)]
        (when-not all-quantiles
          (throw (ex-info
                  "outlier analysis requires quantiles analysis"
-                 {:quantiles-id  quantiles-id
+                 {:quantiles-id quantiles-id
                   :available-ids (keys data-map)})))
-       (let [outliers     (methods/outliers
-                           metrics-samples
-                           all-quantiles
-                           metric-configs
-                           {})
+       (let [outliers (methods/outliers
+                       metrics-samples
+                       all-quantiles
+                       metric-configs
+                       {})
              outliers-map (have
                            types/outliers-map?
                            (merge
-                            {:type         :criterium/outliers
-                             :source-id    samples-id
+                            {:type :criterium/outliers
+                             :source-id samples-id
                              :quantiles-id quantiles-id
                              :metrics-defs metrics-defs}
                             outliers))]
@@ -207,34 +207,34 @@
   ;; Returns {:mean 100.0 :variance 16.0 ...}"
   ([] (stats {}))
   ([{:keys [id samples-id outliers-id metric-ids]
-     :as   analysis}]
-   (let [samples-id  (or samples-id :samples)
-         id          (or id :stats)
+     :as analysis}]
+   (let [samples-id (or samples-id :samples)
+         id (or id :stats)
          outliers-id (or outliers-id :outliers)]
      (fn [data-map]
        (debug/dtap> {:stats id})
-       (let [outliers        (when outliers-id
-                               (data-map outliers-id))
+       (let [outliers (when outliers-id
+                        (data-map outliers-id))
              metrics-samples (have (data-map samples-id))
-             metrics-defs    (-> (have (:metrics-defs metrics-samples))
-                                 (metric/select-metrics metric-ids)
-                                 (metric/filter-metrics
-                                  (metric/type-pred :quantitative)))
-             metric-configs  (metric/all-metric-configs metrics-defs)
-             stats           (methods/stats
-                              metrics-samples
-                              outliers
-                              metric-configs
-                              analysis)
-             stats-map       (have
-                              types/stats-map?
-                              (merge
-                               {:type         :criterium/stats
-                                :metrics-defs metrics-defs
-                                :source-id    samples-id
-                                :outliers-id  outliers-id
-                                :batch-size   (:batch-size metrics-samples)}
-                               stats))]
+             metrics-defs (-> (have (:metrics-defs metrics-samples))
+                              (metric/select-metrics metric-ids)
+                              (metric/filter-metrics
+                               (metric/type-pred :quantitative)))
+             metric-configs (metric/all-metric-configs metrics-defs)
+             stats (methods/stats
+                    metrics-samples
+                    outliers
+                    metric-configs
+                    analysis)
+             stats-map (have
+                        types/stats-map?
+                        (merge
+                         {:type :criterium/stats
+                          :metrics-defs metrics-defs
+                          :source-id samples-id
+                          :outliers-id outliers-id
+                          :batch-size (:batch-size metrics-samples)}
+                         stats))]
          (assoc data-map id stats-map))))))
 
 (defn event-stats
@@ -265,26 +265,26 @@
   ;; Returns {:compilation {:time-ms 8 :sample-count 2} ...}"
   ([] (event-stats {}))
   ([{:keys [id samples-id metric-ids] :as analysis}]
-   (let [id         (or id :event-stats)
+   (let [id (or id :event-stats)
          samples-id (or samples-id :samples)]
      (fn [data-map]
        (debug/dtap> {:event-stats id})
        (let [metrics-samples (data-map samples-id)
-             metrics-defs    (-> (:metrics-defs metrics-samples)
-                                 (metric/select-metrics metric-ids)
-                                 (metric/filter-metrics
-                                  (metric/type-pred :event)))
-             event-stats     (methods/event-stats
-                              metrics-samples
-                              metrics-defs
-                              analysis)
-             es-map          (have
-                              types/event-stats-map?
-                              (merge
-                               {:type         :criterium/event-stats
-                                :source-id    samples-id
-                                :metrics-defs metrics-defs}
-                               event-stats))]
+             metrics-defs (-> (:metrics-defs metrics-samples)
+                              (metric/select-metrics metric-ids)
+                              (metric/filter-metrics
+                               (metric/type-pred :event)))
+             event-stats (methods/event-stats
+                          metrics-samples
+                          metrics-defs
+                          analysis)
+             es-map (have
+                     types/event-stats-map?
+                     (merge
+                      {:type :criterium/event-stats
+                       :source-id samples-id
+                       :metrics-defs metrics-defs}
+                      event-stats))]
          (assoc data-map id es-map))))))
 
 (defn histogram
@@ -310,36 +310,36 @@
     (get-in result [:histogram :elapsed-time]))"
   ([] (histogram {}))
   ([{:keys [id samples-id quantiles-id outliers-id metric-ids]
-     :as   analysis}]
-   (let [samples-id   (or samples-id :samples)
-         id           (or id :histograms)
+     :as analysis}]
+   (let [samples-id (or samples-id :samples)
+         id (or id :histograms)
          quantiles-id (or quantiles-id :quantiles)
-         outliers-id  (or outliers-id :outliers)]
+         outliers-id (or outliers-id :outliers)]
      (fn [data-map]
-       (let [outliers        (when outliers-id
-                               (data-map outliers-id))
-             quantiles       (util/lookup-data data-map quantiles-id)
+       (let [outliers (when outliers-id
+                        (data-map outliers-id))
+             quantiles (util/lookup-data data-map quantiles-id)
              metrics-samples (util/lookup-data data-map samples-id)
-             metrics-defs    (-> (have (:metrics-defs metrics-samples))
-                                 (metric/select-metrics metric-ids)
-                                 (metric/filter-metrics
-                                  (metric/type-pred :quantitative)))
-             metric-configs  (metric/all-metric-configs metrics-defs)
-             histogram       (methods/histogram
-                              metrics-samples
-                              quantiles
-                              outliers
-                              metric-configs
-                              analysis)
-             histogram-map   (have
-                              types/histogram-map?
-                              (merge
-                               {:type         :criterium/histogram
-                                :metrics-defs metrics-defs
-                                :source-id    samples-id
-                                :outliers-id  outliers-id
-                                :batch-size   (:batch-size metrics-samples)}
-                               histogram))]
+             metrics-defs (-> (have (:metrics-defs metrics-samples))
+                              (metric/select-metrics metric-ids)
+                              (metric/filter-metrics
+                               (metric/type-pred :quantitative)))
+             metric-configs (metric/all-metric-configs metrics-defs)
+             histogram (methods/histogram
+                        metrics-samples
+                        quantiles
+                        outliers
+                        metric-configs
+                        analysis)
+             histogram-map (have
+                            types/histogram-map?
+                            (merge
+                             {:type :criterium/histogram
+                              :metrics-defs metrics-defs
+                              :source-id samples-id
+                              :outliers-id outliers-id
+                              :batch-size (:batch-size metrics-samples)}
+                             histogram))]
          (assoc data-map id histogram-map))))))
 
 (defn- min-f
@@ -377,27 +377,27 @@
   (if (or (zero? variance) (< batch-size 16))
     0
     (let [variance-block (* batch-size variance)
-          std-dev-block  (Math/sqrt variance-block)
-          mean-g-min     (/ mean 2)
-          sigma-g        (min (/ mean-g-min 4)
-                              (/ std-dev-block (Math/sqrt batch-size)))
-          variance-g     (* sigma-g sigma-g)
+          std-dev-block (Math/sqrt variance-block)
+          mean-g-min (/ mean 2)
+          sigma-g (min (/ mean-g-min 4)
+                       (/ std-dev-block (Math/sqrt batch-size)))
+          variance-g (* sigma-g sigma-g)
           batch-size-sqr (util/sqr batch-size)
-          c-max-f        (fn ^long [^double t-min]    ; Eq 38
-                           (let [j0-sqr (util/sqr (- mean t-min))
-                                 k0     (- (* batch-size-sqr j0-sqr))
-                                 k1     (+ variance-block
-                                           (- (* batch-size variance-g))
-                                           (* batch-size j0-sqr))
-                                 det    (- (* k1 k1)
-                                           (* 4 variance-g k0))]
-                             (long (Math/floor (/ (* -2 k0)
-                                                  (+ k1 (Math/sqrt det)))))))
-          var-out        (fn ^double [^long c]        ; Eq 45
-                           (let [nmc (- batch-size c)]
-                             (* (/ nmc (double batch-size))
-                                (- variance-block (* nmc variance-g)))))
-          c-max          (min-f c-max-f 0.0 mean-g-min)]
+          c-max-f (fn ^long [^double t-min] ; Eq 38
+                    (let [j0-sqr (util/sqr (- mean t-min))
+                          k0 (- (* batch-size-sqr j0-sqr))
+                          k1 (+ variance-block
+                                (- (* batch-size variance-g))
+                                (* batch-size j0-sqr))
+                          det (- (* k1 k1)
+                                 (* 4 variance-g k0))]
+                      (long (Math/floor (/ (* -2 k0)
+                                           (+ k1 (Math/sqrt det)))))))
+          var-out (fn ^double [^long c] ; Eq 45
+                    (let [nmc (- batch-size c)]
+                      (* (/ nmc (double batch-size))
+                         (- variance-block (* nmc variance-g)))))
+          c-max (min-f c-max-f 0.0 mean-g-min)]
       (/ (min-f var-out 1.0 c-max) variance-block))))
 
 (defn outlier-effect
@@ -405,23 +405,23 @@
   [^double significance]
   (cond
     (< significance 0.01) :unaffected
-    (< significance 0.1)  :slight
-    (< significance 0.5)  :moderate
-    :else                 :severe))
+    (< significance 0.1) :slight
+    (< significance 0.5) :moderate
+    :else :severe))
 
 (defn- samples-outlier-significance [batch-size outliers stats metric-configs]
   (reduce
    (fn sample-m [result metric]
-     (let [path           (:path metric)
-           outlier-data   (get-in outliers path)
-           stat           (get-in stats path)
-           _              (assert (map? outlier-data) outlier-data)
+     (let [path (:path metric)
+           outlier-data (get-in outliers path)
+           stat (get-in stats path)
+           _ (assert (map? outlier-data) outlier-data)
            outlier-counts (:outlier-counts outlier-data)
-           significance   (when (some pos? (vals outlier-counts))
-                            (outlier-significance*
-                             (:mean stat)
-                             (:variance stat)
-                             batch-size))]
+           significance (when (some pos? (vals outlier-counts))
+                          (outlier-significance*
+                           (:mean stat)
+                           (:variance stat)
+                           batch-size))]
        (update-in result path
                   assoc
                   :significance significance
@@ -465,34 +465,34 @@
   ([] (outlier-significance {}))
   ([{:keys [id outliers-id stats-id metric-ids] :as _analysis}]
    (fn [data-map]
-     (let [id             (or id :outlier-significance)
-           outliers-id    (or outliers-id :outliers)
-           stats-id       (or stats-id :stats)
-           outliers       (data-map outliers-id)
-           stats          (data-map stats-id)
-           metrics-defs   (-> (:metrics-defs stats)
-                              (metric/select-metrics metric-ids)
-                              (metric/filter-metrics
-                               (metric/type-pred :quantitative)))
+     (let [id (or id :outlier-significance)
+           outliers-id (or outliers-id :outliers)
+           stats-id (or stats-id :stats)
+           outliers (data-map outliers-id)
+           stats (data-map stats-id)
+           metrics-defs (-> (:metrics-defs stats)
+                            (metric/select-metrics metric-ids)
+                            (metric/filter-metrics
+                             (metric/type-pred :quantitative)))
            metric-configs (metric/all-metric-configs metrics-defs)]
        (when-not outliers
          (throw (ex-info
                  "outlier significance requires outlier analysis"
-                 {:outliers-id   outliers-id
+                 {:outliers-id outliers-id
                   :available-ids (keys data-map)})))
        (let [significance (samples-outlier-significance
                            (:batch-size stats)
                            (util/outliers outliers)
                            (util/stats stats)
                            metric-configs)
-             os-map       (have
-                           types/outlier-significance-map?
-                           {:type                 :criterium/outlier-significance
-                            :transform            collect-plan/identity-transforms
-                            :outlier-significance significance
-                            :metrics-defs         metrics-defs
-                            :outliers-id          outliers-id
-                            :source-id            stats-id})]
+             os-map (have
+                     types/outlier-significance-map?
+                     {:type :criterium/outlier-significance
+                      :transform collect-plan/identity-transforms
+                      :outlier-significance significance
+                      :metrics-defs metrics-defs
+                      :outliers-id outliers-id
+                      :source-id stats-id})]
          (assoc data-map id os-map))))))
 
 ;;; Allocation Analysis
@@ -540,3 +540,20 @@
   ([] (allocation-by-type {}))
   ([opts]
    (allocation-analysis/by-type-fn opts)))
+
+(defn allocation-treemap
+  "Transforms allocation records into hierarchical treemap data.
+
+  Delegates to criterium.allocation.analysis/treemap-fn. Returns data-map
+  unchanged if allocation trace is not present (no-op behavior).
+
+  Parameters:
+    opts - Optional map with keys:
+      :id        - Key for result in output (default: :allocation-treemap)
+      :trace-id  - Path for source trace in input (default: [:samples :allocation-trace])
+      :group-by  - Hierarchy: :class→line→type or :type→class→line (default: :class→line→type)
+      :size-by   - Value sizing: :count, :bytes, :bytes-per-allocation (default: :bytes)
+      :filter-by - Filter: :freed, :not-freed, :all (default: :all)"
+  ([] (allocation-treemap {}))
+  ([opts]
+   (allocation-analysis/treemap-fn opts)))

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -506,7 +506,7 @@
   Parameters:
     opts - Optional map with keys:
       :id       - Key for result in output (default: :allocation-summary)
-      :trace-id - Key for source trace in input (default: :allocation-trace)"
+      :trace-id - Path for source trace in input (default: [:samples :allocation-trace])"
   ([] (allocation-summary {}))
   ([opts]
    (allocation-analysis/summary-fn opts)))
@@ -520,7 +520,7 @@
   Parameters:
     opts - Optional map with keys:
       :id       - Key for result in output (default: :allocation-hotspots)
-      :trace-id - Key for source trace in input (default: :allocation-trace)
+      :trace-id - Path for source trace in input (default: [:samples :allocation-trace])
       :limit    - Maximum number of hotspots to return (default: 10)
       :order-by - Sort key, :bytes or :count (default: :bytes)"
   ([] (allocation-hotspots {}))
@@ -536,7 +536,7 @@
   Parameters:
     opts - Optional map with keys:
       :id       - Key for result in output (default: :allocation-by-type)
-      :trace-id - Key for source trace in input (default: :allocation-trace)"
+      :trace-id - Path for source trace in input (default: [:samples :allocation-trace])"
   ([] (allocation-by-type {}))
   ([opts]
    (allocation-analysis/by-type-fn opts)))

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -1,5 +1,6 @@
 (ns criterium.analyse
   (:require
+   [criterium.allocation.analysis :as allocation-analysis]
    [criterium.analyse.digest-samples]
    [criterium.analyse.methods :as methods]
    [criterium.analyse.metrics-samples]
@@ -493,3 +494,49 @@
                             :outliers-id          outliers-id
                             :source-id            stats-id})]
          (assoc data-map id os-map))))))
+
+;;; Allocation Analysis
+
+(defn allocation-summary
+  "Computes allocation summary statistics from an allocation trace.
+
+  Delegates to criterium.allocation.analysis/summary-fn. Returns data-map
+  unchanged if allocation trace is not present (no-op behavior).
+
+  Parameters:
+    opts - Optional map with keys:
+      :id       - Key for result in output (default: :allocation-summary)
+      :trace-id - Key for source trace in input (default: :allocation-trace)"
+  ([] (allocation-summary {}))
+  ([opts]
+   (allocation-analysis/summary-fn opts)))
+
+(defn allocation-hotspots
+  "Identifies allocation hotspots by call-site from an allocation trace.
+
+  Delegates to criterium.allocation.analysis/hotspots-fn. Returns data-map
+  unchanged if allocation trace is not present (no-op behavior).
+
+  Parameters:
+    opts - Optional map with keys:
+      :id       - Key for result in output (default: :allocation-hotspots)
+      :trace-id - Key for source trace in input (default: :allocation-trace)
+      :limit    - Maximum number of hotspots to return (default: 10)
+      :order-by - Sort key, :bytes or :count (default: :bytes)"
+  ([] (allocation-hotspots {}))
+  ([opts]
+   (allocation-analysis/hotspots-fn opts)))
+
+(defn allocation-by-type
+  "Groups allocations by object type from an allocation trace.
+
+  Delegates to criterium.allocation.analysis/by-type-fn. Returns data-map
+  unchanged if allocation trace is not present (no-op behavior).
+
+  Parameters:
+    opts - Optional map with keys:
+      :id       - Key for result in output (default: :allocation-by-type)
+      :trace-id - Key for source trace in input (default: :allocation-trace)"
+  ([] (allocation-by-type {}))
+  ([opts]
+   (allocation-analysis/by-type-fn opts)))

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -136,7 +136,7 @@
           ;; Collect allocation trace if requested
           data-map (if with-allocation?
                      (if-let [trace (collect-allocation-trace measured)]
-                       (assoc data-map :allocation-trace trace)
+                       (assoc-in data-map [:samples :allocation-trace] trace)
                        data-map)
                      data-map)
           ;; Apply analysis (allocation analysis no-ops when trace absent)

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -28,6 +28,7 @@
    [criterium.collect-plan :as collect-plan]
    [criterium.collector :as collector]
    [criterium.measured :as measured]
+   [criterium.util.blackhole :as blackhole]
    [criterium.util.output :as output]))
 
 (defn default-viewer
@@ -112,9 +113,10 @@
 (defn- collect-allocation-trace
   "Collect allocation trace by running measured once with tracing enabled."
   [measured]
-  (let [state (measured/args measured)
-        [trace _] (allocation/with-allocation-trace {:eval-count 1}
-                    (measured/invoke measured state 1))]
+  (let [state         (measured/args measured)
+        [trace value] (allocation/with-allocation-trace {:eval-count 1}
+                        (measured/invoke measured state 1))]
+    (blackhole/consume value)
     trace))
 
 (defn bench-measured

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -20,6 +20,8 @@
   (bench (+ 1 1) :viewer :pprint) ; With pretty-printed output
   (set-default-viewer! :kindly)   ; Set default for all bench calls"
   (:require
+   [criterium.allocation :as allocation]
+   [criterium.allocation.analysis :as allocation-analysis]
    [criterium.analyse]
    [criterium.bench.config :as bench-config]
    [criterium.bench.impl :as impl]
@@ -108,6 +110,24 @@
   [config bench-map]
   (get-in bench-map (:return-value config)))
 
+(defn- collect-allocation-trace
+  "Collect allocation trace by running measured once with tracing enabled."
+  [measured]
+  (let [state (measured/args measured)
+        [trace _] (allocation/with-allocation-trace {:eval-count 1}
+                    (measured/invoke measured state 1))]
+    trace))
+
+(def ^:private default-allocation-analyse
+  [[:summary-fn {}]
+   [:hotspots-fn {:limit 10}]
+   [:by-type-fn {}]])
+
+(def ^:private default-allocation-view
+  [:allocation-summary
+   :allocation-hotspots
+   :allocation-by-type])
+
 (defn bench-measured
   "Evaluate measured and output the benchmark time.
 
@@ -119,11 +139,30 @@
   Takes a bench-plan that fully specifies the benchmark behaviour."
   [bench-plan measured]
   (output/with-progress-reporting (:verbose bench-plan)
-    (let [data-map (->> (collect-data-map
-                         (:collector-config bench-plan)
-                         (:collect-plan bench-plan) measured)
-                        (analyze (:analyse bench-plan)))
-          viewer-output (view (:view bench-plan) (:viewer bench-plan) data-map)
+    (let [with-allocation? (:with-allocation-trace bench-plan)
+          ;; Collect metrics
+          data-map (collect-data-map
+                    (:collector-config bench-plan)
+                    (:collect-plan bench-plan) measured)
+          ;; Collect allocation trace if requested
+          data-map (if with-allocation?
+                     (if-let [trace (collect-allocation-trace measured)]
+                       (assoc data-map :allocation-trace trace)
+                       data-map)
+                     data-map)
+          ;; Apply standard analysis
+          data-map (analyze (:analyse bench-plan) data-map)
+          ;; Apply allocation analysis if trace present
+          data-map (if (:allocation-trace data-map)
+                     ((allocation-analysis/->allocation-analyse
+                       default-allocation-analyse)
+                      data-map)
+                     data-map)
+          ;; Run views - include allocation views if trace present
+          view-plan (if (:allocation-trace data-map)
+                      (into (vec (:view bench-plan)) default-allocation-view)
+                      (:view bench-plan))
+          viewer-output (view view-plan (:viewer bench-plan) data-map)
           ;; Store viewer output as a proper data-entry-map
           data-map (assoc data-map :viewer
                           {:type :criterium/viewer-output
@@ -196,6 +235,9 @@
       :limit-time-s - Time limit in seconds (optional)
       :collect-plan - Sampling strategy (optional)
       :time-fn     - Custom timing function (optional)
+      :with-allocation-trace - When true, collect allocation trace and display
+                     allocation analysis (summary, hotspots, by-type). Requires
+                     the native agent to be attached. (optional)
 
   Returns:
   The value from evaluating the expression.

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -21,7 +21,6 @@
   (set-default-viewer! :kindly)   ; Set default for all bench calls"
   (:require
    [criterium.allocation :as allocation]
-   [criterium.allocation.analysis :as allocation-analysis]
    [criterium.analyse]
    [criterium.bench.config :as bench-config]
    [criterium.bench.impl :as impl]
@@ -118,16 +117,6 @@
                     (measured/invoke measured state 1))]
     trace))
 
-(def ^:private default-allocation-analyse
-  [[:summary-fn {}]
-   [:hotspots-fn {:limit 10}]
-   [:by-type-fn {}]])
-
-(def ^:private default-allocation-view
-  [:allocation-summary
-   :allocation-hotspots
-   :allocation-by-type])
-
 (defn bench-measured
   "Evaluate measured and output the benchmark time.
 
@@ -150,19 +139,10 @@
                        (assoc data-map :allocation-trace trace)
                        data-map)
                      data-map)
-          ;; Apply standard analysis
+          ;; Apply analysis (allocation analysis no-ops when trace absent)
           data-map (analyze (:analyse bench-plan) data-map)
-          ;; Apply allocation analysis if trace present
-          data-map (if (:allocation-trace data-map)
-                     ((allocation-analysis/->allocation-analyse
-                       default-allocation-analyse)
-                      data-map)
-                     data-map)
-          ;; Run views - include allocation views if trace present
-          view-plan (if (:allocation-trace data-map)
-                      (into (vec (:view bench-plan)) default-allocation-view)
-                      (:view bench-plan))
-          viewer-output (view view-plan (:viewer bench-plan) data-map)
+          ;; Run views (allocation views no-op when trace absent)
+          viewer-output (view (:view bench-plan) (:viewer bench-plan) data-map)
           ;; Store viewer output as a proper data-entry-map
           data-map (assoc data-map :viewer
                           {:type :criterium/viewer-output

--- a/bases/criterium/src/criterium/bench/config.clj
+++ b/bases/criterium/src/criterium/bench/config.clj
@@ -73,7 +73,8 @@
                         :view
                         :bench-plan
                         :verbose
-                        :viewer})
+                        :viewer
+                        :with-allocation-trace})
         limit-time-s (:limit-time-s options-map)
         analyse (:analyse options-map)
         view (:view options-map)
@@ -110,7 +111,7 @@
       (throw (ex-info "Unknown options" {:options unknown-keys})))
     (cond-> (assoc (select-keys
                     options-map
-                    [:return-value :verbose])
+                    [:return-value :verbose :with-allocation-trace])
                    :collect-plan collect-plan
                    :collector-config collector-config
                    :viewer viewer

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -2,67 +2,71 @@
   "Provide pre-configured benchmark definitions.")
 
 (def default-collector-config
-  {:stages     []
+  {:stages []
    :terminator :elapsed-time})
 
 (def default-one-shot
   {:collector-config default-collector-config
-   :analyse          [:event-stats
-                      :allocation-summary
-                      [:allocation-hotspots {:limit 10}]
-                      :allocation-by-type]
-   :view             [:metrics
-                      :event-stats
-                      :collect-plan
-                      :allocation-summary
-                      :allocation-by-type
-                      :allocation-hotspots]
-   :viewer           :print})
+   :analyse [:event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type]
+   :view [:metrics
+          :event-stats
+          :collect-plan
+          :allocation-summary
+          :allocation-by-type
+          :allocation-hotspots]
+   :viewer :print})
 
 (def default-with-warmup
   {:collector-config default-collector-config
-   :analyse          [:transform-log
-                      [:quantiles {:quantiles [0.9 0.99 0.99]}]
-                      :outliers
-                      [:stats {}]
-                      [:stats {:samples-id :log-samples :id :log-stats}]
-                      :event-stats
-                      :allocation-summary
-                      [:allocation-hotspots {:limit 10}]
-                      :allocation-by-type]
-   :view             [[:stats {:metric-ids [:memory]}]
-                      [:stats {:stats-id :log-stats}]
-                      :event-stats
-                      :collect-plan
-                      :allocation-summary
-                      :allocation-hotspots
-                      :allocation-by-type
-                      #_[:final-gc-warnings
-                         {:warn-threshold 0.01}]]
-   :viewer           :print})
+   :analyse [:transform-log
+             [:quantiles {:quantiles [0.9 0.99 0.99]}]
+             :outliers
+             [:stats {}]
+             [:stats {:samples-id :log-samples :id :log-stats}]
+             :event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type
+             :allocation-treemap]
+   :view [[:stats {:metric-ids [:memory]}]
+          [:stats {:stats-id :log-stats}]
+          :event-stats
+          :collect-plan
+          :allocation-summary
+          :allocation-hotspots
+          :allocation-by-type
+          :allocation-treemap
+          #_[:final-gc-warnings
+             {:warn-threshold 0.01}]]
+   :viewer :print})
 
 (def log-histogram
   {:collector-config default-collector-config
-   :analyse          [:transform-log
-                      [:quantiles {:quantiles [0.9 0.99 0.99]}]
-                      :outliers
-                      [:stats {}]
-                      [:stats {:samples-id :log-samples :id :log-stats}]
-                      :histogram
-                      :event-stats
-                      :allocation-summary
-                      [:allocation-hotspots {:limit 10}]
-                      :allocation-by-type]
-   :view             [[:stats {:metric-ids [:memory]}]
-                      [:stats {:stats-id :log-stats}]
-                      :quantiles
-                      :event-stats
-                      :outlier-counts
-                      :collect-plan
-                      [:histogram {:stats-id :log-stats}]
-                      :sample-percentiles
-                      :samples
-                      :allocation-summary
-                      :allocation-hotspots
-                      :allocation-by-type]
-   :viewer           :print})
+   :analyse [:transform-log
+             [:quantiles {:quantiles [0.9 0.99 0.99]}]
+             :outliers
+             [:stats {}]
+             [:stats {:samples-id :log-samples :id :log-stats}]
+             :histogram
+             :event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type
+             :allocation-treemap]
+   :view [[:stats {:metric-ids [:memory]}]
+          [:stats {:stats-id :log-stats}]
+          :quantiles
+          :event-stats
+          :outlier-counts
+          :collect-plan
+          [:histogram {:stats-id :log-stats}]
+          :sample-percentiles
+          :samples
+          :allocation-summary
+          :allocation-hotspots
+          :allocation-by-type
+          :allocation-treemap]
+   :viewer :print})

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -20,11 +20,17 @@
                       :outliers
                       [:stats {}]
                       [:stats {:samples-id :log-samples :id :log-stats}]
-                      :event-stats]
+                      :event-stats
+                      :allocation-summary
+                      [:allocation-hotspots {:limit 10}]
+                      :allocation-by-type]
    :view             [[:stats {:metric-ids [:memory]}]
                       [:stats {:stats-id :log-stats}]
                       :event-stats
                       :collect-plan
+                      :allocation-summary
+                      :allocation-hotspots
+                      :allocation-by-type
                       #_[:final-gc-warnings
                          {:warn-threshold 0.01}]]
    :viewer           :print})
@@ -37,7 +43,10 @@
                       [:stats {}]
                       [:stats {:samples-id :log-samples :id :log-stats}]
                       :histogram
-                      :event-stats]
+                      :event-stats
+                      :allocation-summary
+                      [:allocation-hotspots {:limit 10}]
+                      :allocation-by-type]
    :view             [[:stats {:metric-ids [:memory]}]
                       [:stats {:stats-id :log-stats}]
                       :quantiles
@@ -46,5 +55,8 @@
                       :collect-plan
                       [:histogram {:stats-id :log-stats}]
                       :sample-percentiles
-                      :samples]
+                      :samples
+                      :allocation-summary
+                      :allocation-hotspots
+                      :allocation-by-type]
    :viewer           :print})

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -7,10 +7,16 @@
 
 (def default-one-shot
   {:collector-config default-collector-config
-   :analyse          [:event-stats]
+   :analyse          [:event-stats
+                      :allocation-summary
+                      [:allocation-hotspots {:limit 10}]
+                      :allocation-by-type]
    :view             [:metrics
                       :event-stats
-                      :collect-plan]
+                      :collect-plan
+                      :allocation-summary
+                      :allocation-by-type
+                      :allocation-hotspots]
    :viewer           :print})
 
 (def default-with-warmup

--- a/bases/criterium/src/criterium/types.clj
+++ b/bases/criterium/src/criterium/types.clj
@@ -208,3 +208,16 @@
   [x]
   (and (map? x)
        (result-map? (:data x))))
+
+;;; Allocation trace types
+
+(def allocation-trace-map-keys
+  "Required keys for :criterium/allocation-trace type."
+  #{:type :records :thread-id :eval-count :elapsed-time})
+
+(defn allocation-trace?
+  "Check if x is an allocation trace map with :type :criterium/allocation-trace."
+  [x]
+  (and (map? x)
+       (= :criterium/allocation-trace (:type x))
+       (set/subset? allocation-trace-map-keys (set (keys x)))))

--- a/bases/criterium/src/criterium/view.clj
+++ b/bases/criterium/src/criterium/view.clj
@@ -36,6 +36,12 @@
 (def-multi-view samples)
 (def-multi-view stats)
 
+;;; Allocation Views
+
+(def-multi-view allocation-summary)
+(def-multi-view allocation-hotspots)
+(def-multi-view allocation-by-type)
+
 ;;; Domain Views
 
 (def-multi-view domain-extract)
@@ -63,6 +69,11 @@
 (defmethod collect-plan* :none [_ _ _])
 (defmethod samples* :none [_ _ _])
 (defmethod stats* :none [_ _ _])
+
+;; Allocation Null Viewer
+(defmethod allocation-summary* :none [_ _ _])
+(defmethod allocation-hotspots* :none [_ _ _])
+(defmethod allocation-by-type* :none [_ _ _])
 
 ;; Domain Null Viewer
 (defmethod domain-extract* :none [_ _ _])

--- a/bases/criterium/src/criterium/view.clj
+++ b/bases/criterium/src/criterium/view.clj
@@ -42,6 +42,8 @@
 (def-multi-view allocation-hotspots)
 (def-multi-view allocation-by-type)
 
+(def-multi-view allocation-treemap)
+
 ;;; Domain Views
 
 (def-multi-view domain-extract)
@@ -50,7 +52,7 @@
 (def-multi-view domain-regression)
 
 (defmulti flush-viewer (fn [viewer] viewer))
-(defmethod flush-viewer :default  [_])
+(defmethod flush-viewer :default [_])
 
 ;; Null Viewer
 
@@ -74,6 +76,8 @@
 (defmethod allocation-summary* :none [_ _ _])
 (defmethod allocation-hotspots* :none [_ _ _])
 (defmethod allocation-by-type* :none [_ _ _])
+
+(defmethod allocation-treemap* :none [_ _ _])
 
 ;; Domain Null Viewer
 (defmethod domain-extract* :none [_ _ _])

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -911,3 +911,136 @@
     (->> object-types
          sort
          (clojure.string/join ", "))))
+
+;;; ASCII Treemap rendering
+
+(defn ascii-bar
+  "Generate a bar of █ characters proportional to value/max-value.
+  Returns a string of at most `width` characters."
+  ^String [^double value ^double max-value ^long width]
+  (if (or (<= max-value 0) (<= value 0))
+    ""
+    (let [ratio (min 1.0 (/ value max-value))
+          bar-len (max 0 (long (Math/round (* ratio width))))]
+      (apply str (repeat bar-len \█)))))
+
+(defn- render-treemap-node
+  "Recursively render a treemap node.
+  Returns a vector of lines."
+  [node prefix is-last? max-value opts depth]
+  (let [{:keys [^long bar-width ^long name-width depth-limit ^double min-percent]}
+        opts
+        depth (long depth)
+        {:keys [name value children]} node
+        is-leaf? (empty? children)
+        connector (if is-last? "└── " "├── ")
+        continuation (if is-last? "    " "│   ")
+        node-name (if is-leaf? name (str name "/"))
+        size-str (str "[" (format/format-value :memory value) "]")
+        bar-str (when is-leaf?
+                  (ascii-bar (double value) max-value bar-width))
+        ;; Build the line: prefix + connector + name + padding + size + bar
+        name-part (str prefix connector node-name)
+        name-part-len (long (count name-part))
+        padded-name (if (< name-part-len name-width)
+                      (str name-part
+                           (apply str (repeat (- name-width name-part-len) \space)))
+                      name-part)
+        line (str padded-name " " size-str
+                  (when (seq bar-str) (str " " bar-str)))
+        current-line [line]
+        ;; Recurse into children if not at depth limit
+        child-prefix (str prefix continuation)
+        at-depth-limit? (and depth-limit (>= depth (long depth-limit)))]
+    (if (or is-leaf? at-depth-limit?)
+      current-line
+      (let [root-value (double (:root-value opts))
+            filtered-children (->> children
+                                   (filter (fn [child]
+                                             (>= (* 100.0 (/ (double (:value child))
+                                                             root-value))
+                                                 min-percent)))
+                                   (sort-by :value >))
+            num-children (long (count filtered-children))]
+        (into current-line
+              (mapcat (fn [idx child]
+                        (render-treemap-node
+                         child
+                         child-prefix
+                         (= (long idx) (dec num-children))
+                         max-value
+                         opts
+                         (inc depth)))
+                      (range)
+                      filtered-children))))))
+
+(defn render-ascii-treemap
+  "Render an allocation treemap as an ASCII tree string.
+  
+  treemap-data should be a :criterium/allocation-treemap map with :root, :group-by, :size-by.
+  
+  Options:
+    :bar-width   - max bar characters (default 20)
+    :depth-limit - max nesting depth to display, nil = unlimited (default nil)
+    :min-percent - hide nodes below this % of root total (default 1)
+    :name-width  - column width for names (default 40)"
+  ([treemap-data] (render-ascii-treemap treemap-data {}))
+  ([treemap-data opts]
+   (let [{:keys [root group-by size-by]} treemap-data
+         {:keys [bar-width depth-limit min-percent name-width]
+          :or {bar-width 20 min-percent 1.0 name-width 40}} opts
+         ^long name-width name-width]
+     (if (nil? root)
+       ""
+       (let [root-value (double (:value root))
+             max-leaf-value (if (empty? (:children root))
+                              root-value
+                              (->> (tree-seq :children :children root)
+                                   (remove :children)
+                                   (map :value)
+                                   (reduce max 0.0)
+                                   double))
+             size-by-str (case size-by
+                           :bytes "bytes"
+                           :count "count"
+                           :bytes-per-allocation "bytes/alloc"
+                           (name (or size-by :bytes)))
+             group-by-str (case group-by
+                            :class→line→type "class→line→type"
+                            :type→class→line "type→class→line"
+                            (name (or group-by :class→line→type)))
+             header (str "Allocation Treemap (by " size-by-str ", " group-by-str ")")
+             root-name (str (:name root) "/")
+             root-size (str "[" (format/format-value :memory root-value) "]")
+             root-line (let [name-part root-name
+                             name-part-len (long (count name-part))
+                             padded (if (< name-part-len name-width)
+                                      (str name-part
+                                           (apply str (repeat (- name-width name-part-len) \space)))
+                                      name-part)]
+                         (str padded " " root-size))
+             render-opts {:bar-width bar-width
+                          :depth-limit depth-limit
+                          :min-percent (double min-percent)
+                          :name-width name-width
+                          :root-value root-value}
+             children (:children root)
+             filtered-children (->> children
+                                    (filter (fn [child]
+                                              (>= (* 100.0 (/ (double (:value child))
+                                                              root-value))
+                                                  (double min-percent))))
+                                    (sort-by :value >))
+             num-children (long (count filtered-children))
+             child-lines (mapcat (fn [^long idx child]
+                                   (render-treemap-node
+                                    child
+                                    ""
+                                    (= idx (dec num-children))
+                                    max-leaf-value
+                                    render-opts
+                                    1))
+                                 (range)
+                                 filtered-children)]
+         (str/join "\n" (into [header root-line] child-lines)))))))
+

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -880,6 +880,25 @@
 
 (defn format-call-site
   "Format a call site map for display.
-  Returns a string like 'class.method (file:line)'."
-  [{:keys [call-class call-method call-file call-line]}]
-  (str call-class "." call-method " (" call-file ":" call-line ")"))
+  Returns a string like 'class.method (file:line)'.
+  When call-method is nil (object-type fallback), shows just the class.
+  When call-site is not useful but object-types provided, shows those."
+  ([call-site]
+   (format-call-site call-site nil))
+  ([{:keys [call-class call-method call-file call-line]} object-types]
+   (cond
+     ;; Full call-site info available
+     (and (seq call-class) (seq call-method))
+     (str call-class "." call-method " (" call-file ":" call-line ")")
+
+     ;; Object-type fallback (call-method is nil)
+     (and (seq call-class) (nil? call-method))
+     call-class
+
+     ;; No useful info, show object-types if available
+     (seq object-types)
+     (str "[" (clojure.string/join ", " (sort object-types)) "]")
+
+     ;; Last resort
+     :else
+     (str call-class "." call-method " (" call-file ":" call-line ")"))))

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -875,3 +875,11 @@
                        "model"    (:label model)}))
                   valid-data)))
         models)))))
+
+;;; Allocation view helpers
+
+(defn format-call-site
+  "Format a call site map for display.
+  Returns a string like 'class.method (file:line)'."
+  [{:keys [call-class call-method call-file call-line]}]
+  (str call-class "." call-method " (" call-file ":" call-line ")"))

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -924,6 +924,28 @@
           bar-len (max 0 (long (Math/round (* ratio width))))]
       (apply str (repeat bar-len \█)))))
 
+;;; Treemap box-drawing constants
+
+(def ^:private ^String tree-branch
+  "Branch connector for non-last children: ├── "
+  "\u251C\u2500\u2500 ")
+
+(def ^:private ^String tree-last
+  "Last child connector: └── "
+  "\u2514\u2500\u2500 ")
+
+(def ^:private ^String tree-vertical
+  "Vertical continuation line: │   "
+  "\u2502   ")
+
+(def ^:private ^String tree-space
+  "Space continuation (after last child): 4 spaces"
+  "    ")
+
+(def ^:private ^String ellipsis
+  "Ellipsis for truncated names: …"
+  "\u2026")
+
 (defn- render-treemap-node
   "Recursively render a treemap node.
   Returns a vector of lines."
@@ -933,20 +955,35 @@
         depth (long depth)
         {:keys [name value children]} node
         is-leaf? (empty? children)
-        connector (if is-last? "└── " "├── ")
-        continuation (if is-last? "    " "│   ")
+        connector (if is-last? tree-last tree-branch)
+        continuation (if is-last? tree-space tree-vertical)
         node-name (if is-leaf? name (str name "/"))
         size-str (str "[" (format/format-value :memory value) "]")
         bar-str (when is-leaf?
                   (ascii-bar (double value) max-value bar-width))
-        ;; Build the line: prefix + connector + name + padding + size + bar
-        name-part (str prefix connector node-name)
-        name-part-len (long (count name-part))
-        padded-name (if (< name-part-len name-width)
-                      (str name-part
-                           (apply str (repeat (- name-width name-part-len) \space)))
-                      name-part)
-        line (str padded-name " " size-str
+        ;; Keep prefix + connector intact, only truncate the name if needed
+        prefix-connector (str prefix connector)
+        prefix-len (long (count prefix-connector))
+        available-for-name (- name-width prefix-len)
+        node-name-len (long (count node-name))
+        ;; Truncate name from left if it exceeds available space
+        ;; Ensure at least 2 chars available (for ellipsis + 1 char)
+        truncated-name (cond
+                         (<= available-for-name 1)
+                         ellipsis
+
+                         (> node-name-len available-for-name)
+                         (str ellipsis (subs node-name (- node-name-len (dec available-for-name))))
+
+                         :else
+                         node-name)
+        truncated-name-len (long (count truncated-name))
+        ;; Pad to fill remaining space
+        padding-needed (max 0 (- available-for-name truncated-name-len))
+        padded-line (str prefix-connector truncated-name
+                         (when (pos? padding-needed)
+                           (apply str (repeat padding-needed \space))))
+        line (str padded-line " " size-str
                   (when (seq bar-str) (str " " bar-str)))
         current-line [line]
         ;; Recurse into children if not at depth limit
@@ -1012,12 +1049,18 @@
              header (str "Allocation Treemap (by " size-by-str ", " group-by-str ")")
              root-name (str (:name root) "/")
              root-size (str "[" (format/format-value :memory root-value) "]")
-             root-line (let [name-part root-name
-                             name-part-len (long (count name-part))
-                             padded (if (< name-part-len name-width)
-                                      (str name-part
-                                           (apply str (repeat (- name-width name-part-len) \space)))
-                                      name-part)]
+             ;; Format root line with same fixed-width treatment as children
+             root-name-len (long (count root-name))
+             root-line (let [padded (cond
+                                      (< root-name-len name-width)
+                                      (str root-name
+                                           (apply str (repeat (- name-width root-name-len) \space)))
+
+                                      (> root-name-len name-width)
+                                      (str ellipsis (subs root-name (- root-name-len (dec name-width))))
+
+                                      :else
+                                      root-name)]
                          (str padded " " root-size))
              render-opts {:bar-width bar-width
                           :depth-limit depth-limit

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -226,29 +226,29 @@
   - total-scale: base-scale * si-scale
   - unit: SI unit string (e.g., \"ms\", \"μs\")"
   [metric-path values]
-  (let [base-scale                 (metric-path->base-scale metric-path)
-        dimension                  (metric-path->dimension metric-path)
-        base-values                (when (seq values)
-                                     (map #(* (double %) base-scale) values))
-        representative-value       (when (seq base-values)
-                                     (/ (double (reduce + base-values))
-                                        (count base-values)))
+  (let [base-scale (metric-path->base-scale metric-path)
+        dimension (metric-path->dimension metric-path)
+        base-values (when (seq values)
+                      (map #(* (double %) base-scale) values))
+        representative-value (when (seq base-values)
+                               (/ (double (reduce + base-values))
+                                  (count base-values)))
         [^double si-scale si-unit] (if (and dimension representative-value)
                                      (format/scale
                                       dimension
                                       representative-value)
                                      [1 ""])]
-    {:base-scale  base-scale
-     :si-scale    si-scale
+    {:base-scale base-scale
+     :si-scale si-scale
      :total-scale (* base-scale si-scale)
-     :unit        si-unit}))
+     :unit si-unit}))
 
 (defn format-value-with-unit
   "Format a value from domain-extract as a string with SI units."
   [value metric-path]
   (when (some? value)
     (let [base-value (* (double value) (metric-path->base-scale metric-path))
-          dimension  (metric-path->dimension metric-path)]
+          dimension (metric-path->dimension metric-path)]
       (if dimension
         (format/format-value dimension base-value)
         (format "%g" (double base-value))))))
@@ -320,17 +320,17 @@
   [extract {:keys [header-sep] :or {header-sep " "}}]
   (when extract
     (let [impl-axis-key (:impl-axis extract)
-          multi-impl?   (> (count (:implementations extract)) 1)
-          metrics       (:metrics extract)
-          metric-ids    (sort (keys metrics))
+          multi-impl? (> (count (:implementations extract)) 1)
+          metrics (:metrics extract)
+          metric-ids (sort (keys metrics))
 
           ;; Collect all data points with their full coords
           all-data (for [[metric-id {:keys [metric data]}] metrics
-                         [coord value]                     data]
+                         [coord value] data]
                      {:metric-id metric-id
-                      :metric    metric
-                      :coord     coord
-                      :value     (get-numeric-value value)})
+                      :metric metric
+                      :coord coord
+                      :value (get-numeric-value value)})
 
           ;; Collect all coordinates to detect uniform axes
           all-coords (map :coord all-data)
@@ -338,15 +338,15 @@
           ;; Find axes with uniform values across all coords (e.g., :impl
           ;; :default)
           ;; Only use uniform axes if stripping them leaves at least one key
-          uniform-axes          (detect-uniform-axes all-coords)
-          first-coord           (first all-coords)
+          uniform-axes (detect-uniform-axes all-coords)
+          first-coord (first all-coords)
           remaining-after-strip (when (and (map? first-coord)
                                            (seq uniform-axes))
                                   (count
                                    (apply dissoc first-coord uniform-axes)))
-          use-uniform-axes?     (and (seq uniform-axes)
-                                     (some? remaining-after-strip)
-                                     (pos? (long remaining-after-strip)))
+          use-uniform-axes? (and (seq uniform-axes)
+                                 (some? remaining-after-strip)
+                                 (pos? (long remaining-after-strip)))
 
           ;; Determine row key: strip impl axis for multi-impl, or uniform axes
           row-key-fn (cond
@@ -366,8 +366,8 @@
 
           ;; Detect single-key pattern and sort appropriately
           single-key-info (single-key-coord-info raw-row-keys)
-          row-keys        (sort-row-keys raw-row-keys single-key-info)
-          coord-header    (coord-column-header single-key-info)
+          row-keys (sort-row-keys raw-row-keys single-key-info)
+          coord-header (coord-column-header single-key-info)
 
           impl-vals (when multi-impl?
                       (->> all-data
@@ -378,17 +378,17 @@
           ;; Build column specs: [{:metric-id :impl (optional)}...]
           col-specs (if multi-impl?
                       (for [metric-id metric-ids
-                            impl      impl-vals]
+                            impl impl-vals]
                         {:metric-id metric-id :impl impl})
                       (for [metric-id metric-ids]
                         {:metric-id metric-id}))
 
           ;; Build lookup: {[row-key metric-id impl?] -> value}
           lookup (reduce (fn [acc {:keys [metric-id coord value]}]
-                           (let [row-key    (row-key-fn coord)
-                                 impl-val   (when
-                                             multi-impl?
-                                              (get coord impl-axis-key))
+                           (let [row-key (row-key-fn coord)
+                                 impl-val (when
+                                           multi-impl?
+                                            (get coord impl-axis-key))
                                  lookup-key (if multi-impl?
                                               [row-key metric-id impl-val]
                                               [row-key metric-id])]
@@ -404,13 +404,13 @@
                   (let [{:keys [metric-id impl]}
                         col-spec
                         metric-path (get-in metrics [metric-id :metric])
-                        col-values  (for [row-key row-keys
-                                          :let    [lk (if multi-impl?
-                                                        [row-key metric-id impl]
-                                                        [row-key metric-id])
-                                                   v (get lookup lk)]
-                                          :when   (some? v)]
-                                      v)]
+                        col-values (for [row-key row-keys
+                                         :let [lk (if multi-impl?
+                                                    [row-key metric-id impl]
+                                                    [row-key metric-id])
+                                               v (get lookup lk)]
+                                         :when (some? v)]
+                                     v)]
                     [col-spec (compute-si-scaling metric-path col-values)])))
            col-specs)
 
@@ -420,10 +420,10 @@
                   (let [{:keys [metric-id impl]}
                         col-spec
                         {:keys [unit]} (get col-scales col-spec)
-                        metric-name    (name metric-id)
-                        header-base    (if (seq unit)
-                                         (str metric-name " (" unit ")")
-                                         metric-name)]
+                        metric-name (name metric-id)
+                        header-base (if (seq unit)
+                                      (str metric-name " (" unit ")")
+                                      metric-name)]
                     (if multi-impl?
                       (str (name impl) header-sep header-base)
                       header-base)))
@@ -438,13 +438,13 @@
                          (fn [idx col-spec]
                            (let [{:keys [metric-id impl]}
                                  col-spec
-                                 lk        (if multi-impl?
-                                             [row-key metric-id impl]
-                                             [row-key metric-id])
+                                 lk (if multi-impl?
+                                      [row-key metric-id impl]
+                                      [row-key metric-id])
                                  raw-value (get lookup lk)
                                  {:keys [^double total-scale]}
                                  (get col-scales col-spec)
-                                 header    (nth col-headers idx)]
+                                 header (nth col-headers idx)]
                              [header (when raw-value
                                        (format
                                         "%.3g"
@@ -452,10 +452,10 @@
                          col-specs)))
                 row-keys)]
 
-      {:heading      "Domain Extract"
+      {:heading "Domain Extract"
        :coord-header coord-header
-       :col-headers  col-headers
-       :rows         table-rows})))
+       :col-headers col-headers
+       :rows table-rows})))
 
 (defn- extract-row-key
   "Extract row key from coord, removing axis key for map coords."
@@ -469,32 +469,32 @@
   [axis metric data]
   (let [axis-vals (sort-by str (keys data))]
     (when (and (seq data) (some #(seq (second %)) data))
-      (let [all-entries     (mapcat
-                             (fn [[axis-val entries]]
-                               (mapv #(assoc % :axis-val axis-val) entries))
-                             data)
-            raw-row-keys    (->> all-entries
-                                 (mapv
-                                  #(extract-row-key (:coord %) axis)) distinct)
+      (let [all-entries (mapcat
+                         (fn [[axis-val entries]]
+                           (mapv #(assoc % :axis-val axis-val) entries))
+                         data)
+            raw-row-keys (->> all-entries
+                              (mapv
+                               #(extract-row-key (:coord %) axis)) distinct)
             single-key-info (single-key-coord-info raw-row-keys)
-            row-keys        (sort-row-keys
-                             raw-row-keys
-                             single-key-info)
-            coord-header    (coord-column-header single-key-info)
-            lookup          (reduce
-                             (fn [acc {:keys [coord value axis-val]}]
-                               (let [row-key (extract-row-key coord axis)]
-                                 (assoc-in acc [row-key axis-val] value)))
-                             {}
-                             all-entries)
-            all-values      (keep :value all-entries)
+            row-keys (sort-row-keys
+                      raw-row-keys
+                      single-key-info)
+            coord-header (coord-column-header single-key-info)
+            lookup (reduce
+                    (fn [acc {:keys [coord value axis-val]}]
+                      (let [row-key (extract-row-key coord axis)]
+                        (assoc-in acc [row-key axis-val] value)))
+                    {}
+                    all-entries)
+            all-values (keep :value all-entries)
             {:keys [^double total-scale unit]}
             (compute-si-scaling metric all-values)
-            heading         (str
-                             "Domain Comparison by "
-                             (name axis) ": " (pr-str metric)
-                             (when (seq unit) (str " (" unit ")")))
-            col-headers     (mapv str axis-vals)
+            heading (str
+                     "Domain Comparison by "
+                     (name axis) ": " (pr-str metric)
+                     (when (seq unit) (str " (" unit ")")))
+            col-headers (mapv str axis-vals)
             table-rows
             (mapv (fn [row-key]
                     (into {coord-header (format-row-key-value
@@ -510,53 +510,53 @@
                                        (* raw-value total-scale)))]))
                                axis-vals)))
                   row-keys)]
-        {:heading      heading
+        {:heading heading
          :coord-header coord-header
-         :col-headers  col-headers
-         :rows         table-rows}))))
+         :col-headers col-headers
+         :rows table-rows}))))
 
 (defn- build-factor-table-single-metric
   "Build a table spec for single-metric factor display (with implementations)."
   [axis metric implementations data]
   (let [data-keys (set (keys data))
-        missing   (remove data-keys implementations)]
+        missing (remove data-keys implementations)]
     (when (seq missing)
       (throw (ex-info "Domain :implementations do not match comparison data keys"
                       {:implementations implementations
-                       :data-keys       (keys data)
-                       :missing         missing})))
-    (let [baseline-impl   (first implementations)
-          other-impls     (rest implementations)
-          all-row-keys    (->> (vals data)
-                               (mapcat (fn [entries]
-                                         (map #(extract-row-key (:coord %) axis) entries)))
-                               distinct)
+                       :data-keys (keys data)
+                       :missing missing})))
+    (let [baseline-impl (first implementations)
+          other-impls (rest implementations)
+          all-row-keys (->> (vals data)
+                            (mapcat (fn [entries]
+                                      (map #(extract-row-key (:coord %) axis) entries)))
+                            distinct)
           single-key-info (single-key-coord-info all-row-keys)
-          row-keys        (sort-row-keys all-row-keys single-key-info)
-          coord-header    (coord-column-header single-key-info)
-          lookup          (reduce (fn [acc [impl-val entries]]
-                                    (reduce (fn [acc2 {:keys [coord value]}]
-                                              (let [row-key (extract-row-key coord axis)]
-                                                (assoc-in acc2 [impl-val row-key] value)))
-                                            acc
-                                            entries))
-                                  {}
-                                  data)
-          col-specs       (vec (cons {:type :baseline :impl baseline-impl}
-                                     (map (fn [impl] {:type :factor :impl impl})
-                                          other-impls)))
-          col-headers     (mapv (fn [{:keys [type impl]}]
-                                  (if (= type :baseline)
-                                    (str (name impl))
-                                    (str (name impl) " ×")))
-                                col-specs)
+          row-keys (sort-row-keys all-row-keys single-key-info)
+          coord-header (coord-column-header single-key-info)
+          lookup (reduce (fn [acc [impl-val entries]]
+                           (reduce (fn [acc2 {:keys [coord value]}]
+                                     (let [row-key (extract-row-key coord axis)]
+                                       (assoc-in acc2 [impl-val row-key] value)))
+                                   acc
+                                   entries))
+                         {}
+                         data)
+          col-specs (vec (cons {:type :baseline :impl baseline-impl}
+                               (map (fn [impl] {:type :factor :impl impl})
+                                    other-impls)))
+          col-headers (mapv (fn [{:keys [type impl]}]
+                              (if (= type :baseline)
+                                (str (name impl))
+                                (str (name impl) " ×")))
+                            col-specs)
           table-rows
           (mapv
            (fn [row-key]
              (into {coord-header (format-row-key-value row-key single-key-info)}
                    (map (fn [{:keys [type impl]} header]
-                          (let [value          (double
-                                                (get-in lookup [impl row-key]))
+                          (let [value (double
+                                       (get-in lookup [impl row-key]))
                                 baseline-value (double
                                                 (get-in
                                                  lookup
@@ -565,8 +565,8 @@
                              (if (= type :baseline)
                                (format-value-with-unit value metric)
                                (cond
-                                 (nil? value)           "-"
-                                 (nil? baseline-value)  "-"
+                                 (nil? value) "-"
+                                 (nil? baseline-value) "-"
                                  (zero? baseline-value) "-"
                                  :else
                                  (format
@@ -574,55 +574,55 @@
                                   (double (/ value baseline-value)))))]))
                         col-specs col-headers)))
            row-keys)]
-      {:heading      (str "Domain Comparison by " (name axis) ": " (pr-str metric))
+      {:heading (str "Domain Comparison by " (name axis) ": " (pr-str metric))
        :coord-header coord-header
-       :col-headers  col-headers
-       :rows         table-rows})))
+       :col-headers col-headers
+       :rows table-rows})))
 
 (defn- build-factor-table-multi-metric
   "Build a table spec for multi-metric factor display (with implementations)."
   [axis implementations metrics]
-  (let [baseline-impl   (first implementations)
-        other-impls     (rest implementations)
-        metric-ids      (sort (keys metrics))
-        all-row-keys    (->> (vals metrics)
-                             (mapcat (fn [{:keys [data]}]
-                                       (mapcat (fn [[_impl entries]]
-                                                 (map #(extract-row-key (:coord %) axis) entries))
-                                               data)))
-                             distinct)
+  (let [baseline-impl (first implementations)
+        other-impls (rest implementations)
+        metric-ids (sort (keys metrics))
+        all-row-keys (->> (vals metrics)
+                          (mapcat (fn [{:keys [data]}]
+                                    (mapcat (fn [[_impl entries]]
+                                              (map #(extract-row-key (:coord %) axis) entries))
+                                            data)))
+                          distinct)
         single-key-info (single-key-coord-info all-row-keys)
-        row-keys        (sort-row-keys all-row-keys single-key-info)
-        coord-header    (coord-column-header single-key-info)
-        lookup          (reduce (fn [acc [metric-id {:keys [data]}]]
-                                  (reduce (fn [acc2 [impl-val entries]]
-                                            (reduce (fn [acc3 {:keys [coord value]}]
-                                                      (let [row-key (extract-row-key coord axis)]
-                                                        (assoc-in acc3 [metric-id impl-val row-key] value)))
-                                                    acc2
-                                                    entries))
-                                          acc
-                                          data))
-                                {}
-                                metrics)
-        col-specs       (vec (mapcat (fn [metric-id]
-                                       (let [metric-path (get-in metrics [metric-id :metric])]
-                                         (cons {:type        :baseline
-                                                :metric-id   metric-id
-                                                :metric-path metric-path
-                                                :impl        baseline-impl}
-                                               (map (fn [impl]
-                                                      {:type        :factor
-                                                       :metric-id   metric-id
-                                                       :metric-path metric-path
-                                                       :impl        impl})
-                                                    other-impls))))
-                                     metric-ids))
-        col-headers     (mapv (fn [{:keys [type metric-id impl]}]
-                                (if (= type :baseline)
-                                  (str (name impl) " " (name metric-id))
-                                  (str (name impl) " " (name metric-id) " ×")))
-                              col-specs)
+        row-keys (sort-row-keys all-row-keys single-key-info)
+        coord-header (coord-column-header single-key-info)
+        lookup (reduce (fn [acc [metric-id {:keys [data]}]]
+                         (reduce (fn [acc2 [impl-val entries]]
+                                   (reduce (fn [acc3 {:keys [coord value]}]
+                                             (let [row-key (extract-row-key coord axis)]
+                                               (assoc-in acc3 [metric-id impl-val row-key] value)))
+                                           acc2
+                                           entries))
+                                 acc
+                                 data))
+                       {}
+                       metrics)
+        col-specs (vec (mapcat (fn [metric-id]
+                                 (let [metric-path (get-in metrics [metric-id :metric])]
+                                   (cons {:type :baseline
+                                          :metric-id metric-id
+                                          :metric-path metric-path
+                                          :impl baseline-impl}
+                                         (map (fn [impl]
+                                                {:type :factor
+                                                 :metric-id metric-id
+                                                 :metric-path metric-path
+                                                 :impl impl})
+                                              other-impls))))
+                               metric-ids))
+        col-headers (mapv (fn [{:keys [type metric-id impl]}]
+                            (if (= type :baseline)
+                              (str (name impl) " " (name metric-id))
+                              (str (name impl) " " (name metric-id) " ×")))
+                          col-specs)
         table-rows
         (mapv
          (fn [row-key]
@@ -630,8 +630,8 @@
             {coord-header (format-row-key-value row-key single-key-info)}
             (map
              (fn [{:keys [type metric-id metric-path impl]} header]
-               (let [value          (double
-                                     (get-in lookup [metric-id impl row-key]))
+               (let [value (double
+                            (get-in lookup [metric-id impl row-key]))
                      baseline-value (double
                                      (get-in
                                       lookup
@@ -640,16 +640,16 @@
                   (if (= type :baseline)
                     (format-value-with-unit value metric-path)
                     (cond
-                      (nil? value)           "-"
-                      (nil? baseline-value)  "-"
+                      (nil? value) "-"
+                      (nil? baseline-value) "-"
                       (zero? baseline-value) "-"
-                      :else                  (format "%.2f" (/ value baseline-value))))]))
+                      :else (format "%.2f" (/ value baseline-value))))]))
              col-specs col-headers)))
          row-keys)]
-    {:heading      (str "Domain Comparison by " (name axis))
+    {:heading (str "Domain Comparison by " (name axis))
      :coord-header coord-header
-     :col-headers  col-headers
-     :rows         table-rows}))
+     :col-headers col-headers
+     :rows table-rows}))
 
 (defn prepare-domain-comparison-tables
   "Prepare domain-comparison data for table rendering.
@@ -692,12 +692,12 @@
   (when grouped
     (let [{:keys [axis data]} grouped]
       {:heading (str "Domain Grouped by: " (name axis))
-       :rows    (mapv (fn [[axis-val sub-domain]]
-                        {:axis-value (if (nil? axis-val)
-                                       "<nil>"
-                                       (str axis-val))
-                         :run-count  (count (:runs sub-domain))})
-                      (sort-by (comp str key) data))})))
+       :rows (mapv (fn [[axis-val sub-domain]]
+                     {:axis-value (if (nil? axis-val)
+                                    "<nil>"
+                                    (str axis-val))
+                      :run-count (count (:runs sub-domain))})
+                   (sort-by (comp str key) data))})))
 
 ;;; Domain regression view helpers
 
@@ -710,29 +710,29 @@
     :tolerance - fraction within best r-squared to mark as plotted (default 0.01)"
   [{:keys [models best-fit]}
    {:keys [best-fit-marker plotted-marker ^double tolerance]
-    :or   {best-fit-marker "✓" plotted-marker "" tolerance 0.01}}]
+    :or {best-fit-marker "✓" plotted-marker "" tolerance 0.01}}]
   (when (seq models)
     (let [best-r-squared (->> models
                               (filter #(= (:id %) best-fit))
                               first
                               :r-squared
                               double)
-          plotted-ids    (when best-r-squared
-                           (->> models
-                                (filter #(>= (double (:r-squared %))
-                                             (* best-r-squared (- 1 tolerance))))
-                                (map :id)
-                                set))
-          sorted-models  (sort-by :r-squared > models)]
+          plotted-ids (when best-r-squared
+                        (->> models
+                             (filter #(>= (double (:r-squared %))
+                                          (* best-r-squared (- 1 tolerance))))
+                             (map :id)
+                             set))
+          sorted-models (sort-by :r-squared > models)]
       (mapv (fn [{:keys [id label equation-str r-squared]}]
               (let [plotted? (and plotted-ids (plotted-ids id))]
-                {:model     label
+                {:model label
                  :r-squared (format "%.4f" r-squared)
-                 :equation  (or equation-str "")
-                 :best-fit  (cond
-                              (= id best-fit) best-fit-marker
-                              plotted?        plotted-marker
-                              :else           "")}))
+                 :equation (or equation-str "")
+                 :best-fit (cond
+                             (= id best-fit) best-fit-marker
+                             plotted? plotted-marker
+                             :else "")}))
             sorted-models))))
 
 (defn prepare-regression-model-table-multi-impl
@@ -756,45 +756,45 @@
   [extract-data {:keys [axis impl-axis has-error-bounds? metric]}]
   (when extract-data
     (let [{:keys [data]} extract-data
-          get-value      (if has-error-bounds?
-                           (fn [[_ v]] (when v (:value v)))
-                           (fn [[_ v]] v))
-          multi-impl?    (some? impl-axis)
-          valid-data     (filterv (fn [datum]
-                                    (let [[coord _] datum
-                                          value     (get-value datum)]
-                                      (and (some? value)
-                                           (map? coord)
-                                           (contains? coord axis)
-                                           (or (not multi-impl?)
-                                               (contains? coord impl-axis)))))
-                                  data)]
+          get-value (if has-error-bounds?
+                      (fn [[_ v]] (when v (:value v)))
+                      (fn [[_ v]] v))
+          multi-impl? (some? impl-axis)
+          valid-data (filterv (fn [datum]
+                                (let [[coord _] datum
+                                      value (get-value datum)]
+                                  (and (some? value)
+                                       (map? coord)
+                                       (contains? coord axis)
+                                       (or (not multi-impl?)
+                                           (contains? coord impl-axis)))))
+                              data)]
       (when (seq valid-data)
         (let [raw-values (mapv get-value valid-data)
               {:keys [^double total-scale unit]}
               (compute-si-scaling metric raw-values)
-              points     (mapv (fn [[coord v]]
-                                 (let [y-val (double
-                                              (if has-error-bounds?
-                                                (:value v)
-                                                v))
-                                       x-val (double (get coord axis))]
-                                   (cond-> {"x" x-val
-                                            "y" (* y-val total-scale)}
-                                     has-error-bounds?
-                                     (assoc "yLower" (* (double (:lower v))
-                                                        total-scale)
-                                            "yUpper" (* (double (:upper v))
-                                                        total-scale))
-                                     multi-impl?
-                                     (assoc "impl" (name (get coord impl-axis))))))
-                               valid-data)
-              x-vals     (mapv #(get % "x") points)]
-          {:points      points
+              points (mapv (fn [[coord v]]
+                             (let [y-val (double
+                                          (if has-error-bounds?
+                                            (:value v)
+                                            v))
+                                   x-val (double (get coord axis))]
+                               (cond-> {"x" x-val
+                                        "y" (* y-val total-scale)}
+                                 has-error-bounds?
+                                 (assoc "yLower" (* (double (:lower v))
+                                                    total-scale)
+                                        "yUpper" (* (double (:upper v))
+                                                    total-scale))
+                                 multi-impl?
+                                 (assoc "impl" (name (get coord impl-axis))))))
+                           valid-data)
+              x-vals (mapv #(get % "x") points)]
+          {:points points
            :total-scale total-scale
-           :unit        unit
-           :x-vals      x-vals
-           :valid-data  valid-data})))))
+           :unit unit
+           :x-vals x-vals
+           :valid-data valid-data})))))
 
 (defn prepare-regression-fit-lines
   "Generate fit line points for plotting.
@@ -803,8 +803,8 @@
   Returns vector of point maps with x, y, and model or impl key."
   [{:keys [x-vals ^double total-scale]} {:keys [models by-impl impl-keys]}]
   (when (seq x-vals)
-    (let [x-min   (double (reduce min x-vals))
-          x-max   (double (reduce max x-vals))
+    (let [x-min (double (reduce min x-vals))
+          x-max (double (reduce max x-vals))
           x-range (range x-min (+ x-max 1) (/ (- x-max x-min) 50))]
       (if by-impl
         ;; Multi-impl: one best-fit line per implementation
@@ -812,12 +812,12 @@
          (mapcat
           (fn [impl-key]
             (let [{:keys [models best-fit]} (get by-impl impl-key)
-                  best-model                (first (filter #(= (:id %) best-fit) models))]
+                  best-model (first (filter #(= (:id %) best-fit) models))]
               (when best-model
                 (let [mfn (:predict-fn best-model)]
                   (mapv (fn [x]
-                          {"x"    x
-                           "y"    (* (double (mfn x)) total-scale)
+                          {"x" x
+                           "y" (* (double (mfn x)) total-scale)
                            "impl" (name impl-key)})
                         x-range)))))
           impl-keys))
@@ -827,8 +827,8 @@
           (fn [model]
             (let [mfn (:predict-fn model)]
               (mapv (fn [x]
-                      {"x"     x
-                       "y"     (* (double (mfn x)) total-scale)
+                      {"x" x
+                       "y" (* (double (mfn x)) total-scale)
                        "model" (:label model)})
                     x-range)))
           models))))))
@@ -848,17 +848,17 @@
        (mapcat
         (fn [impl-key]
           (let [{:keys [models best-fit]} (get by-impl impl-key)
-                best-model                (first (filter #(= (:id %) best-fit) models))]
+                best-model (first (filter #(= (:id %) best-fit) models))]
             (when best-model
               (let [mfn (:predict-fn best-model)]
                 (keep (fn [[coord v]]
                         (when (= (get coord impl-axis) impl-key)
-                          (let [y-val     (double (get-value [coord v]))
-                                x-val     (double (get coord axis))
+                          (let [y-val (double (get-value [coord v]))
+                                x-val (double (get coord axis))
                                 predicted (double (mfn x-val))]
-                            {"x"        x-val
+                            {"x" x-val
                              "residual" (* (- y-val predicted) total-scale)
-                             "impl"     (name impl-key)})))
+                             "impl" (name impl-key)})))
                       valid-data)))))
         impl-keys))
       ;; Single-impl mode
@@ -867,12 +867,12 @@
         (fn [model]
           (let [mfn (:predict-fn model)]
             (mapv (fn [[coord v]]
-                    (let [y-val     (double (get-value [coord v]))
-                          x-val     (double (get coord axis))
+                    (let [y-val (double (get-value [coord v]))
+                          x-val (double (get coord axis))
                           predicted (double (mfn x-val))]
-                      {"x"        x-val
+                      {"x" x-val
                        "residual" (* (- y-val predicted) total-scale)
-                       "model"    (:label model)}))
+                       "model" (:label model)}))
                   valid-data)))
         models)))))
 
@@ -902,3 +902,12 @@
      ;; Last resort
      :else
      (str call-class "." call-method " (" call-file ":" call-line ")"))))
+
+(defn format-object-types
+  "Format object types set for display.
+  Returns a comma-separated string of simplified type names."
+  [object-types]
+  (when (seq object-types)
+    (->> object-types
+         sort
+         (clojure.string/join ", "))))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -607,6 +607,7 @@
                :parentKey "parent"}
               {:type "treemap"
                :field "value"
+               :sort {:field "value" :order "descending"}
                :method "squarify"
                :ratio 1.6
                :size [{:signal "width"} {:signal "height"}]

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -2,8 +2,9 @@
   "Common Vega-Lite chart generation functions for viewers.
 
   Provides reusable chart-building functions extracted from the Portal viewer
-  for generating histograms, scatter plots, and percentile charts."
+  for generating histograms, scatter plots, percentile charts, and treemaps."
   (:require
+   [clojure.string :as str]
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have have?]]
@@ -266,23 +267,23 @@
   :height for chart dimensions. Returns the Vega-Lite spec without
   viewer-specific wrapping."
   [data-map view chart-options]
-  (let [histogram-id     (or (:histogram-id view) :histograms)
-        stats-id         (or (:stats-id view) :stats)
+  (let [histogram-id (or (:histogram-id view) :histograms)
+        stats-id (or (:stats-id view) :stats)
         quant-samples-id (or (:samples-id view) :samples)
-        quant-samples    (data-map quant-samples-id)
-        stats            (data-map stats-id)
-        histograms-map   (util/lookup-data data-map histogram-id)
-        histograms       (:histograms histograms-map)
-        metrics-defs     (-> (:metrics-defs quant-samples)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-        metric-configs   (metric/all-metric-configs metrics-defs)
-        hist-transforms  (util/get-transforms data-map histogram-id)
+        quant-samples (data-map quant-samples-id)
+        stats (data-map stats-id)
+        histograms-map (util/lookup-data data-map histogram-id)
+        histograms (:histograms histograms-map)
+        metrics-defs (-> (:metrics-defs quant-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        hist-transforms (util/get-transforms data-map histogram-id)
         stats-transforms (util/get-transforms data-map (:source-id stats))
-        layer-num        (volatile! 0)]
-    {:data    {:values []}
-     :resolve {:scale {:x     "independent"
-                       :y     "independent"
+        layer-num (volatile! 0)]
+    {:data {:values []}
+     :resolve {:scale {:x "independent"
+                       :y "independent"
                        :color "shared"}}
      :vconcat (mapv
                (fn [metric-config]
@@ -470,20 +471,20 @@
   [points line-pts
    {:keys [width height color-field color-value
            legend-options has-error-bounds?]
-    :or   {width 600 height 400 color-value "steelblue"} :as opts}]
+    :or {width 600 height 400 color-value "steelblue"} :as opts}]
   (let [scatter-layer (regression-scatter-layer points opts)
-        line-layer    (regression-line-layer line-pts
-                                             {:color-field    color-field
-                                              :legend-options legend-options})
-        error-layer   (when has-error-bounds?
-                        (regression-error-layer points
-                                                {:color-field color-field
-                                                 :color-value color-value}))
-        layers        (cond-> [scatter-layer line-layer]
-                        has-error-bounds? (conj error-layer))]
-    {:width  width
+        line-layer (regression-line-layer line-pts
+                                          {:color-field color-field
+                                           :legend-options legend-options})
+        error-layer (when has-error-bounds?
+                      (regression-error-layer points
+                                              {:color-field color-field
+                                               :color-value color-value}))
+        layers (cond-> [scatter-layer line-layer]
+                 has-error-bounds? (conj error-layer))]
+    {:width width
      :height height
-     :layer  layers}))
+     :layer layers}))
 
 (defn regression-residual-layer
   "Build scatter layer for residual plot.
@@ -533,9 +534,142 @@
     :color-field - field for color encoding
     :legend-options - legend config map"
   [residual-pts {:keys [width height color-field]
-                 :or   {width 600 height 200} :as opts}]
-  {:width  width
+                 :or {width 600 height 200} :as opts}]
+  {:width width
    :height height
-   :layer  [(regression-residual-layer residual-pts opts)
-            (regression-loess-layer residual-pts {:color-field color-field})
-            (regression-zero-line-layer)]})
+   :layer [(regression-residual-layer residual-pts opts)
+           (regression-loess-layer residual-pts {:color-field color-field})
+           (regression-zero-line-layer)]})
+
+;;; Treemap charts
+
+(defn- flatten-treemap-node
+  "Flatten a hierarchical treemap node into a sequence of flat records.
+  Each record has :id, :parent, :value, and :name keys for use with Vega stratify."
+  ([node] (flatten-treemap-node node nil []))
+  ([node parent-id path]
+   (let [node-name (:name node)
+         node-id (if (empty? path)
+                   "root"
+                   (str/join "/" (conj path node-name)))
+         current-path (conj path node-name)
+         node-record {:id node-id
+                      :parent parent-id
+                      :name node-name
+                      :value (:value node 0)
+                      :depth (count path)}]
+     (if-let [children (:children node)]
+       (cons node-record
+             (mapcat #(flatten-treemap-node % node-id current-path) children))
+       [node-record]))))
+
+(defn treemap-vega-spec
+  "Build a complete Vega spec for treemap visualization.
+
+  Takes treemap-data (a :criterium/allocation-treemap map from analysis)
+  and opts map containing display options.
+
+  Parameters:
+    treemap-data - The allocation treemap map with :root containing hierarchy
+    opts - Display options:
+      :width (default 700)
+      :height (default 400)
+      :color-scheme (default \"tableau10\")
+
+  Returns a full Vega spec (not Vega-Lite) using:
+    - stratify transform to build hierarchy from flat data
+    - treemap transform with squarify tiling
+    - rect marks sized by x0/x1/y0/y1
+    - text labels for cells above size threshold
+    - color by first-level category
+    - tooltip showing name, value (formatted bytes), path"
+  [treemap-data opts]
+  (let [width (or (:width opts) 700)
+        height (or (:height opts) 400)
+        color-scheme (or (:color-scheme opts) "tableau10")
+        root (:root treemap-data)
+        flat-data (when root (flatten-treemap-node root))
+        size-by (or (:size-by treemap-data) :bytes)
+        value-format (if (= size-by :count) "d" "~s")]
+    {:$schema "https://vega.github.io/schema/vega/v5.json"
+     :width width
+     :height height
+     :padding 2
+     :autosize "none"
+
+     :data [{:name "tree"
+             :values (or flat-data [])
+             :transform
+             [{:type "stratify"
+               :key "id"
+               :parentKey "parent"}
+              {:type "treemap"
+               :field "value"
+               :method "squarify"
+               :ratio 1.6
+               :size [{:signal "width"} {:signal "height"}]
+               :as ["x0" "y0" "x1" "y1" "depth" "children"]}]}
+            {:name "nodes"
+             :source "tree"
+             :transform [{:type "filter"
+                          :expr "datum.children"}]}
+            {:name "leaves"
+             :source "tree"
+             :transform [{:type "filter"
+                          :expr "!datum.children"}]}]
+
+     :scales [{:name "color"
+               :type "ordinal"
+               :domain {:data "nodes"
+                        :field "name"
+                        :sort true}
+               :range {:scheme color-scheme}}]
+
+     :marks [;; Parent category rectangles (colored background)
+             {:type "rect"
+              :from {:data "nodes"}
+              :encode
+              {:enter
+               {:fill {:scale "color" :field "name"}}
+               :update
+               {:x {:field "x0"}
+                :y {:field "y0"}
+                :x2 {:field "x1"}
+                :y2 {:field "y1"}}}}
+             ;; Leaf rectangles (white stroke, interactive)
+             {:type "rect"
+              :from {:data "leaves"}
+              :encode
+              {:enter
+               {:stroke {:value "#fff"}
+                :strokeWidth {:value 1}}
+               :update
+               {:x {:field "x0"}
+                :y {:field "y0"}
+                :x2 {:field "x1"}
+                :y2 {:field "y1"}
+                :fill {:value "transparent"}
+                :tooltip
+                {:signal
+                 (str "{'Name': datum.name, "
+                      "'Value': format(datum.value, '" value-format "'), "
+                      "'Path': datum.id}")}}
+               :hover
+               {:fill {:value "rgba(0,0,0,0.1)"}}}}
+             ;; Text labels for larger cells
+             {:type "text"
+              :from {:data "leaves"}
+              :encode
+              {:enter
+               {:font {:value "Helvetica Neue, Arial"}
+                :align {:value "center"}
+                :baseline {:value "middle"}
+                :fill {:value "#000"}
+                :fontSize {:value 10}}
+               :update
+               {:x {:signal "(datum.x0 + datum.x1) / 2"}
+                :y {:signal "(datum.y0 + datum.y1) / 2"}
+                :text {:field "name"}
+                :opacity
+                {:signal
+                 "(datum.x1 - datum.x0) > 40 && (datum.y1 - datum.y0) > 20 ? 1 : 0"}}}}]}))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -590,45 +590,43 @@
     - color by first-level category
     - tooltip on hover showing name, value (formatted bytes), path"
   [treemap-data opts]
-  (let [width (or (:width opts) 700)
-        height (or (:height opts) 400)
+  (let [width        (or (:width opts) 700)
+        height       (or (:height opts) 400)
         color-scheme (or (:color-scheme opts) "tableau10")
-        root (:root treemap-data)
-        flat-data (when root (vec (flatten-treemap-node root)))
-        size-by (or (:size-by treemap-data) :bytes)
-        value-format (if (= size-by :count) "d" "~s")]
+        root         (:root treemap-data)
+        flat-data    (when root (vec (flatten-treemap-node root)))]
     {:$schema "https://vega.github.io/schema/vega/v5.json"
-     :width width
-     :height height
+     :width   width
+     :height  height
 
-     :data [{:name "tree"
+     :data [{:name   "tree"
              :values (or flat-data [])
              :transform
-             [{:type "stratify"
-               :key "id"
+             [{:type      "stratify"
+               :key       "id"
                :parentKey "parent"}
-              {:type "treemap"
-               :field "value"
-               :sort {:field "value" :order "descending"}
+              {:type   "treemap"
+               :field  "value"
+               :sort   {:field "value" :order "descending"}
                :method "squarify"
-               :ratio 1.6
-               :size [{:signal "width"} {:signal "height"}]
-               :as ["x0" "y0" "x1" "y1" "depth" "children"]}]}
-            {:name "nodes"
-             :source "tree"
+               :ratio  1.6
+               :size   [{:signal "width"} {:signal "height"}]
+               :as     ["x0" "y0" "x1" "y1" "depth" "children"]}]}
+            {:name      "nodes"
+             :source    "tree"
              :transform [{:type "filter"
                           :expr "datum.children"}]}
-            {:name "leaves"
-             :source "tree"
+            {:name      "leaves"
+             :source    "tree"
              :transform [{:type "filter"
                           :expr "!datum.children"}]}]
 
-     :scales [{:name "color"
-               :type "ordinal"
-               :domain {:data "nodes"
+     :scales [{:name   "color"
+               :type   "ordinal"
+               :domain {:data  "nodes"
                         :field "name"
-                        :sort true}
-               :range {:scheme color-scheme}}]
+                        :sort  true}
+               :range  {:scheme color-scheme}}]
 
      :marks [;; Parent category rectangles (colored background)
              {:type "rect"
@@ -637,8 +635,8 @@
               {:enter
                {:fill {:scale "color" :field "name"}}
                :update
-               {:x {:field "x0"}
-                :y {:field "y0"}
+               {:x  {:field "x0"}
+                :y  {:field "y0"}
                 :x2 {:field "x1"}
                 :y2 {:field "y1"}}}}
              ;; Leaf rectangles (white stroke, interactive with tooltip)
@@ -646,13 +644,13 @@
               :from {:data "leaves"}
               :encode
               {:enter
-               {:stroke {:value "#fff"}
+               {:stroke      {:value "#fff"}
                 :strokeWidth {:value 1}}
                :update
-               {:x {:field "x0"}
-                :y {:field "y0"}
-                :x2 {:field "x1"}
-                :y2 {:field "y1"}
+               {:x    {:field "x0"}
+                :y    {:field "y0"}
+                :x2   {:field "x1"}
+                :y2   {:field "y1"}
                 :fill {:value "transparent"}
                 :tooltip
                 {:signal

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -656,7 +656,7 @@
                 {:signal
                  (str "{'Name': datum.name, "
                       "'Value': format(datum.value, '" value-format "'), "
-                      "'Path': datum.id}")}}
+                      "'Path': replace(datum.id, /^[^/]+\\//, '')}")}}
                :hover
                {:fill {:value "rgba(0,0,0,0.1)"}}}}
              ;; Text labels for larger cells

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -546,7 +546,7 @@
 (defn- flatten-treemap-node
   "Flatten a hierarchical treemap node into a sequence of flat records.
   Each record has :id, :parent, and :name keys for use with Vega stratify.
-  Only leaf nodes get :value - parent sizes are computed by Vega's treemap transform."
+  Only leaf nodes get stats - parent sizes are computed by Vega's treemap transform."
   ([node] (flatten-treemap-node node nil []))
   ([node parent-id path]
    (let [node-name (:name node)
@@ -559,8 +559,12 @@
                               :parent parent-id
                               :name node-name
                               :depth (count path)}
-                       ;; Only set value on leaf nodes
-                       (not children) (assoc :value (:value node 0)))]
+                       ;; Only set stats on leaf nodes
+                       (not children) (assoc :value (:value node 0)
+                                             :bytes (:bytes node)
+                                             :count (:count node)
+                                             :freed-bytes (:freed-bytes node 0)
+                                             :freed-count (:freed-count node 0)))]
      (if children
        (cons node-record
              (mapcat #(flatten-treemap-node % node-id current-path) children))
@@ -652,8 +656,11 @@
                 :fill {:value "transparent"}
                 :tooltip
                 {:signal
-                 (str "{'Name': datum.name, "
-                      "'Value': format(datum.value, '" value-format "'), "
-                      "'Path': replace(datum.id, /^[^/]+\\//, '')}")}}
+                 (str "{'Type': datum.name, "
+                      "'Bytes': format(datum.bytes, '~s'), "
+                      "'Count': datum.count, "
+                      "'Bytes/Alloc': format(datum.bytes / datum.count, '.1f'), "
+                      "'Freed %': format(datum['freed-count'] / datum.count, '.1%'), "
+                      "'Path': replace(replace(datum.id, /^[^/]+\\//, ''), /\\/[^/]+$/, '')}")}}
                :hover
                {:fill {:value "rgba(0,0,0,0.1)"}}}}]}))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -590,14 +590,12 @@
         height (or (:height opts) 400)
         color-scheme (or (:color-scheme opts) "tableau10")
         root (:root treemap-data)
-        flat-data (when root (flatten-treemap-node root))
+        flat-data (when root (vec (flatten-treemap-node root)))
         size-by (or (:size-by treemap-data) :bytes)
         value-format (if (= size-by :count) "d" "~s")]
     {:$schema "https://vega.github.io/schema/vega/v5.json"
      :width width
      :height height
-     :padding 2
-     :autosize "none"
 
      :data [{:name "tree"
              :values (or flat-data [])

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -583,9 +583,8 @@
     - stratify transform to build hierarchy from flat data
     - treemap transform with squarify tiling
     - rect marks sized by x0/x1/y0/y1
-    - text labels for cells above size threshold
     - color by first-level category
-    - tooltip showing name, value (formatted bytes), path"
+    - tooltip on hover showing name, value (formatted bytes), path"
   [treemap-data opts]
   (let [width (or (:width opts) 700)
         height (or (:height opts) 400)
@@ -639,7 +638,7 @@
                 :y {:field "y0"}
                 :x2 {:field "x1"}
                 :y2 {:field "y1"}}}}
-             ;; Leaf rectangles (white stroke, interactive)
+             ;; Leaf rectangles (white stroke, interactive with tooltip)
              {:type "rect"
               :from {:data "leaves"}
               :encode
@@ -658,21 +657,4 @@
                       "'Value': format(datum.value, '" value-format "'), "
                       "'Path': replace(datum.id, /^[^/]+\\//, '')}")}}
                :hover
-               {:fill {:value "rgba(0,0,0,0.1)"}}}}
-             ;; Text labels for larger cells
-             {:type "text"
-              :from {:data "leaves"}
-              :encode
-              {:enter
-               {:font {:value "Helvetica Neue, Arial"}
-                :align {:value "center"}
-                :baseline {:value "middle"}
-                :fill {:value "#000"}
-                :fontSize {:value 10}}
-               :update
-               {:x {:signal "(datum.x0 + datum.x1) / 2"}
-                :y {:signal "(datum.y0 + datum.y1) / 2"}
-                :text {:field "name"}
-                :opacity
-                {:signal
-                 "(datum.x1 - datum.x0) > 40 && (datum.y1 - datum.y0) > 20 ? 1 : 0"}}}}]}))
+               {:fill {:value "rgba(0,0,0,0.1)"}}}}]}))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -545,7 +545,8 @@
 
 (defn- flatten-treemap-node
   "Flatten a hierarchical treemap node into a sequence of flat records.
-  Each record has :id, :parent, :value, and :name keys for use with Vega stratify."
+  Each record has :id, :parent, and :name keys for use with Vega stratify.
+  Only leaf nodes get :value - parent sizes are computed by Vega's treemap transform."
   ([node] (flatten-treemap-node node nil []))
   ([node parent-id path]
    (let [node-name (:name node)
@@ -553,12 +554,14 @@
                    "root"
                    (str/join "/" (conj path node-name)))
          current-path (conj path node-name)
-         node-record {:id node-id
-                      :parent parent-id
-                      :name node-name
-                      :value (:value node 0)
-                      :depth (count path)}]
-     (if-let [children (:children node)]
+         children (:children node)
+         node-record (cond-> {:id node-id
+                              :parent parent-id
+                              :name node-name
+                              :depth (count path)}
+                       ;; Only set value on leaf nodes
+                       (not children) (assoc :value (:value node 0)))]
+     (if children
        (cons node-record
              (mapcat #(flatten-treemap-node % node-id current-path) children))
        [node-record]))))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -10,6 +10,7 @@
   (:refer-clojure :exclude [flush])
   (:require
    [criterium.metric :as metric]
+   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
@@ -396,6 +397,69 @@
                            :residual-title residual-title
                            :color-field    "model"
                            :legend-options legend-options}))))))))))))))
+
+;;; Allocation view implementations
+
+(defmethod view/allocation-summary* :kindly
+  [_ {:keys [summary-id]} data-map]
+  (let [summary-id (or summary-id :allocation-summary)
+        summary (data-map summary-id)]
+    (when summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+            retained (- (long total-allocated) (long total-freed))]
+        (kindly-heading "Allocation Summary")
+        (kindly-table
+         [{:metric "Total allocated"
+           :value (format/format-value :memory total-allocated)}
+          {:metric "Total freed"
+           :value (format/format-value :memory total-freed)}
+          {:metric "Retained"
+           :value (format/format-value :memory retained)}
+          {:metric "Allocation count"
+           :value num-allocations}
+          {:metric "Freed count"
+           :value num-freed}
+          {:metric "Freed ratio"
+           :value (if (pos? (long num-allocations))
+                    (clojure.core/format "%.1f%%"
+                                         (* 100.0 (/ (double num-freed)
+                                                     (double num-allocations))))
+                    "N/A")}])))))
+
+(defmethod view/allocation-hotspots* :kindly
+  [_ {:keys [hotspots-id]} data-map]
+  (let [hotspots-id (or hotspots-id :allocation-hotspots)
+        hotspots-map (data-map hotspots-id)]
+    (when hotspots-map
+      (let [hotspots (:hotspots hotspots-map)]
+        (when (seq hotspots)
+          (kindly-heading "Allocation Hotspots")
+          (kindly-table
+           (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
+                   {:call-site (viewer-common/format-call-site call-site)
+                    :count count
+                    :bytes (format/format-value :memory bytes)
+                    :freed-count freed-count
+                    :freed-bytes (format/format-value :memory freed-bytes)})
+                 hotspots)))))))
+
+(defmethod view/allocation-by-type* :kindly
+  [_ {:keys [by-type-id]} data-map]
+  (let [by-type-id (or by-type-id :allocation-by-type)
+        by-type-map (data-map by-type-id)]
+    (when by-type-map
+      (let [by-type (:by-type by-type-map)
+            sorted (sort-by (comp :bytes second) > by-type)]
+        (when (seq sorted)
+          (kindly-heading "Allocations by Type")
+          (kindly-table
+           (mapv (fn [[type-name {:keys [count bytes freed-count freed-bytes]}]]
+                   {:type type-name
+                    :count count
+                    :bytes (format/format-value :memory bytes)
+                    :freed-count freed-count
+                    :freed-bytes (format/format-value :memory freed-bytes)})
+                 sorted)))))))
 
 ;;; Noop implementations for views not applicable to Kindly output
 

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -417,13 +417,7 @@
             summary
             total-allocated (long total-allocated)
             total-freed (long total-freed)
-            retained (- total-allocated total-freed)
-            freed-ratio (or freed-ratio
-                            (when (pos? total-allocated)
-                              (/ (double total-freed) (double total-allocated))))
-            freed-ratio-str (if (some? freed-ratio)
-                              (clojure.core/format "%.1f%%" (* 100.0 (double freed-ratio)))
-                              "N/A")]
+            retained (- total-allocated total-freed)]
         (kindly-heading "Allocation Summary")
         (kindly-table
          [{:metric "Total allocated"
@@ -437,7 +431,7 @@
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value freed-ratio-str}])))))
+           :value (clojure.core/format "%.1f%%" (* 100.0 (double freed-ratio)))}])))))
 
 (defmethod view/allocation-hotspots* :kindly
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -435,8 +435,8 @@
         (when (seq hotspots)
           (kindly-heading "Allocation Hotspots")
           (kindly-table
-           (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
-                   {:call-site (viewer-common/format-call-site call-site)
+           (mapv (fn [{:keys [call-site object-types count bytes freed-count freed-bytes]}]
+                   {:call-site (viewer-common/format-call-site call-site object-types)
                     :count count
                     :bytes (format/format-value :memory bytes)
                     :freed-count freed-count

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -413,9 +413,17 @@
         summary (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
-                    ^double freed-ratio]}
+                    freed-ratio]}
             summary
-            retained (- (long total-allocated) (long total-freed))]
+            total-allocated (long total-allocated)
+            total-freed (long total-freed)
+            retained (- total-allocated total-freed)
+            freed-ratio (or freed-ratio
+                            (when (pos? total-allocated)
+                              (/ (double total-freed) (double total-allocated))))
+            freed-ratio-str (if (some? freed-ratio)
+                              (clojure.core/format "%.1f%%" (* 100.0 (double freed-ratio)))
+                              "N/A")]
         (kindly-heading "Allocation Summary")
         (kindly-table
          [{:metric "Total allocated"
@@ -429,7 +437,7 @@
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value (clojure.core/format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value freed-ratio-str}])))))
 
 (defmethod view/allocation-hotspots* :kindly
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -403,25 +403,26 @@
 (defmethod view/allocation-summary* :kindly
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary (data-map summary-id)]
+        summary    (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
-                    freed-ratio]} summary
+                    ^double freed-ratio]}
+            summary
             retained (- (long total-allocated) (long total-freed))]
         (kindly-heading "Allocation Summary")
         (kindly-table
          [{:metric "Total allocated"
-           :value (str total-allocated " bytes")}
+           :value  (str total-allocated " bytes")}
           {:metric "Total freed"
-           :value (str total-freed " bytes")}
+           :value  (str total-freed " bytes")}
           {:metric "Retained"
-           :value (str retained " bytes")}
+           :value  (str retained " bytes")}
           {:metric "Allocation count"
-           :value num-allocations}
+           :value  num-allocations}
           {:metric "Freed count"
-           :value num-freed}
+           :value  num-freed}
           {:metric "Freed ratio"
-           :value (clojure.core/format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value  (clojure.core/format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :kindly
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -25,7 +25,7 @@
   last-fragment
   (atom nil))
 
-(def ^:private  chart-width
+(def ^:private chart-width
   "Width for Kindly vega-lite charts, sized for notebook display."
   700)
 
@@ -232,7 +232,7 @@
 (defmethod view/domain-grouped* :kindly
   [_ {:keys [grouped-id]} data-map]
   (let [grouped-id (or grouped-id :grouped)
-        grouped    (data-map grouped-id)]
+        grouped (data-map grouped-id)]
     (when-let [{:keys [heading rows]} (viewer-common/prepare-domain-grouped-table
                                        grouped)]
       (kindly-heading heading)
@@ -241,7 +241,7 @@
 (defmethod view/domain-comparison* :kindly
   [_ {:keys [comparison-id]} data-map]
   (let [comparison-id (or comparison-id :comparison)
-        comparison    (data-map comparison-id)]
+        comparison (data-map comparison-id)]
     (when-let [tables (viewer-common/prepare-domain-comparison-tables
                        comparison)]
       (doseq [{:keys [heading rows]} tables]
@@ -250,19 +250,19 @@
 
 (defmethod view/domain-regression* :kindly
   [_ {:keys [regression-id extract-id tolerance]} data-map]
-  (let [regression-id  (or regression-id :regression)
-        regression     (data-map regression-id)
-        tolerance      (double  (or tolerance 0.01))
-        table-options  {:best-fit-marker "✓"
-                        :plotted-marker  ""
-                        :tolerance       tolerance}
-        legend-options {:orient  "none"
+  (let [regression-id (or regression-id :regression)
+        regression (data-map regression-id)
+        tolerance (double (or tolerance 0.01))
+        table-options {:best-fit-marker "✓"
+                       :plotted-marker ""
+                       :tolerance tolerance}
+        legend-options {:orient "none"
                         :legendX 10
                         :legendY 10}]
     (when regression
-      (let [{:keys [axis regressions impl-axis implementations]}          regression
-            extract-id  (or extract-id :extract)
-            extract     (data-map extract-id)
+      (let [{:keys [axis regressions impl-axis implementations]} regression
+            extract-id (or extract-id :extract)
+            extract (data-map extract-id)
             multi-impl? (> (count implementations) 1)]
 
         (if multi-impl?
@@ -270,7 +270,7 @@
           (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  impl-keys           (sort (keys by-impl))]
+                  impl-keys (sort (keys by-impl))]
               (kindly-heading (str "Domain Regression (axis: " (name axis)
                                    ", metric: " (pr-str metric)
                                    ", by: " (name impl-axis) ")"))
@@ -282,19 +282,19 @@
               ;; Charts
               (when-let [point-data (viewer-common/prepare-regression-points
                                      metric-extract-data
-                                     {:axis              axis
-                                      :impl-axis         impl-axis
+                                     {:axis axis
+                                      :impl-axis impl-axis
                                       :has-error-bounds? with-error-bounds
-                                      :metric            metric})]
+                                      :metric metric})]
                 (let [{:keys [points unit]}
                       point-data
                       line-pts
                       (viewer-common/prepare-regression-fit-lines
                        point-data
                        {:by-impl by-impl :impl-keys impl-keys})
-                      y-title        (if (seq unit)
-                                       (str (pr-str metric) " (" unit ")")
-                                       (pr-str metric))
+                      y-title (if (seq unit)
+                                (str (pr-str metric) " (" unit ")")
+                                (pr-str metric))
                       residual-title (if (seq unit)
                                        (str "Residual (" unit ")")
                                        "Residual")]
@@ -302,47 +302,47 @@
                     (kindly-vega-lite
                      (charts/regression-chart-spec
                       points line-pts
-                      {:width             chart-width
-                       :height            chart-height
-                       :axis-name         (name axis) :y-title y-title
-                       :color-field       "impl"
-                       :legend-options    legend-options
+                      {:width chart-width
+                       :height chart-height
+                       :axis-name (name axis) :y-title y-title
+                       :color-field "impl"
+                       :legend-options legend-options
                        :has-error-bounds? with-error-bounds}))
                     ;; Residual plot
                     (let [residual-pts
                           (viewer-common/prepare-regression-residuals
                            point-data
-                           {:axis              axis
-                            :impl-axis         impl-axis
+                           {:axis axis
+                            :impl-axis impl-axis
                             :has-error-bounds? with-error-bounds
-                            :by-impl           by-impl
-                            :impl-keys         impl-keys})]
+                            :by-impl by-impl
+                            :impl-keys impl-keys})]
                       (kindly-heading "Residual Plot")
                       (kindly-vega-lite
                        (charts/regression-residual-spec
                         residual-pts
-                        {:width          chart-width
-                         :height         (long (/ (long chart-height) 2))
-                         :axis-name      (name axis)
+                        {:width chart-width
+                         :height (long (/ (long chart-height) 2))
+                         :axis-name (name axis)
                          :residual-title residual-title
-                         :color-field    "impl"
+                         :color-field "impl"
                          :legend-options legend-options}))))))))
 
           ;; Single-implementation mode
           (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  best-r-squared      (when best-fit
-                                        (->> models
-                                             (filter #(= (:id %) best-fit))
-                                             first :r-squared))
-                  models-to-plot      (when best-r-squared
-                                        (->> models
-                                             (filter
-                                              #(>= (double (:r-squared %))
-                                                   (* (double best-r-squared)
-                                                      (- 1.0 tolerance))))
-                                             (sort-by :r-squared >)))]
+                  best-r-squared (when best-fit
+                                   (->> models
+                                        (filter #(= (:id %) best-fit))
+                                        first :r-squared))
+                  models-to-plot (when best-r-squared
+                                   (->> models
+                                        (filter
+                                         #(>= (double (:r-squared %))
+                                              (* (double best-r-squared)
+                                                 (- 1.0 tolerance))))
+                                        (sort-by :r-squared >)))]
               (kindly-heading (str "Domain Regression (axis: " (name axis)
                                    ", metric: " (pr-str metric) ")"))
               ;; Model table
@@ -355,17 +355,17 @@
               (when (and metric-extract-data (seq models-to-plot))
                 (when-let [point-data (viewer-common/prepare-regression-points
                                        metric-extract-data
-                                       {:axis              axis
+                                       {:axis axis
                                         :has-error-bounds? with-error-bounds
-                                        :metric            metric})]
+                                        :metric metric})]
                   (let [{:keys [points unit]}
                         point-data
                         line-pts
                         (viewer-common/prepare-regression-fit-lines
                          point-data {:models models-to-plot})
-                        y-title        (if (seq unit)
-                                         (str (pr-str metric) " (" unit ")")
-                                         (pr-str metric))
+                        y-title (if (seq unit)
+                                  (str (pr-str metric) " (" unit ")")
+                                  (pr-str metric))
                         residual-title (if (seq unit)
                                          (str "Residual (" unit ")")
                                          "Residual")]
@@ -373,29 +373,29 @@
                       (kindly-vega-lite
                        (charts/regression-chart-spec
                         points line-pts
-                        {:width             chart-width
-                         :height            chart-height
-                         :axis-name         (name axis)
-                         :y-title           y-title
-                         :color-field       "model"
-                         :legend-options    legend-options
+                        {:width chart-width
+                         :height chart-height
+                         :axis-name (name axis)
+                         :y-title y-title
+                         :color-field "model"
+                         :legend-options legend-options
                          :has-error-bounds? with-error-bounds}))
                       ;; Residual plot
                       (let [residual-pts
                             (viewer-common/prepare-regression-residuals
                              point-data
-                             {:axis              axis
+                             {:axis axis
                               :has-error-bounds? with-error-bounds
-                              :models            models-to-plot})]
+                              :models models-to-plot})]
                         (kindly-heading "Residual Plot")
                         (kindly-vega-lite
                          (charts/regression-residual-spec
                           residual-pts
-                          {:width          chart-width
-                           :height         (long (/ (long chart-height) 2))
-                           :axis-name      (name axis)
+                          {:width chart-width
+                           :height (long (/ (long chart-height) 2))
+                           :axis-name (name axis)
                            :residual-title residual-title
-                           :color-field    "model"
+                           :color-field "model"
                            :legend-options legend-options}))))))))))))))
 
 ;;; Allocation view implementations
@@ -410,20 +410,20 @@
         (kindly-heading "Allocation Summary")
         (kindly-table
          [{:metric "Total allocated"
-           :value (format/format-value :memory total-allocated)}
+           :value (str total-allocated " bytes")}
           {:metric "Total freed"
-           :value (format/format-value :memory total-freed)}
+           :value (str total-freed " bytes")}
           {:metric "Retained"
-           :value (format/format-value :memory retained)}
+           :value (str retained " bytes")}
           {:metric "Allocation count"
            :value num-allocations}
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value (if (pos? (long num-allocations))
+           :value (if (pos? (long total-allocated))
                     (clojure.core/format "%.1f%%"
-                                         (* 100.0 (/ (double num-freed)
-                                                     (double num-allocations))))
+                                         (* 100.0 (/ (double total-freed)
+                                                     (double total-allocated))))
                     "N/A")}])))))
 
 (defmethod view/allocation-hotspots* :kindly
@@ -435,12 +435,13 @@
         (when (seq hotspots)
           (kindly-heading "Allocation Hotspots")
           (kindly-table
-           (mapv (fn [{:keys [call-site object-types count bytes freed-count freed-bytes]}]
-                   {:call-site (viewer-common/format-call-site call-site object-types)
+           (mapv (fn [{:keys [call-site object-type count bytes freed-count freed-bytes]}]
+                   {:call-site (viewer-common/format-call-site call-site nil)
+                    :object-type (or object-type "")
                     :count count
-                    :bytes (format/format-value :memory bytes)
+                    :bytes bytes
                     :freed-count freed-count
-                    :freed-bytes (format/format-value :memory freed-bytes)})
+                    :freed-bytes freed-bytes})
                  hotspots)))))))
 
 (defmethod view/allocation-by-type* :kindly
@@ -456,9 +457,9 @@
            (mapv (fn [[type-name {:keys [count bytes freed-count freed-bytes]}]]
                    {:type type-name
                     :count count
-                    :bytes (format/format-value :memory bytes)
+                    :bytes bytes
                     :freed-count freed-count
-                    :freed-bytes (format/format-value :memory freed-bytes)})
+                    :freed-bytes freed-bytes})
                  sorted)))))))
 
 ;;; Noop implementations for views not applicable to Kindly output

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -10,7 +10,6 @@
   (:refer-clojure :exclude [flush])
   (:require
    [criterium.metric :as metric]
-   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -405,7 +405,8 @@
   (let [summary-id (or summary-id :allocation-summary)
         summary (data-map summary-id)]
     (when summary
-      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed
+                    freed-ratio]} summary
             retained (- (long total-allocated) (long total-freed))]
         (kindly-heading "Allocation Summary")
         (kindly-table
@@ -420,11 +421,7 @@
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value (if (pos? (long total-allocated))
-                    (clojure.core/format "%.1f%%"
-                                         (* 100.0 (/ (double total-freed)
-                                                     (double total-allocated))))
-                    "N/A")}])))))
+           :value (clojure.core/format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :kindly
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -60,6 +60,14 @@
      (assoc spec :$schema "https://vega.github.io/schema/vega-lite/v5.json")
      {:kindly/kind :kind/vega-lite})))
 
+(defn kindly-vega
+  "Add a full Vega chart to the accumulator."
+  [spec]
+  (kindly-add
+   (with-meta
+     (assoc spec :$schema "https://vega.github.io/schema/vega/v5.json")
+     {:kindly/kind :kind/vega})))
+
 (defn flush
   "Return accumulated values as a kind/fragment and clear the accumulator.
   Also stores the fragment in `last-fragment` for retrieval after bench completes."
@@ -402,7 +410,7 @@
 (defmethod view/allocation-summary* :kindly
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary    (data-map summary-id)]
+        summary (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
                     ^double freed-ratio]}
@@ -411,17 +419,17 @@
         (kindly-heading "Allocation Summary")
         (kindly-table
          [{:metric "Total allocated"
-           :value  (str total-allocated " bytes")}
+           :value (str total-allocated " bytes")}
           {:metric "Total freed"
-           :value  (str total-freed " bytes")}
+           :value (str total-freed " bytes")}
           {:metric "Retained"
-           :value  (str retained " bytes")}
+           :value (str retained " bytes")}
           {:metric "Allocation count"
-           :value  num-allocations}
+           :value num-allocations}
           {:metric "Freed count"
-           :value  num-freed}
+           :value num-freed}
           {:metric "Freed ratio"
-           :value  (clojure.core/format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value (clojure.core/format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :kindly
   [_ {:keys [hotspots-id]} data-map]
@@ -458,6 +466,14 @@
                     :freed-count freed-count
                     :freed-bytes freed-bytes})
                  sorted)))))))
+
+(defmethod view/allocation-treemap* :kindly
+  [_ {:keys [treemap-id]} data-map]
+  (let [treemap-id (or treemap-id :allocation-treemap)
+        treemap-data (data-map treemap-id)]
+    (when (and treemap-data (:root treemap-data))
+      (kindly-heading "Allocation Treemap")
+      (kindly-vega (charts/treemap-vega-spec treemap-data {})))))
 
 ;;; Noop implementations for views not applicable to Kindly output
 

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -398,13 +398,7 @@
             summary
             total-allocated (long total-allocated)
             total-freed (long total-freed)
-            retained (- total-allocated total-freed)
-            freed-ratio (or freed-ratio
-                            (when (pos? total-allocated)
-                              (/ (double total-freed) (double total-allocated))))
-            freed-ratio-str (if (some? freed-ratio)
-                              (format "%.1f%%" (* 100.0 (double freed-ratio)))
-                              "N/A")]
+            retained (- total-allocated total-freed)]
         (heading "Allocation Summary")
         (portal-table
          [{:metric "Total allocated" :value total-allocated}
@@ -412,7 +406,8 @@
           {:metric "Retained" :value retained}
           {:metric "Allocation count" :value num-allocations}
           {:metric "Freed count" :value num-freed}
-          {:metric "Freed ratio" :value freed-ratio-str}])))))
+          {:metric "Freed ratio"
+           :value (format "%.1f%%" (* 100.0 (double freed-ratio)))}])))))
 
 (defmethod view/allocation-hotspots* :portal
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -384,11 +384,13 @@
 (defmethod view/allocation-summary* :portal
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary (data-map summary-id)]
+        summary    (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
-                    freed-ratio]} summary
-            retained (- (long total-allocated) (long total-freed))]
+                    ^double freed-ratio]}
+            summary
+            retained (- (long total-allocated)
+                        (long total-freed))]
         (heading "Allocation Summary")
         (portal-table
          [{:metric "Total allocated" :value total-allocated}
@@ -397,7 +399,7 @@
           {:metric "Allocation count" :value num-allocations}
           {:metric "Freed count" :value num-freed}
           {:metric "Freed ratio"
-           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value  (format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :portal
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -220,7 +220,7 @@
 (defmethod view/domain-grouped* :portal
   [_ {:keys [grouped-id]} data-map]
   (let [grouped-id (or grouped-id :grouped)
-        grouped    (data-map grouped-id)]
+        grouped (data-map grouped-id)]
     (when-let [{:keys [rows] heading-text :heading}
                (viewer-common/prepare-domain-grouped-table grouped)]
       (heading heading-text)
@@ -229,7 +229,7 @@
 (defmethod view/domain-comparison* :portal
   [_ {:keys [comparison-id]} data-map]
   (let [comparison-id (or comparison-id :comparison)
-        comparison    (data-map comparison-id)]
+        comparison (data-map comparison-id)]
     (when-let [tables (viewer-common/prepare-domain-comparison-tables
                        comparison)]
       (doseq [{:keys [rows] heading-text :heading} tables]
@@ -239,18 +239,18 @@
 (defmethod view/domain-regression* :portal
   [_ {:keys [regression-id extract-id tolerance]} data-map]
   (let [regression-id (or regression-id :regression)
-        regression    (data-map regression-id)
-        tolerance     (double (or tolerance 0.01))
-        chart-width   600
-        chart-height  400
+        regression (data-map regression-id)
+        tolerance (double (or tolerance 0.01))
+        chart-width 600
+        chart-height 400
         table-options {:best-fit-marker "✓"
-                       :plotted-marker  ""
-                       :tolerance       tolerance}]
+                       :plotted-marker ""
+                       :tolerance tolerance}]
     (when regression
       (let [{:keys [axis regressions impl-axis implementations]}
             regression
-            extract-id  (or extract-id :extract)
-            extract     (data-map extract-id)
+            extract-id (or extract-id :extract)
+            extract (data-map extract-id)
             multi-impl? (> (count implementations) 1)]
 
         (if multi-impl?
@@ -258,7 +258,7 @@
           (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  impl-keys           (sort (keys by-impl))]
+                  impl-keys (sort (keys by-impl))]
               (heading (str "Domain Regression (axis: " (name axis)
                             ", metric: " (pr-str metric)
                             ", by: " (name impl-axis) ")"))
@@ -270,65 +270,65 @@
               ;; Charts
               (when-let [point-data (viewer-common/prepare-regression-points
                                      metric-extract-data
-                                     {:axis              axis
-                                      :impl-axis         impl-axis
+                                     {:axis axis
+                                      :impl-axis impl-axis
                                       :has-error-bounds? with-error-bounds
-                                      :metric            metric})]
+                                      :metric metric})]
                 (let [{:keys [points unit]} point-data
                       line-pts
                       (viewer-common/prepare-regression-fit-lines
                        point-data
-                       {:by-impl   by-impl
+                       {:by-impl by-impl
                         :impl-keys impl-keys})
-                      y-title               (if (seq unit)
-                                              (str (pr-str metric)
-                                                   " (" unit ")")
-                                              (pr-str metric))
-                      residual-title        (if (seq unit)
-                                              (str "Residual (" unit ")")
-                                              "Residual")]
+                      y-title (if (seq unit)
+                                (str (pr-str metric)
+                                     " (" unit ")")
+                                (pr-str metric))
+                      residual-title (if (seq unit)
+                                       (str "Residual (" unit ")")
+                                       "Residual")]
                   (when (seq points)
                     (portal-vega-lite
                      (charts/regression-chart-spec
                       points line-pts
-                      {:width             chart-width :height  chart-height
-                       :axis-name         (name axis) :y-title y-title
-                       :color-field       "impl"
+                      {:width chart-width :height chart-height
+                       :axis-name (name axis) :y-title y-title
+                       :color-field "impl"
                        :has-error-bounds? with-error-bounds}))
                     ;; Residual plot
                     (let [residual-pts
                           (viewer-common/prepare-regression-residuals
                            point-data
-                           {:axis              axis
-                            :impl-axis         impl-axis
+                           {:axis axis
+                            :impl-axis impl-axis
                             :has-error-bounds? with-error-bounds
-                            :by-impl           by-impl
-                            :impl-keys         impl-keys})]
+                            :by-impl by-impl
+                            :impl-keys impl-keys})]
                       (heading "Residual Plot")
                       (portal-vega-lite
                        (charts/regression-residual-spec
                         residual-pts
-                        {:width       chart-width
-                         :height      (/ chart-height 2)
-                         :axis-name   (name axis) :residual-title residual-title
+                        {:width chart-width
+                         :height (/ chart-height 2)
+                         :axis-name (name axis) :residual-title residual-title
                          :color-field "impl"}))))))))
 
           ;; Single-implementation mode
           (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  best-r-squared      (when best-fit
-                                        (->> models
-                                             (filter #(= (:id %) best-fit))
-                                             first
-                                             :r-squared))
-                  models-to-plot      (when best-r-squared
-                                        (->> models
-                                             (filter
-                                              #(>= (double (:r-squared %))
-                                                   (* (double best-r-squared)
-                                                      (- 1 tolerance))))
-                                             (sort-by :r-squared >)))]
+                  best-r-squared (when best-fit
+                                   (->> models
+                                        (filter #(= (:id %) best-fit))
+                                        first
+                                        :r-squared))
+                  models-to-plot (when best-r-squared
+                                   (->> models
+                                        (filter
+                                         #(>= (double (:r-squared %))
+                                              (* (double best-r-squared)
+                                                 (- 1 tolerance))))
+                                        (sort-by :r-squared >)))]
               (heading (str "Domain Regression (axis: " (name axis)
                             ", metric: " (pr-str metric) ")"))
               ;; Model table
@@ -341,17 +341,17 @@
               (when (and metric-extract-data (seq models-to-plot))
                 (when-let [point-data (viewer-common/prepare-regression-points
                                        metric-extract-data
-                                       {:axis              axis
+                                       {:axis axis
                                         :has-error-bounds? with-error-bounds
-                                        :metric            metric})]
+                                        :metric metric})]
                   (let [{:keys [points unit]}
                         point-data
-                        line-pts       (viewer-common/prepare-regression-fit-lines
-                                        point-data
-                                        {:models models-to-plot})
-                        y-title        (if (seq unit)
-                                         (str (pr-str metric) " (" unit ")")
-                                         (pr-str metric))
+                        line-pts (viewer-common/prepare-regression-fit-lines
+                                  point-data
+                                  {:models models-to-plot})
+                        y-title (if (seq unit)
+                                  (str (pr-str metric) " (" unit ")")
+                                  (pr-str metric))
                         residual-title (if (seq unit)
                                          (str "Residual (" unit ")")
                                          "Residual")]
@@ -359,25 +359,25 @@
                       (portal-vega-lite
                        (charts/regression-chart-spec
                         points line-pts
-                        {:width             chart-width :height  chart-height
-                         :axis-name         (name axis) :y-title y-title
-                         :color-field       "model"
+                        {:width chart-width :height chart-height
+                         :axis-name (name axis) :y-title y-title
+                         :color-field "model"
                          :has-error-bounds? with-error-bounds}))
                       ;; Residual plot
                       (let [residual-pts (viewer-common/prepare-regression-residuals
                                           point-data
-                                          {:axis              axis
+                                          {:axis axis
                                            :has-error-bounds? with-error-bounds
-                                           :models            models-to-plot})]
+                                           :models models-to-plot})]
                         (heading "Residual Plot")
                         (portal-vega-lite
                          (charts/regression-residual-spec
                           residual-pts
-                          {:width          chart-width
-                           :height         (/ chart-height 2)
-                           :axis-name      (name axis)
+                          {:width chart-width
+                           :height (/ chart-height 2)
+                           :axis-name (name axis)
                            :residual-title residual-title
-                           :color-field    "model"}))))))))))))))
+                           :color-field "model"}))))))))))))))
 
 ;;; Allocation Views
 
@@ -410,8 +410,9 @@
         (when (seq hotspots)
           (heading "Allocation Hotspots")
           (portal-table
-           (mapv (fn [{:keys [call-site object-types count bytes freed-count freed-bytes]}]
-                   {:call-site (viewer-common/format-call-site call-site object-types)
+           (mapv (fn [{:keys [call-site object-type count bytes freed-count freed-bytes]}]
+                   {:call-site (viewer-common/format-call-site call-site nil)
+                    :object-type (or object-type "")
                     :count count
                     :bytes bytes
                     :freed-count freed-count

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -401,11 +401,6 @@
                                                  (double num-allocations))))
                     "N/A")}])))))
 
-(defn- format-call-site
-  "Format a call site for display."
-  [{:keys [call-class call-method call-file call-line]}]
-  (str call-class "." call-method " (" call-file ":" call-line ")"))
-
 (defmethod view/allocation-hotspots* :portal
   [_ {:keys [hotspots-id]} data-map]
   (let [hotspots-id (or hotspots-id :allocation-hotspots)
@@ -416,7 +411,7 @@
           (heading "Allocation Hotspots")
           (portal-table
            (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
-                   {:call-site (format-call-site call-site)
+                   {:call-site (viewer-common/format-call-site call-site)
                     :count count
                     :bytes bytes
                     :freed-count freed-count

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -394,10 +394,17 @@
         summary (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
-                    ^double freed-ratio]}
+                    freed-ratio]}
             summary
-            retained (- (long total-allocated)
-                        (long total-freed))]
+            total-allocated (long total-allocated)
+            total-freed (long total-freed)
+            retained (- total-allocated total-freed)
+            freed-ratio (or freed-ratio
+                            (when (pos? total-allocated)
+                              (/ (double total-freed) (double total-allocated))))
+            freed-ratio-str (if (some? freed-ratio)
+                              (format "%.1f%%" (* 100.0 (double freed-ratio)))
+                              "N/A")]
         (heading "Allocation Summary")
         (portal-table
          [{:metric "Total allocated" :value total-allocated}
@@ -405,8 +412,7 @@
           {:metric "Retained" :value retained}
           {:metric "Allocation count" :value num-allocations}
           {:metric "Freed count" :value num-freed}
-          {:metric "Freed ratio"
-           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
+          {:metric "Freed ratio" :value freed-ratio-str}])))))
 
 (defmethod view/allocation-hotspots* :portal
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -386,7 +386,8 @@
   (let [summary-id (or summary-id :allocation-summary)
         summary (data-map summary-id)]
     (when summary
-      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed
+                    freed-ratio]} summary
             retained (- (long total-allocated) (long total-freed))]
         (heading "Allocation Summary")
         (portal-table
@@ -396,10 +397,7 @@
           {:metric "Allocation count" :value num-allocations}
           {:metric "Freed count" :value num-freed}
           {:metric "Freed ratio"
-           :value (if (pos? (long num-allocations))
-                    (format "%.1f%%" (* 100.0 (/ (double num-freed)
-                                                 (double num-allocations))))
-                    "N/A")}])))))
+           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :portal
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -378,3 +378,65 @@
                            :axis-name      (name axis)
                            :residual-title residual-title
                            :color-field    "model"}))))))))))))))
+
+;;; Allocation Views
+
+(defmethod view/allocation-summary* :portal
+  [_ {:keys [summary-id]} data-map]
+  (let [summary-id (or summary-id :allocation-summary)
+        summary (data-map summary-id)]
+    (when summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+            retained (- (long total-allocated) (long total-freed))]
+        (heading "Allocation Summary")
+        (portal-table
+         [{:metric "Total allocated" :value total-allocated}
+          {:metric "Total freed" :value total-freed}
+          {:metric "Retained" :value retained}
+          {:metric "Allocation count" :value num-allocations}
+          {:metric "Freed count" :value num-freed}
+          {:metric "Freed ratio"
+           :value (if (pos? (long num-allocations))
+                    (format "%.1f%%" (* 100.0 (/ (double num-freed)
+                                                 (double num-allocations))))
+                    "N/A")}])))))
+
+(defn- format-call-site
+  "Format a call site for display."
+  [{:keys [call-class call-method call-file call-line]}]
+  (str call-class "." call-method " (" call-file ":" call-line ")"))
+
+(defmethod view/allocation-hotspots* :portal
+  [_ {:keys [hotspots-id]} data-map]
+  (let [hotspots-id (or hotspots-id :allocation-hotspots)
+        hotspots-map (data-map hotspots-id)]
+    (when hotspots-map
+      (let [hotspots (:hotspots hotspots-map)]
+        (when (seq hotspots)
+          (heading "Allocation Hotspots")
+          (portal-table
+           (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
+                   {:call-site (format-call-site call-site)
+                    :count count
+                    :bytes bytes
+                    :freed-count freed-count
+                    :freed-bytes freed-bytes})
+                 hotspots)))))))
+
+(defmethod view/allocation-by-type* :portal
+  [_ {:keys [by-type-id]} data-map]
+  (let [by-type-id (or by-type-id :allocation-by-type)
+        by-type-map (data-map by-type-id)]
+    (when by-type-map
+      (let [by-type (:by-type by-type-map)
+            sorted (sort-by (comp :bytes second) > by-type)]
+        (when (seq sorted)
+          (heading "Allocations by Type")
+          (portal-table
+           (mapv (fn [[type-name {:keys [count bytes freed-count freed-bytes]}]]
+                   {:type type-name
+                    :count count
+                    :bytes bytes
+                    :freed-count freed-count
+                    :freed-bytes freed-bytes})
+                 sorted)))))))

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -56,6 +56,13 @@
           (assoc s :$schema "https://vega.github.io/schema/vega-lite/v5.json")
           {:portal.viewer/default :portal.viewer/vega-lite})))
 
+(defn portal-vega
+  "Submit a full Vega spec to Portal."
+  [s]
+  (tap> (with-meta
+          (assoc s :$schema "https://vega.github.io/schema/vega/v5.json")
+          {:portal.viewer/default :portal.viewer/vega})))
+
 (defn heading [s]
   (portal-heading [:b s]))
 
@@ -384,7 +391,7 @@
 (defmethod view/allocation-summary* :portal
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary    (data-map summary-id)]
+        summary (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
                     ^double freed-ratio]}
@@ -399,7 +406,7 @@
           {:metric "Allocation count" :value num-allocations}
           {:metric "Freed count" :value num-freed}
           {:metric "Freed ratio"
-           :value  (format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :portal
   [_ {:keys [hotspots-id]} data-map]
@@ -436,3 +443,11 @@
                     :freed-count freed-count
                     :freed-bytes freed-bytes})
                  sorted)))))))
+
+(defmethod view/allocation-treemap* :portal
+  [_ {:keys [treemap-id]} data-map]
+  (let [treemap-id (or treemap-id :allocation-treemap)
+        treemap-data (data-map treemap-id)]
+    (when (and treemap-data (:root treemap-data))
+      (heading "Allocation Treemap")
+      (portal-vega (charts/treemap-vega-spec treemap-data {})))))

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -410,8 +410,8 @@
         (when (seq hotspots)
           (heading "Allocation Hotspots")
           (portal-table
-           (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
-                   {:call-site (viewer-common/format-call-site call-site)
+           (mapv (fn [{:keys [call-site object-types count bytes freed-count freed-bytes]}]
+                   {:call-site (viewer-common/format-call-site call-site object-types)
                     :count count
                     :bytes bytes
                     :freed-count freed-count

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -306,11 +306,18 @@
   (let [summary-id (or summary-id :allocation-summary)
         summary (data-map summary-id)]
     (when summary
-      (let [{:keys [^long total-allocated ^long total-freed
-                    num-allocations num-freed
-                    ^double freed-ratio]}
+      (let [{:keys [total-allocated total-freed num-allocations num-freed
+                    freed-ratio]}
             summary
-            retained (- total-allocated total-freed)]
+            total-allocated (long total-allocated)
+            total-freed (long total-freed)
+            retained (- total-allocated total-freed)
+            freed-ratio (or freed-ratio
+                            (when (pos? total-allocated)
+                              (/ (double total-freed) (double total-allocated))))
+            freed-ratio-str (if (some? freed-ratio)
+                              (format "%.1f%%" (* 100.0 (double freed-ratio)))
+                              "N/A")]
         (println "Allocation Summary:")
         (pprint/print-table
          [:metric :value]
@@ -325,7 +332,7 @@
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value freed-ratio-str}])))))
 
 (defmethod view/allocation-hotspots* :pprint
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -231,13 +231,13 @@
 (defmethod view/domain-extract* :pprint
   [_ {:keys [extract-id]} data-map]
   (let [extract-id (or extract-id :extract)
-        extract    (data-map extract-id)]
+        extract (data-map extract-id)]
     (when-let [{:keys [heading coord-header col-headers rows]}
                (viewer-common/prepare-domain-extract-table extract {:header-sep " "})]
       (println heading)
       ;; pprint/print-table needs string keys for column headers to display
       ;; without colon prefix; transform the coord key from keyword to string
-      (let [coord-key   (keyword coord-header)
+      (let [coord-key (keyword coord-header)
             pprint-rows (mapv #(-> %
                                    (assoc coord-header (get % coord-key))
                                    (dissoc coord-key))
@@ -247,7 +247,7 @@
 (defmethod view/domain-grouped* :pprint
   [_ {:keys [grouped-id]} data-map]
   (let [grouped-id (or grouped-id :grouped)
-        grouped    (data-map grouped-id)]
+        grouped (data-map grouped-id)]
     (when-let [{:keys [heading rows]} (viewer-common/prepare-domain-grouped-table
                                        grouped)]
       (println heading)
@@ -265,21 +265,21 @@
 (defmethod view/domain-regression* :pprint
   [_ {:keys [regression-id tolerance]} data-map]
   (let [regression-id (or regression-id :regression)
-        regression    (data-map regression-id)
-        tolerance     (or tolerance 0.01)
+        regression (data-map regression-id)
+        tolerance (or tolerance 0.01)
         table-options {:best-fit-marker "<- best"
-                       :plotted-marker  "[plotted]"
-                       :tolerance       tolerance}]
+                       :plotted-marker "[plotted]"
+                       :tolerance tolerance}]
     (when regression
       (let [{:keys [axis regressions impl-axis implementations]} regression
-            multi-impl?                                          (> (count implementations) 1)]
+            multi-impl? (> (count implementations) 1)]
         (if multi-impl?
           ;; Multi-implementation mode
           (doseq [[_metric-id {:keys [metric by-impl]}] regressions]
             (println (format "Domain Regression (axis: %s, metric: %s, by: %s)"
                              (name axis) (pr-str metric) (name impl-axis)))
             (if (seq by-impl)
-              (let [impl-keys  (sort (keys by-impl))
+              (let [impl-keys (sort (keys by-impl))
                     table-rows (viewer-common/prepare-regression-model-table-multi-impl
                                 by-impl impl-keys table-options)]
                 (pprint/print-table
@@ -305,7 +305,7 @@
 (defmethod view/allocation-summary* :pprint
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary    (data-map summary-id)]
+        summary (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
             retained (- total-allocated total-freed)]
@@ -313,18 +313,18 @@
         (pprint/print-table
          [:metric :value]
          [{:metric "Total allocated"
-           :value (format/format-value :memory total-allocated)}
+           :value (str total-allocated " bytes")}
           {:metric "Total freed"
-           :value (format/format-value :memory total-freed)}
+           :value (str total-freed " bytes")}
           {:metric "Retained"
-           :value (format/format-value :memory retained)}
+           :value (str retained " bytes")}
           {:metric "Allocation count"
            :value num-allocations}
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value (if (pos? num-allocations)
-                    (format "%.1f%%" (* 100.0 (/ num-freed num-allocations)))
+           :value (if (pos? total-allocated)
+                    (format "%.1f%%" (* 100.0 (/ (double total-freed) total-allocated)))
                     "N/A")}])))))
 
 (defmethod view/allocation-hotspots* :pprint
@@ -336,13 +336,14 @@
         (when (seq hotspots)
           (println "Allocation Hotspots:")
           (pprint/print-table
-           [:count :bytes :freed-count :freed-bytes :call-site]
-           (mapv (fn [{:keys [call-site object-types count bytes freed-count freed-bytes]}]
+           [:count :bytes :freed-count :freed-bytes :object-type :call-site]
+           (mapv (fn [{:keys [call-site object-type count bytes freed-count freed-bytes]}]
                    {:count count
-                    :bytes (format/format-value :memory bytes)
+                    :bytes bytes
                     :freed-count freed-count
-                    :freed-bytes (format/format-value :memory freed-bytes)
-                    :call-site (viewer-common/format-call-site call-site object-types)})
+                    :freed-bytes freed-bytes
+                    :object-type (or object-type "")
+                    :call-site (viewer-common/format-call-site call-site nil)})
                  hotspots)))))))
 
 (defmethod view/allocation-by-type* :pprint
@@ -359,7 +360,7 @@
            (mapv (fn [[type-name {:keys [count bytes freed-count freed-bytes]}]]
                    {:type type-name
                     :count count
-                    :bytes (format/format-value :memory bytes)
+                    :bytes bytes
                     :freed-count freed-count
-                    :freed-bytes (format/format-value :memory freed-bytes)})
+                    :freed-bytes freed-bytes})
                  sorted)))))))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -305,26 +305,28 @@
 (defmethod view/allocation-summary* :pprint
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary (data-map summary-id)]
+        summary    (data-map summary-id)]
     (when summary
-      (let [{:keys [total-allocated total-freed num-allocations num-freed
-                    freed-ratio]} summary
+      (let [{:keys [^long total-allocated ^long total-freed
+                    num-allocations num-freed
+                    ^double freed-ratio]}
+            summary
             retained (- total-allocated total-freed)]
         (println "Allocation Summary:")
         (pprint/print-table
          [:metric :value]
          [{:metric "Total allocated"
-           :value (str total-allocated " bytes")}
+           :value  (str total-allocated " bytes")}
           {:metric "Total freed"
-           :value (str total-freed " bytes")}
+           :value  (str total-freed " bytes")}
           {:metric "Retained"
-           :value (str retained " bytes")}
+           :value  (str retained " bytes")}
           {:metric "Allocation count"
-           :value num-allocations}
+           :value  num-allocations}
           {:metric "Freed count"
-           :value num-freed}
+           :value  num-freed}
           {:metric "Freed ratio"
-           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value  (format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :pprint
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.pprint :as pprint]
    [criterium.metric :as metric]
+   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
@@ -298,3 +299,67 @@
                 (pprint/print-table [:model :r-squared :equation :best-fit] table-rows))
               (println "  (insufficient data for regression)"))
             (println)))))))
+
+;;; Allocation Views
+
+(defmethod view/allocation-summary* :pprint
+  [_ {:keys [summary-id]} data-map]
+  (let [summary-id (or summary-id :allocation-summary)
+        summary    (data-map summary-id)]
+    (when summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+            retained (- total-allocated total-freed)]
+        (println "Allocation Summary:")
+        (pprint/print-table
+         [:metric :value]
+         [{:metric "Total allocated"
+           :value (format/format-value :memory total-allocated)}
+          {:metric "Total freed"
+           :value (format/format-value :memory total-freed)}
+          {:metric "Retained"
+           :value (format/format-value :memory retained)}
+          {:metric "Allocation count"
+           :value num-allocations}
+          {:metric "Freed count"
+           :value num-freed}
+          {:metric "Freed ratio"
+           :value (if (pos? num-allocations)
+                    (format "%.1f%%" (* 100.0 (/ num-freed num-allocations)))
+                    "N/A")}])))))
+
+(defmethod view/allocation-hotspots* :pprint
+  [_ {:keys [hotspots-id]} data-map]
+  (let [hotspots-id (or hotspots-id :allocation-hotspots)
+        hotspots-map (data-map hotspots-id)]
+    (when hotspots-map
+      (let [hotspots (:hotspots hotspots-map)]
+        (when (seq hotspots)
+          (println "Allocation Hotspots:")
+          (pprint/print-table
+           [:count :bytes :freed-count :freed-bytes :call-site]
+           (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
+                   {:count count
+                    :bytes (format/format-value :memory bytes)
+                    :freed-count freed-count
+                    :freed-bytes (format/format-value :memory freed-bytes)
+                    :call-site (viewer-common/format-call-site call-site)})
+                 hotspots)))))))
+
+(defmethod view/allocation-by-type* :pprint
+  [_ {:keys [by-type-id]} data-map]
+  (let [by-type-id (or by-type-id :allocation-by-type)
+        by-type-map (data-map by-type-id)]
+    (when by-type-map
+      (let [by-type (:by-type by-type-map)
+            sorted (sort-by (comp :bytes second) > by-type)]
+        (when (seq sorted)
+          (println "Allocations by Type:")
+          (pprint/print-table
+           [:type :count :bytes :freed-count :freed-bytes]
+           (mapv (fn [[type-name {:keys [count bytes freed-count freed-bytes]}]]
+                   {:type type-name
+                    :count count
+                    :bytes (format/format-value :memory bytes)
+                    :freed-count freed-count
+                    :freed-bytes (format/format-value :memory freed-bytes)})
+                 sorted)))))))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -307,7 +307,8 @@
   (let [summary-id (or summary-id :allocation-summary)
         summary (data-map summary-id)]
     (when summary
-      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed
+                    freed-ratio]} summary
             retained (- total-allocated total-freed)]
         (println "Allocation Summary:")
         (pprint/print-table
@@ -323,9 +324,7 @@
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value (if (pos? total-allocated)
-                    (format "%.1f%%" (* 100.0 (/ (double total-freed) total-allocated)))
-                    "N/A")}])))))
+           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :pprint
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -311,13 +311,7 @@
             summary
             total-allocated (long total-allocated)
             total-freed (long total-freed)
-            retained (- total-allocated total-freed)
-            freed-ratio (or freed-ratio
-                            (when (pos? total-allocated)
-                              (/ (double total-freed) (double total-allocated))))
-            freed-ratio-str (if (some? freed-ratio)
-                              (format "%.1f%%" (* 100.0 (double freed-ratio)))
-                              "N/A")]
+            retained (- total-allocated total-freed)]
         (println "Allocation Summary:")
         (pprint/print-table
          [:metric :value]
@@ -332,7 +326,7 @@
           {:metric "Freed count"
            :value num-freed}
           {:metric "Freed ratio"
-           :value freed-ratio-str}])))))
+           :value (format "%.1f%%" (* 100.0 (double freed-ratio)))}])))))
 
 (defmethod view/allocation-hotspots* :pprint
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -304,7 +304,7 @@
 (defmethod view/allocation-summary* :pprint
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary    (data-map summary-id)]
+        summary (data-map summary-id)]
     (when summary
       (let [{:keys [^long total-allocated ^long total-freed
                     num-allocations num-freed
@@ -315,17 +315,17 @@
         (pprint/print-table
          [:metric :value]
          [{:metric "Total allocated"
-           :value  (str total-allocated " bytes")}
+           :value (str total-allocated " bytes")}
           {:metric "Total freed"
-           :value  (str total-freed " bytes")}
+           :value (str total-freed " bytes")}
           {:metric "Retained"
-           :value  (str retained " bytes")}
+           :value (str retained " bytes")}
           {:metric "Allocation count"
-           :value  num-allocations}
+           :value num-allocations}
           {:metric "Freed count"
-           :value  num-freed}
+           :value num-freed}
           {:metric "Freed ratio"
-           :value  (format "%.1f%%" (* 100.0 freed-ratio))}])))))
+           :value (format "%.1f%%" (* 100.0 freed-ratio))}])))))
 
 (defmethod view/allocation-hotspots* :pprint
   [_ {:keys [hotspots-id]} data-map]
@@ -364,3 +364,11 @@
                     :freed-count freed-count
                     :freed-bytes freed-bytes})
                  sorted)))))))
+
+(defmethod view/allocation-treemap* :pprint
+  [_ {:keys [treemap-id]} data-map]
+  (let [treemap-id (or treemap-id :allocation-treemap)
+        treemap-data (data-map treemap-id)]
+    (when (and treemap-data (:root treemap-data))
+      (println)
+      (println (viewer-common/render-ascii-treemap treemap-data)))))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -337,12 +337,12 @@
           (println "Allocation Hotspots:")
           (pprint/print-table
            [:count :bytes :freed-count :freed-bytes :call-site]
-           (mapv (fn [{:keys [call-site count bytes freed-count freed-bytes]}]
+           (mapv (fn [{:keys [call-site object-types count bytes freed-count freed-bytes]}]
                    {:count count
                     :bytes (format/format-value :memory bytes)
                     :freed-count freed-count
                     :freed-bytes (format/format-value :memory freed-bytes)
-                    :call-site (viewer-common/format-call-site call-site)})
+                    :call-site (viewer-common/format-call-site call-site object-types)})
                  hotspots)))))))
 
 (defmethod view/allocation-by-type* :pprint

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.pprint :as pprint]
    [criterium.metric :as metric]
-   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -897,13 +897,13 @@
           (println (format "%8s %12s %8s %12s  %s"
                            "Count" "Bytes" "Freed" "Freed Bytes" "Call Site"))
           (println (apply str (repeat 80 "-")))
-          (doseq [{:keys [call-site count bytes freed-count freed-bytes]} hotspots]
+          (doseq [{:keys [call-site object-types count bytes freed-count freed-bytes]} hotspots]
             (println (format "%8d %12s %8d %12s  %s"
                              count
                              (format/format-value :memory bytes)
                              freed-count
                              (format/format-value :memory freed-bytes)
-                             (viewer-common/format-call-site call-site)))))))))
+                             (viewer-common/format-call-site call-site object-types)))))))))
 
 (defmethod view/allocation-by-type* :print
   [_ {:keys [by-type-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -886,11 +886,6 @@
                            "Freed ratio"
                            (* 100.0 (/ num-freed num-allocations)))))))))
 
-(defn- format-call-site
-  "Format a call site for display."
-  [{:keys [call-class call-method call-file call-line]}]
-  (str call-class "." call-method " (" call-file ":" call-line ")"))
-
 (defmethod view/allocation-hotspots* :print
   [_ {:keys [hotspots-id]} data-map]
   (let [hotspots-id (or hotspots-id :allocation-hotspots)
@@ -908,7 +903,7 @@
                              (format/format-value :memory bytes)
                              freed-count
                              (format/format-value :memory freed-bytes)
-                             (format-call-site call-site)))))))))
+                             (viewer-common/format-call-site call-site)))))))))
 
 (defmethod view/allocation-by-type* :print
   [_ {:keys [by-type-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -867,10 +867,7 @@
                     freed-ratio]} summary
             total-allocated (long total-allocated)
             total-freed (long total-freed)
-            retained (- total-allocated total-freed)
-            freed-ratio (or freed-ratio
-                            (when (pos? total-allocated)
-                              (/ (double total-freed) (double total-allocated))))]
+            retained (- total-allocated total-freed)]
         (println)
         (println "Allocation Summary:")
         (println (format "  %16s: %12d bytes"
@@ -888,10 +885,9 @@
         (println (format "  %16s: %12d"
                          "Freed count"
                          num-freed))
-        (when (some? freed-ratio)
-          (println (format "  %16s: %12.1f%%"
-                           "Freed ratio"
-                           (* 100.0 (double freed-ratio)))))))))
+        (println (format "  %16s: %12.1f%%"
+                         "Freed ratio"
+                         (* 100.0 (double freed-ratio))))))))
 
 (defmethod view/allocation-hotspots* :print
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -432,7 +432,7 @@
   (when (some? value)
     (let [base-value (* (double value)
                         (viewer-common/metric-path->base-scale metric-path))
-          dimension  (viewer-common/metric-path->dimension metric-path)]
+          dimension (viewer-common/metric-path->dimension metric-path)]
       (if dimension
         (format/format-value dimension base-value)
         (format "%g" base-value)))))
@@ -462,8 +462,8 @@
   [coords]
   (if-not (every? map? coords)
     coords
-    (let [uniform-axes   (viewer-common/detect-uniform-axes coords)
-          first-coord    (first coords)
+    (let [uniform-axes (viewer-common/detect-uniform-axes coords)
+          first-coord (first coords)
           remaining-keys (count (apply dissoc first-coord uniform-axes))]
       (if (and (seq uniform-axes) (pos? remaining-keys))
         (mapv #(apply dissoc % uniform-axes) coords)
@@ -472,15 +472,15 @@
 (defmethod view/domain-extract* :print
   [_ {:keys [extract-id]} data-map]
   (let [extract-id (or extract-id :extract)
-        extract    (data-map extract-id)]
+        extract (data-map extract-id)]
     (when extract
       (doseq [[_metric-id {:keys [metric data]}] (:metrics extract)]
-        (let [raw-coords      (map first data)
+        (let [raw-coords (map first data)
               ;; Strip uniform axes (e.g., :impl :default for single-impl scenarios)
               stripped-coords (strip-uniform-axes raw-coords)
-              coord-map       (zipmap raw-coords stripped-coords)
+              coord-map (zipmap raw-coords stripped-coords)
               single-key-info (viewer-common/single-key-coord-info stripped-coords)
-              sorted-data     (sort-coords data single-key-info)]
+              sorted-data (sort-coords data single-key-info)]
           (println (format "Domain Extract: %s" (pr-str metric)))
           (doseq [[coord value] sorted-data]
             (let [display-coord (get coord-map coord coord)]
@@ -492,7 +492,7 @@
 (defmethod view/domain-grouped* :print
   [_ {:keys [grouped-id]} data-map]
   (let [grouped-id (or grouped-id :grouped)
-        grouped    (data-map grouped-id)]
+        grouped (data-map grouped-id)]
     (when-let [{:keys [heading rows]} (viewer-common/prepare-domain-grouped-table
                                        grouped)]
       (println heading)
@@ -734,7 +734,7 @@
 (defmethod view/domain-comparison* :print
   [_ {:keys [comparison-id]} data-map]
   (let [comparison-id (or comparison-id :comparison)
-        comparison    (data-map comparison-id)]
+        comparison (data-map comparison-id)]
     (when comparison
       (let [{:keys [axis metric metrics implementations data]} comparison]
         (if metrics
@@ -749,14 +749,14 @@
           (if (and (seq data) (some #(seq (second %)) data))
             (if implementations
               (let [data-keys (set (keys data))
-                    missing   (remove data-keys implementations)]
+                    missing (remove data-keys implementations)]
                 (when (seq missing)
                   (throw
                    (ex-info
                     "Domain :implementations do not match comparison data keys"
                     {:implementations implementations
-                     :data-keys       (keys data)
-                     :missing         missing})))
+                     :data-keys (keys data)
+                     :missing missing})))
                 (print-single-metric-factor-table
                  axis
                  metric
@@ -768,8 +768,8 @@
 (defmethod view/domain-regression* :print
   [_ {:keys [regression-id tolerance]} data-map]
   (let [regression-id (or regression-id :regression)
-        regression    (data-map regression-id)
-        tolerance     (or tolerance 0.01)]
+        regression (data-map regression-id)
+        tolerance (or tolerance 0.01)]
     (when regression
       (let [{:keys [axis regressions impl-axis implementations]}
             regression
@@ -798,9 +798,9 @@
                   (println (format "  [%s]" (name impl-key)))
                   (if (seq models)
                     (let [sorted-models (sort-by :r-squared > models)
-                          label-width   (reduce
-                                         max
-                                         (map #(count (:label %)) models))]
+                          label-width (reduce
+                                       max
+                                       (map #(count (:label %)) models))]
                       (doseq [{:keys [id label equation-str r-squared]}
                               sorted-models]
                         (let [plotted? (and plotted-ids (plotted-ids id))]
@@ -825,21 +825,21 @@
                                         (filter #(= (:id %) best-fit))
                                         first
                                         :r-squared))
-                  plotted-ids    (when best-r-squared
-                                   (->> models
-                                        (filter
-                                         #(>= (:r-squared %)
-                                              (* best-r-squared
-                                                 (- 1 tolerance))))
-                                        (map :id)
-                                        set))]
+                  plotted-ids (when best-r-squared
+                                (->> models
+                                     (filter
+                                      #(>= (:r-squared %)
+                                           (* best-r-squared
+                                              (- 1 tolerance))))
+                                     (map :id)
+                                     set))]
               (println (format "Domain Regression (axis: %s, metric: %s)"
                                (name axis) (pr-str metric)))
               (if (seq models)
                 (let [sorted-models (sort-by :r-squared > models)
-                      label-width   (reduce
-                                     max
-                                     (map #(count (:label %)) models))]
+                      label-width (reduce
+                                   max
+                                   (map #(count (:label %)) models))]
                   (doseq [{:keys [id label equation-str r-squared]}
                           sorted-models]
                     (let [plotted? (and plotted-ids (plotted-ids id))]
@@ -861,49 +861,57 @@
 (defmethod view/allocation-summary* :print
   [_ {:keys [summary-id]} data-map]
   (let [summary-id (or summary-id :allocation-summary)
-        summary    (data-map summary-id)]
+        summary (data-map summary-id)]
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
             retained (- total-allocated total-freed)]
+        (println)
         (println "Allocation Summary:")
-        (println (format "%32s: %s"
+        (println (format "  %16s: %12d bytes"
                          "Total allocated"
-                         (format/format-value :memory total-allocated)))
-        (println (format "%32s: %s"
+                         total-allocated))
+        (println (format "  %16s: %12d bytes"
                          "Total freed"
-                         (format/format-value :memory total-freed)))
-        (println (format "%32s: %s"
+                         total-freed))
+        (println (format "  %16s: %12d bytes"
                          "Retained"
-                         (format/format-value :memory retained)))
-        (println (format "%32s: %d"
+                         retained))
+        (println (format "  %16s: %12d"
                          "Allocation count"
                          num-allocations))
-        (println (format "%32s: %d"
+        (println (format "  %16s: %12d"
                          "Freed count"
                          num-freed))
-        (when (pos? num-allocations)
-          (println (format "%32s: %.1f%%"
+        (when (pos? total-allocated)
+          (println (format "  %16s: %12.1f%%"
                            "Freed ratio"
-                           (* 100.0 (/ num-freed num-allocations)))))))))
+                           (* 100.0 (/ (double total-freed) total-allocated)))))))))
 
 (defmethod view/allocation-hotspots* :print
   [_ {:keys [hotspots-id]} data-map]
   (let [hotspots-id (or hotspots-id :allocation-hotspots)
         hotspots-map (data-map hotspots-id)]
     (when hotspots-map
-      (let [hotspots (:hotspots hotspots-map)]
+      (let [hotspots (:hotspots hotspots-map)
+            type-col-width 30
+            truncate-type (fn [s]
+                            (if (and s (> (count s) type-col-width))
+                              (str "…" (subs s (- (count s) (- type-col-width 1))))
+                              (or s "")))]
         (when (seq hotspots)
+          (println)
           (println "Allocation Hotspots:")
-          (println (format "%8s %12s %8s %12s  %s"
-                           "Count" "Bytes" "Freed" "Freed Bytes" "Call Site"))
-          (println (apply str (repeat 80 "-")))
-          (doseq [{:keys [call-site object-types count bytes freed-count freed-bytes]} hotspots]
-            (println (format "%8d %12s %8d %12s  %s"
+          (println (format "%8s %12s %8s %12s  %-30s  %s"
+                           "Count" "Bytes" "Freed" "Freed Bytes" "Object Type" "Call Site"))
+          (println (apply str (repeat 110 "-")))
+          (doseq [{:keys [call-site object-type count bytes freed-count freed-bytes]} hotspots]
+            (println (format "%8d %12d %8d %12d  %-30s  %s"
                              count
-                             (format/format-value :memory bytes)
+                             bytes
                              freed-count
-                             (format/format-value :memory freed-bytes)
-                             (viewer-common/format-call-site call-site object-types)))))))))
+                             freed-bytes
+                             (truncate-type object-type)
+                             (viewer-common/format-call-site call-site nil)))))))))
 
 (defmethod view/allocation-by-type* :print
   [_ {:keys [by-type-id]} data-map]
@@ -911,17 +919,17 @@
         by-type-map (data-map by-type-id)]
     (when by-type-map
       (let [by-type (:by-type by-type-map)
-            ;; Sort by bytes descending
             sorted (sort-by (comp :bytes second) > by-type)]
         (when (seq sorted)
+          (println)
           (println "Allocations by Type:")
           (println (format "%8s %12s %8s %12s  %s"
                            "Count" "Bytes" "Freed" "Freed Bytes" "Type"))
           (println (apply str (repeat 80 "-")))
           (doseq [[type-name {:keys [count bytes freed-count freed-bytes]}] sorted]
-            (println (format "%8d %12s %8d %12s  %s"
+            (println (format "%8d %12d %8d %12d  %s"
                              count
-                             (format/format-value :memory bytes)
+                             bytes
                              freed-count
-                             (format/format-value :memory freed-bytes)
+                             freed-bytes
                              type-name))))))))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -855,3 +855,78 @@
                           ""))))))
                 (println "  (insufficient data for regression)"))
               (println))))))))
+
+;;; Allocation Views
+
+(defmethod view/allocation-summary* :print
+  [_ {:keys [summary-id]} data-map]
+  (let [summary-id (or summary-id :allocation-summary)
+        summary    (data-map summary-id)]
+    (when summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+            retained (- total-allocated total-freed)]
+        (println "Allocation Summary:")
+        (println (format "%32s: %s"
+                         "Total allocated"
+                         (format/format-value :memory total-allocated)))
+        (println (format "%32s: %s"
+                         "Total freed"
+                         (format/format-value :memory total-freed)))
+        (println (format "%32s: %s"
+                         "Retained"
+                         (format/format-value :memory retained)))
+        (println (format "%32s: %d"
+                         "Allocation count"
+                         num-allocations))
+        (println (format "%32s: %d"
+                         "Freed count"
+                         num-freed))
+        (when (pos? num-allocations)
+          (println (format "%32s: %.1f%%"
+                           "Freed ratio"
+                           (* 100.0 (/ num-freed num-allocations)))))))))
+
+(defn- format-call-site
+  "Format a call site for display."
+  [{:keys [call-class call-method call-file call-line]}]
+  (str call-class "." call-method " (" call-file ":" call-line ")"))
+
+(defmethod view/allocation-hotspots* :print
+  [_ {:keys [hotspots-id]} data-map]
+  (let [hotspots-id (or hotspots-id :allocation-hotspots)
+        hotspots-map (data-map hotspots-id)]
+    (when hotspots-map
+      (let [hotspots (:hotspots hotspots-map)]
+        (when (seq hotspots)
+          (println "Allocation Hotspots:")
+          (println (format "%8s %12s %8s %12s  %s"
+                           "Count" "Bytes" "Freed" "Freed Bytes" "Call Site"))
+          (println (apply str (repeat 80 "-")))
+          (doseq [{:keys [call-site count bytes freed-count freed-bytes]} hotspots]
+            (println (format "%8d %12s %8d %12s  %s"
+                             count
+                             (format/format-value :memory bytes)
+                             freed-count
+                             (format/format-value :memory freed-bytes)
+                             (format-call-site call-site)))))))))
+
+(defmethod view/allocation-by-type* :print
+  [_ {:keys [by-type-id]} data-map]
+  (let [by-type-id (or by-type-id :allocation-by-type)
+        by-type-map (data-map by-type-id)]
+    (when by-type-map
+      (let [by-type (:by-type by-type-map)
+            ;; Sort by bytes descending
+            sorted (sort-by (comp :bytes second) > by-type)]
+        (when (seq sorted)
+          (println "Allocations by Type:")
+          (println (format "%8s %12s %8s %12s  %s"
+                           "Count" "Bytes" "Freed" "Freed Bytes" "Type"))
+          (println (apply str (repeat 80 "-")))
+          (doseq [[type-name {:keys [count bytes freed-count freed-bytes]}] sorted]
+            (println (format "%8d %12s %8d %12s  %s"
+                             count
+                             (format/format-value :memory bytes)
+                             freed-count
+                             (format/format-value :memory freed-bytes)
+                             type-name))))))))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -865,7 +865,12 @@
     (when summary
       (let [{:keys [total-allocated total-freed num-allocations num-freed
                     freed-ratio]} summary
-            retained (- total-allocated total-freed)]
+            total-allocated (long total-allocated)
+            total-freed (long total-freed)
+            retained (- total-allocated total-freed)
+            freed-ratio (or freed-ratio
+                            (when (pos? total-allocated)
+                              (/ (double total-freed) (double total-allocated))))]
         (println)
         (println "Allocation Summary:")
         (println (format "  %16s: %12d bytes"
@@ -883,9 +888,10 @@
         (println (format "  %16s: %12d"
                          "Freed count"
                          num-freed))
-        (println (format "  %16s: %12.1f%%"
-                         "Freed ratio"
-                         (* 100.0 freed-ratio)))))))
+        (when (some? freed-ratio)
+          (println (format "  %16s: %12.1f%%"
+                           "Freed ratio"
+                           (* 100.0 (double freed-ratio)))))))))
 
 (defmethod view/allocation-hotspots* :print
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -863,7 +863,8 @@
   (let [summary-id (or summary-id :allocation-summary)
         summary (data-map summary-id)]
     (when summary
-      (let [{:keys [total-allocated total-freed num-allocations num-freed]} summary
+      (let [{:keys [total-allocated total-freed num-allocations num-freed
+                    freed-ratio]} summary
             retained (- total-allocated total-freed)]
         (println)
         (println "Allocation Summary:")
@@ -882,10 +883,9 @@
         (println (format "  %16s: %12d"
                          "Freed count"
                          num-freed))
-        (when (pos? total-allocated)
-          (println (format "  %16s: %12.1f%%"
-                           "Freed ratio"
-                           (* 100.0 (/ (double total-freed) total-allocated)))))))))
+        (println (format "  %16s: %12.1f%%"
+                         "Freed ratio"
+                         (* 100.0 freed-ratio)))))))
 
 (defmethod view/allocation-hotspots* :print
   [_ {:keys [hotspots-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -933,3 +933,11 @@
                              freed-count
                              freed-bytes
                              type-name))))))))
+
+(defmethod view/allocation-treemap* :print
+  [_ {:keys [treemap-id]} data-map]
+  (let [treemap-id (or treemap-id :allocation-treemap)
+        treemap-data (data-map treemap-id)]
+    (when (and treemap-data (:root treemap-data))
+      (println)
+      (println (viewer-common/render-ascii-treemap treemap-data)))))

--- a/bases/criterium/test/criterium/allocation/analysis_test.clj
+++ b/bases/criterium/test/criterium/allocation/analysis_test.clj
@@ -1,0 +1,215 @@
+(ns criterium.allocation.analysis-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.allocation.analysis :as analysis]))
+
+;; Tests for criterium.allocation.analysis namespace.
+;; Validates analysis functions for allocation traces: summary, hotspots,
+;; and by-type grouping.
+
+(def sample-trace
+  "Sample allocation trace for testing."
+  {:type :criterium/allocation-trace
+   :records [{:object-type "Ljava/lang/String;"
+              :object_size 48
+              :call-class "my.ns$fn"
+              :call-method "invoke"
+              :call-file "my_ns.clj"
+              :call-line 42
+              :thread 1
+              :freed true}
+             {:object-type "Ljava/lang/String;"
+              :object_size 64
+              :call-class "my.ns$fn"
+              :call-method "invoke"
+              :call-file "my_ns.clj"
+              :call-line 42
+              :thread 1
+              :freed false}
+             {:object-type "[J"
+              :object_size 1024
+              :call-class "other.ns$bar"
+              :call-method "invoke"
+              :call-file "other_ns.clj"
+              :call-line 10
+              :thread 1
+              :freed true}
+             {:object-type "Ljava/lang/Long;"
+              :object_size 24
+              :call-class "my.ns$fn"
+              :call-method "invoke"
+              :call-file "my_ns.clj"
+              :call-line 42
+              :thread 2
+              :freed false}]
+   :thread-id 1
+   :eval-count 100
+   :elapsed-time 1.5e9})
+
+(def empty-trace
+  "Empty allocation trace for edge case testing."
+  {:type :criterium/allocation-trace
+   :records []
+   :thread-id 1
+   :eval-count 1
+   :elapsed-time 1e6})
+
+(deftest summary-fn-test
+  (testing "summary-fn"
+    (testing "computes totals from allocation trace"
+      (let [analyse (analysis/summary-fn)
+            result (analyse {:allocation-trace sample-trace})
+            summary (:allocation-summary result)]
+        (is (= :criterium/allocation-summary (:type summary)))
+        (is (= 4 (:num-allocations summary)))
+        (is (= 2 (:num-freed summary)))
+        (is (= (+ 48 64 1024 24) (:total-allocated summary)))
+        (is (= (+ 48 1024) (:total-freed summary)))))
+
+    (testing "returns zeros for empty trace"
+      (let [analyse (analysis/summary-fn)
+            result (analyse {:allocation-trace empty-trace})
+            summary (:allocation-summary result)]
+        (is (= 0 (:num-allocations summary)))
+        (is (= 0 (:num-freed summary)))
+        (is (= 0 (:total-allocated summary)))
+        (is (= 0 (:total-freed summary)))))
+
+    (testing "uses custom :id option"
+      (let [analyse (analysis/summary-fn {:id :my-summary})
+            result (analyse {:allocation-trace sample-trace})]
+        (is (contains? result :my-summary))
+        (is (not (contains? result :allocation-summary)))))
+
+    (testing "uses custom :trace-id option"
+      (let [analyse (analysis/summary-fn {:trace-id :my-trace})
+            result (analyse {:my-trace sample-trace})]
+        (is (= 4 (get-in result [:allocation-summary :num-allocations])))))
+
+    (testing "preserves other data-map entries"
+      (let [analyse (analysis/summary-fn)
+            result (analyse {:allocation-trace sample-trace
+                             :other-data :preserved})]
+        (is (= :preserved (:other-data result)))))))
+
+(deftest hotspots-fn-test
+  (testing "hotspots-fn"
+    (testing "groups allocations by call-site"
+      (let [analyse (analysis/hotspots-fn)
+            result (analyse {:allocation-trace sample-trace})
+            hotspots (get-in result [:allocation-hotspots :hotspots])]
+        (is (= :criterium/allocation-hotspots
+               (get-in result [:allocation-hotspots :type])))
+        (is (= 2 (count hotspots)))
+        ;; First hotspot should be the one with most bytes
+        (let [first-hotspot (first hotspots)]
+          (is (= "other.ns$bar"
+                 (get-in first-hotspot [:call-site :call-class])))
+          (is (= 1024 (:bytes first-hotspot)))
+          (is (= 1 (:count first-hotspot))))))
+
+    (testing "aggregates stats for same call-site"
+      (let [analyse (analysis/hotspots-fn)
+            result (analyse {:allocation-trace sample-trace})
+            hotspots (get-in result [:allocation-hotspots :hotspots])
+            my-ns-hotspot (first (filter #(= "my.ns$fn"
+                                             (get-in % [:call-site :call-class]))
+                                         hotspots))]
+        (is (= 3 (:count my-ns-hotspot)))
+        (is (= (+ 48 64 24) (:bytes my-ns-hotspot)))
+        (is (= 1 (:freed-count my-ns-hotspot)))
+        (is (= 48 (:freed-bytes my-ns-hotspot)))))
+
+    (testing "respects :limit option"
+      (let [analyse (analysis/hotspots-fn {:limit 1})
+            result (analyse {:allocation-trace sample-trace})
+            hotspots (get-in result [:allocation-hotspots :hotspots])]
+        (is (= 1 (count hotspots)))))
+
+    (testing "sorts by :count when specified"
+      (let [analyse (analysis/hotspots-fn {:order-by :count})
+            result (analyse {:allocation-trace sample-trace})
+            hotspots (get-in result [:allocation-hotspots :hotspots])]
+        ;; my.ns$fn has 3 allocations, other.ns$bar has 1
+        (is (= "my.ns$fn"
+               (get-in (first hotspots) [:call-site :call-class])))))
+
+    (testing "returns empty vector for empty trace"
+      (let [analyse (analysis/hotspots-fn)
+            result (analyse {:allocation-trace empty-trace})
+            hotspots (get-in result [:allocation-hotspots :hotspots])]
+        (is (= [] hotspots))))
+
+    (testing "uses custom :id option"
+      (let [analyse (analysis/hotspots-fn {:id :my-hotspots})
+            result (analyse {:allocation-trace sample-trace})]
+        (is (contains? result :my-hotspots))))))
+
+(deftest by-type-fn-test
+  (testing "by-type-fn"
+    (testing "groups allocations by object type"
+      (let [analyse (analysis/by-type-fn)
+            result (analyse {:allocation-trace sample-trace})
+            by-type (get-in result [:allocation-by-type :by-type])]
+        (is (= :criterium/allocation-by-type
+               (get-in result [:allocation-by-type :type])))
+        (is (= 3 (count by-type)))
+        (is (contains? by-type "Ljava/lang/String;"))
+        (is (contains? by-type "[J"))
+        (is (contains? by-type "Ljava/lang/Long;"))))
+
+    (testing "computes per-type statistics"
+      (let [analyse (analysis/by-type-fn)
+            result (analyse {:allocation-trace sample-trace})
+            string-stats (get-in result [:allocation-by-type
+                                         :by-type
+                                         "Ljava/lang/String;"])]
+        (is (= 2 (:count string-stats)))
+        (is (= (+ 48 64) (:bytes string-stats)))
+        (is (= 1 (:freed-count string-stats)))
+        (is (= 48 (:freed-bytes string-stats)))))
+
+    (testing "returns empty map for empty trace"
+      (let [analyse (analysis/by-type-fn)
+            result (analyse {:allocation-trace empty-trace})
+            by-type (get-in result [:allocation-by-type :by-type])]
+        (is (= {} by-type))))
+
+    (testing "uses custom :id option"
+      (let [analyse (analysis/by-type-fn {:id :my-by-type})
+            result (analyse {:allocation-trace sample-trace})]
+        (is (contains? result :my-by-type))))))
+
+(deftest ->allocation-analyse-test
+  (testing "->allocation-analyse"
+    (testing "composes multiple analysis functions"
+      (let [analyse (analysis/->allocation-analyse
+                     [[:summary-fn {}]
+                      [:hotspots-fn {:limit 5}]
+                      [:by-type-fn {}]])
+            result (analyse {:allocation-trace sample-trace})]
+        (is (contains? result :allocation-summary))
+        (is (contains? result :allocation-hotspots))
+        (is (contains? result :allocation-by-type))))
+
+    (testing "functions are applied in order"
+      (let [analyse (analysis/->allocation-analyse
+                     [[:summary-fn {:id :first}]
+                      [:summary-fn {:id :second}]])
+            result (analyse {:allocation-trace sample-trace})]
+        (is (contains? result :first))
+        (is (contains? result :second))))
+
+    (testing "handles empty plan"
+      (let [analyse (analysis/->allocation-analyse [])
+            result (analyse {:allocation-trace sample-trace})]
+        (is (= sample-trace (:allocation-trace result)))))
+
+    (testing "handles nil plan"
+      (let [analyse (analysis/->allocation-analyse nil)
+            result (analyse {:allocation-trace sample-trace})]
+        (is (= sample-trace (:allocation-trace result)))))
+
+    (testing "throws on invalid plan type"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (analysis/->allocation-analyse :invalid))))))

--- a/bases/criterium/test/criterium/allocation/analysis_test.clj
+++ b/bases/criterium/test/criterium/allocation/analysis_test.clj
@@ -17,7 +17,7 @@
               :call-file "my_ns.clj"
               :call-line 42
               :thread 1
-              :freed true}
+              :freed 1}
              {:object-type "Ljava/lang/String;"
               :object_size 64
               :call-class "my.ns$fn"
@@ -25,7 +25,7 @@
               :call-file "my_ns.clj"
               :call-line 42
               :thread 1
-              :freed false}
+              :freed 0}
              {:object-type "[J"
               :object_size 1024
               :call-class "other.ns$bar"
@@ -33,7 +33,7 @@
               :call-file "other_ns.clj"
               :call-line 10
               :thread 1
-              :freed true}
+              :freed 1}
              {:object-type "Ljava/lang/Long;"
               :object_size 24
               :call-class "my.ns$fn"
@@ -41,7 +41,7 @@
               :call-file "my_ns.clj"
               :call-line 42
               :thread 2
-              :freed false}]
+              :freed 0}]
    :thread-id 1
    :eval-count 100
    :elapsed-time 1.5e9})
@@ -118,7 +118,9 @@
         (is (= 3 (:count my-ns-hotspot)))
         (is (= (+ 48 64 24) (:bytes my-ns-hotspot)))
         (is (= 1 (:freed-count my-ns-hotspot)))
-        (is (= 48 (:freed-bytes my-ns-hotspot)))))
+        (is (= 48 (:freed-bytes my-ns-hotspot)))
+        (is (= #{"Ljava/lang/String;" "Ljava/lang/Long;"}
+               (:object-types my-ns-hotspot)))))
 
     (testing "respects :limit option"
       (let [analyse (analysis/hotspots-fn {:limit 1})
@@ -143,7 +145,33 @@
     (testing "uses custom :id option"
       (let [analyse (analysis/hotspots-fn {:id :my-hotspots})
             result (analyse {:samples {:allocation-trace sample-trace}})]
-        (is (contains? result :my-hotspots))))))
+        (is (contains? result :my-hotspots))))
+
+    (testing "falls back to alloc-* fields when call-* are empty"
+      (let [trace-with-fallback {:type :criterium/allocation-trace
+                                 :records [{:object-type "Ljava/lang/Object;"
+                                            :object_size 16
+                                            :call-class ""
+                                            :call-method ""
+                                            :call-file ""
+                                            :call-line -1
+                                            :alloc-class "java.lang.Object"
+                                            :alloc-method "<init>"
+                                            :alloc-file "Object.java"
+                                            :alloc-line 50
+                                            :thread 1
+                                            :freed 0}]
+                                 :thread-id 1
+                                 :eval-count 1
+                                 :elapsed-time 1e6}
+            analyse (analysis/hotspots-fn)
+            result (analyse {:samples {:allocation-trace trace-with-fallback}})
+            hotspots (get-in result [:allocation-hotspots :hotspots])
+            hotspot (first hotspots)]
+        (is (= "java.lang.Object" (get-in hotspot [:call-site :call-class])))
+        (is (= "<init>" (get-in hotspot [:call-site :call-method])))
+        (is (= "Object.java" (get-in hotspot [:call-site :call-file])))
+        (is (= 50 (get-in hotspot [:call-site :call-line])))))))
 
 (deftest by-type-fn-test
   (testing "by-type-fn"

--- a/bases/criterium/test/criterium/allocation/analysis_test.clj
+++ b/bases/criterium/test/criterium/allocation/analysis_test.clj
@@ -93,34 +93,43 @@
         (is (= :preserved (:other-data result)))))))
 
 (deftest hotspots-fn-test
+  ;; Tests hotspots-fn which groups allocations by (call-site, object-type) pairs.
+  ;; Verifies aggregation, sorting, limiting, and fallback behavior.
   (testing "hotspots-fn"
-    (testing "groups allocations by call-site"
+    (testing "groups allocations by call-site and object-type"
       (let [analyse (analysis/hotspots-fn)
             result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])]
         (is (= :criterium/allocation-hotspots
                (get-in result [:allocation-hotspots :type])))
-        (is (= 2 (count hotspots)))
+        ;; With (call-site, object-type) grouping:
+        ;; - other.ns$bar + [J: 1024 bytes (1 alloc)
+        ;; - my.ns$fn + String: 112 bytes (2 allocs)
+        ;; - my.ns$fn + Long: 24 bytes (1 alloc)
+        (is (= 3 (count hotspots)))
         ;; First hotspot should be the one with most bytes
         (let [first-hotspot (first hotspots)]
           (is (= "other.ns$bar"
                  (get-in first-hotspot [:call-site :call-class])))
+          (is (= "[J" (:object-type first-hotspot)))
           (is (= 1024 (:bytes first-hotspot)))
           (is (= 1 (:count first-hotspot))))))
 
-    (testing "aggregates stats for same call-site"
+    (testing "aggregates stats for same call-site and object-type"
       (let [analyse (analysis/hotspots-fn)
             result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])
-            my-ns-hotspot (first (filter #(= "my.ns$fn"
-                                             (get-in % [:call-site :call-class]))
-                                         hotspots))]
-        (is (= 3 (:count my-ns-hotspot)))
-        (is (= (+ 48 64 24) (:bytes my-ns-hotspot)))
-        (is (= 1 (:freed-count my-ns-hotspot)))
-        (is (= 48 (:freed-bytes my-ns-hotspot)))
-        (is (= #{"Ljava/lang/String;" "Ljava/lang/Long;"}
-               (:object-types my-ns-hotspot)))))
+            string-hotspot (first (filter #(and (= "my.ns$fn"
+                                                   (get-in % [:call-site :call-class]))
+                                                (= "Ljava/lang/String;"
+                                                   (:object-type %)))
+                                          hotspots))]
+        ;; Two String allocations from my.ns$fn: 48 + 64 = 112 bytes
+        (is (= 2 (:count string-hotspot)))
+        (is (= (+ 48 64) (:bytes string-hotspot)))
+        (is (= 1 (:freed-count string-hotspot)))
+        (is (= 48 (:freed-bytes string-hotspot)))
+        (is (= "Ljava/lang/String;" (:object-type string-hotspot)))))
 
     (testing "respects :limit option"
       (let [analyse (analysis/hotspots-fn {:limit 1})
@@ -132,9 +141,10 @@
       (let [analyse (analysis/hotspots-fn {:order-by :count})
             result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])]
-        ;; my.ns$fn has 3 allocations, other.ns$bar has 1
+        ;; my.ns$fn + String has 2 allocations (highest count)
         (is (= "my.ns$fn"
-               (get-in (first hotspots) [:call-site :call-class])))))
+               (get-in (first hotspots) [:call-site :call-class])))
+        (is (= "Ljava/lang/String;" (:object-type (first hotspots))))))
 
     (testing "returns empty vector for empty trace"
       (let [analyse (analysis/hotspots-fn)
@@ -171,7 +181,8 @@
         (is (= "java.lang.Object" (get-in hotspot [:call-site :call-class])))
         (is (= "<init>" (get-in hotspot [:call-site :call-method])))
         (is (= "Object.java" (get-in hotspot [:call-site :call-file])))
-        (is (= 50 (get-in hotspot [:call-site :call-line])))))))
+        (is (= 50 (get-in hotspot [:call-site :call-line])))
+        (is (= "Ljava/lang/Object;" (:object-type hotspot)))))))
 
 (deftest by-type-fn-test
   (testing "by-type-fn"

--- a/bases/criterium/test/criterium/allocation/analysis_test.clj
+++ b/bases/criterium/test/criterium/allocation/analysis_test.clj
@@ -17,7 +17,7 @@
               :call-file "my_ns.clj"
               :call-line 42
               :thread 1
-              :freed 1}
+              :freed true}
              {:object-type "Ljava/lang/String;"
               :object_size 64
               :call-class "my.ns$fn"
@@ -25,7 +25,7 @@
               :call-file "my_ns.clj"
               :call-line 42
               :thread 1
-              :freed 0}
+              :freed false}
              {:object-type "[J"
               :object_size 1024
               :call-class "other.ns$bar"
@@ -33,7 +33,7 @@
               :call-file "other_ns.clj"
               :call-line 10
               :thread 1
-              :freed 1}
+              :freed true}
              {:object-type "Ljava/lang/Long;"
               :object_size 24
               :call-class "my.ns$fn"
@@ -41,7 +41,7 @@
               :call-file "my_ns.clj"
               :call-line 42
               :thread 2
-              :freed 0}]
+              :freed false}]
    :thread-id 1
    :eval-count 100
    :elapsed-time 1.5e9})
@@ -160,7 +160,7 @@
                                             :alloc-file "Object.java"
                                             :alloc-line 50
                                             :thread 1
-                                            :freed 0}]
+                                            :freed false}]
                                  :thread-id 1
                                  :eval-count 1
                                  :elapsed-time 1e6}

--- a/bases/criterium/test/criterium/allocation/analysis_test.clj
+++ b/bases/criterium/test/criterium/allocation/analysis_test.clj
@@ -219,6 +219,107 @@
             result (analyse {:samples {:allocation-trace sample-trace}})]
         (is (contains? result :my-by-type))))))
 
+;; Tests for treemap-fn.
+;; Validates hierarchical treemap generation with various grouping, sizing,
+;; and filtering options.
+(deftest treemap-fn-test
+  (testing "treemap-fn"
+    (testing "with default options produces correct hierarchy"
+      ;; Default: :class→line→type grouping, :bytes sizing, :all filtering
+      (let [analyse (analysis/treemap-fn)
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            treemap (:allocation-treemap result)
+            root (:root treemap)]
+        (is (= :criterium/allocation-treemap (:type treemap)))
+        (is (= :class→line→type (:group-by treemap)))
+        (is (= :bytes (:size-by treemap)))
+        (is (= "allocations" (:name root)))
+        ;; Total bytes: 48 + 64 + 1024 + 24 = 1160
+        (is (= 1160 (:value root)))
+        ;; Should have children for each call-class
+        (is (contains? root :children))
+        (is (= 2 (count (:children root))))))
+
+    (testing "with :type→class→line grouping"
+      (let [analyse (analysis/treemap-fn {:group-by :type→class→line})
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            treemap (:allocation-treemap result)
+            root (:root treemap)]
+        (is (= :type→class→line (:group-by treemap)))
+        ;; Should have children for each object-type (String, [J, Long)
+        (is (= 3 (count (:children root))))))
+
+    (testing "with :size-by :count"
+      (let [analyse (analysis/treemap-fn {:size-by :count})
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            root (get-in result [:allocation-treemap :root])]
+        ;; Total count: 4 allocations
+        (is (= 4 (:value root)))))
+
+    (testing "with :size-by :bytes-per-allocation"
+      ;; Total bytes = 1160, total count = 4
+      ;; Average = 290.0
+      (let [analyse (analysis/treemap-fn {:size-by :bytes-per-allocation})
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            root (get-in result [:allocation-treemap :root])]
+        ;; Value should be sum of children's bytes-per-allocation values
+        (is (number? (:value root)))
+        (is (pos? (:value root)))))
+
+    (testing "with :filter-by :freed"
+      ;; Only freed records: String (48 bytes) + [J (1024 bytes)
+      (let [analyse (analysis/treemap-fn {:filter-by :freed})
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            root (get-in result [:allocation-treemap :root])]
+        (is (= (+ 48 1024) (:value root)))))
+
+    (testing "with :filter-by :not-freed"
+      ;; Only not-freed records: String (64 bytes) + Long (24 bytes)
+      (let [analyse (analysis/treemap-fn {:filter-by :not-freed})
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            root (get-in result [:allocation-treemap :root])]
+        (is (= (+ 64 24) (:value root)))))
+
+    (testing "returns unchanged data-map when trace absent"
+      (let [analyse (analysis/treemap-fn)
+            input {:other :data}
+            result (analyse input)]
+        (is (= input result))
+        (is (not (contains? result :allocation-treemap)))))
+
+    (testing "hierarchical values sum correctly"
+      (let [analyse (analysis/treemap-fn)
+            result (analyse {:samples {:allocation-trace sample-trace}})
+            root (get-in result [:allocation-treemap :root])]
+        ;; Sum of all children values should equal root value
+        (let [children-sum (reduce + 0 (map :value (:children root)))]
+          (is (= (:value root) children-sum)))
+        ;; Check one level deeper - my.ns$fn class
+        (let [my-ns-node (first (filter #(= "my.ns$fn" (:name %))
+                                        (:children root)))]
+          (when my-ns-node
+            (let [children-sum (reduce + 0 (map :value (:children my-ns-node)))]
+              (is (= (:value my-ns-node) children-sum)))))))
+
+    (testing "uses custom :id option"
+      (let [analyse (analysis/treemap-fn {:id :my-treemap})
+            result (analyse {:samples {:allocation-trace sample-trace}})]
+        (is (contains? result :my-treemap))
+        (is (not (contains? result :allocation-treemap)))))
+
+    (testing "uses custom :trace-id option"
+      (let [analyse (analysis/treemap-fn {:trace-id [:custom :path]})
+            result (analyse {:custom {:path sample-trace}})]
+        (is (contains? result :allocation-treemap))))
+
+    (testing "returns empty root for empty trace"
+      (let [analyse (analysis/treemap-fn)
+            result (analyse {:samples {:allocation-trace empty-trace}})
+            root (get-in result [:allocation-treemap :root])]
+        (is (= "allocations" (:name root)))
+        (is (= 0 (:value root)))
+        (is (not (contains? root :children)))))))
+
 (deftest ->allocation-analyse-test
   (testing "->allocation-analyse"
     (testing "composes multiple analysis functions"

--- a/bases/criterium/test/criterium/allocation/analysis_test.clj
+++ b/bases/criterium/test/criterium/allocation/analysis_test.clj
@@ -58,7 +58,7 @@
   (testing "summary-fn"
     (testing "computes totals from allocation trace"
       (let [analyse (analysis/summary-fn)
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             summary (:allocation-summary result)]
         (is (= :criterium/allocation-summary (:type summary)))
         (is (= 4 (:num-allocations summary)))
@@ -68,7 +68,7 @@
 
     (testing "returns zeros for empty trace"
       (let [analyse (analysis/summary-fn)
-            result (analyse {:allocation-trace empty-trace})
+            result (analyse {:samples {:allocation-trace empty-trace}})
             summary (:allocation-summary result)]
         (is (= 0 (:num-allocations summary)))
         (is (= 0 (:num-freed summary)))
@@ -77,18 +77,18 @@
 
     (testing "uses custom :id option"
       (let [analyse (analysis/summary-fn {:id :my-summary})
-            result (analyse {:allocation-trace sample-trace})]
+            result (analyse {:samples {:allocation-trace sample-trace}})]
         (is (contains? result :my-summary))
         (is (not (contains? result :allocation-summary)))))
 
     (testing "uses custom :trace-id option"
-      (let [analyse (analysis/summary-fn {:trace-id :my-trace})
+      (let [analyse (analysis/summary-fn {:trace-id [:my-trace]})
             result (analyse {:my-trace sample-trace})]
         (is (= 4 (get-in result [:allocation-summary :num-allocations])))))
 
     (testing "preserves other data-map entries"
       (let [analyse (analysis/summary-fn)
-            result (analyse {:allocation-trace sample-trace
+            result (analyse {:samples {:allocation-trace sample-trace}
                              :other-data :preserved})]
         (is (= :preserved (:other-data result)))))))
 
@@ -96,7 +96,7 @@
   (testing "hotspots-fn"
     (testing "groups allocations by call-site"
       (let [analyse (analysis/hotspots-fn)
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])]
         (is (= :criterium/allocation-hotspots
                (get-in result [:allocation-hotspots :type])))
@@ -110,7 +110,7 @@
 
     (testing "aggregates stats for same call-site"
       (let [analyse (analysis/hotspots-fn)
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])
             my-ns-hotspot (first (filter #(= "my.ns$fn"
                                              (get-in % [:call-site :call-class]))
@@ -122,13 +122,13 @@
 
     (testing "respects :limit option"
       (let [analyse (analysis/hotspots-fn {:limit 1})
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])]
         (is (= 1 (count hotspots)))))
 
     (testing "sorts by :count when specified"
       (let [analyse (analysis/hotspots-fn {:order-by :count})
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])]
         ;; my.ns$fn has 3 allocations, other.ns$bar has 1
         (is (= "my.ns$fn"
@@ -136,20 +136,20 @@
 
     (testing "returns empty vector for empty trace"
       (let [analyse (analysis/hotspots-fn)
-            result (analyse {:allocation-trace empty-trace})
+            result (analyse {:samples {:allocation-trace empty-trace}})
             hotspots (get-in result [:allocation-hotspots :hotspots])]
         (is (= [] hotspots))))
 
     (testing "uses custom :id option"
       (let [analyse (analysis/hotspots-fn {:id :my-hotspots})
-            result (analyse {:allocation-trace sample-trace})]
+            result (analyse {:samples {:allocation-trace sample-trace}})]
         (is (contains? result :my-hotspots))))))
 
 (deftest by-type-fn-test
   (testing "by-type-fn"
     (testing "groups allocations by object type"
       (let [analyse (analysis/by-type-fn)
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             by-type (get-in result [:allocation-by-type :by-type])]
         (is (= :criterium/allocation-by-type
                (get-in result [:allocation-by-type :type])))
@@ -160,7 +160,7 @@
 
     (testing "computes per-type statistics"
       (let [analyse (analysis/by-type-fn)
-            result (analyse {:allocation-trace sample-trace})
+            result (analyse {:samples {:allocation-trace sample-trace}})
             string-stats (get-in result [:allocation-by-type
                                          :by-type
                                          "Ljava/lang/String;"])]
@@ -171,13 +171,13 @@
 
     (testing "returns empty map for empty trace"
       (let [analyse (analysis/by-type-fn)
-            result (analyse {:allocation-trace empty-trace})
+            result (analyse {:samples {:allocation-trace empty-trace}})
             by-type (get-in result [:allocation-by-type :by-type])]
         (is (= {} by-type))))
 
     (testing "uses custom :id option"
       (let [analyse (analysis/by-type-fn {:id :my-by-type})
-            result (analyse {:allocation-trace sample-trace})]
+            result (analyse {:samples {:allocation-trace sample-trace}})]
         (is (contains? result :my-by-type))))))
 
 (deftest ->allocation-analyse-test
@@ -187,7 +187,7 @@
                      [[:summary-fn {}]
                       [:hotspots-fn {:limit 5}]
                       [:by-type-fn {}]])
-            result (analyse {:allocation-trace sample-trace})]
+            result (analyse {:samples {:allocation-trace sample-trace}})]
         (is (contains? result :allocation-summary))
         (is (contains? result :allocation-hotspots))
         (is (contains? result :allocation-by-type))))
@@ -196,19 +196,19 @@
       (let [analyse (analysis/->allocation-analyse
                      [[:summary-fn {:id :first}]
                       [:summary-fn {:id :second}]])
-            result (analyse {:allocation-trace sample-trace})]
+            result (analyse {:samples {:allocation-trace sample-trace}})]
         (is (contains? result :first))
         (is (contains? result :second))))
 
     (testing "handles empty plan"
       (let [analyse (analysis/->allocation-analyse [])
-            result (analyse {:allocation-trace sample-trace})]
-        (is (= sample-trace (:allocation-trace result)))))
+            result (analyse {:samples {:allocation-trace sample-trace}})]
+        (is (= sample-trace (get-in result [:samples :allocation-trace])))))
 
     (testing "handles nil plan"
       (let [analyse (analysis/->allocation-analyse nil)
-            result (analyse {:allocation-trace sample-trace})]
-        (is (= sample-trace (:allocation-trace result)))))
+            result (analyse {:samples {:allocation-trace sample-trace}})]
+        (is (= sample-trace (get-in result [:samples :allocation-trace])))))
 
     (testing "throws on invalid plan type"
       (is (thrown? clojure.lang.ExceptionInfo

--- a/bases/criterium/test/criterium/allocation_test.clj
+++ b/bases/criterium/test/criterium/allocation_test.clj
@@ -1,0 +1,78 @@
+(ns criterium.allocation-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.allocation :as allocation]
+   [criterium.types :as types]))
+
+;; Tests for criterium.allocation namespace.
+;; Validates the allocation tracing wrapper that bridges the native agent
+;; to the criterium pipeline architecture.
+
+(deftest trace?-test
+  (testing "trace?"
+    (testing "is the same as types/allocation-trace?"
+      (is (= allocation/trace? types/allocation-trace?)))
+    (testing "returns true for valid allocation trace"
+      (is (true? (allocation/trace?
+                  {:type :criterium/allocation-trace
+                   :records []
+                   :thread-id 1
+                   :eval-count 100
+                   :elapsed-time 1.5e9}))))
+    (testing "returns false for invalid trace"
+      (is (false? (allocation/trace? {:type :other})))
+      (is (false? (allocation/trace? nil))))))
+
+(deftest filter-thread-test
+  (testing "filter-thread"
+    (let [records [{:thread 1 :object-type "String"}
+                   {:thread 2 :object-type "Long"}
+                   {:thread 1 :object-type "Vector"}
+                   {:thread 3 :object-type "Map"}]]
+      (testing "filters records by specified thread-id"
+        (is (= [{:thread 1 :object-type "String"}
+                {:thread 1 :object-type "Vector"}]
+               (vec (allocation/filter-thread records 1)))))
+      (testing "returns empty for non-matching thread"
+        (is (= [] (vec (allocation/filter-thread records 999)))))
+      (testing "returns all matching records"
+        (is (= 1 (count (allocation/filter-thread records 2))))
+        (is (= 1 (count (allocation/filter-thread records 3))))))))
+
+(deftest with-allocation-trace-test
+  (testing "with-allocation-trace"
+    (testing "returns result from body"
+      (let [[_trace result] (allocation/with-allocation-trace {}
+                              (+ 1 2))]
+        (is (= 3 result))))
+    (testing "returns nil trace when agent not attached"
+      ;; Without agent, we get [nil result]
+      (let [[trace result] (allocation/with-allocation-trace {}
+                             :test-value)]
+        ;; Agent may or may not be attached in test environment
+        (is (= :test-value result))
+        (when trace
+          (is (allocation/trace? trace)))))
+    (testing "uses default eval-count of 1"
+      (let [[trace _] (allocation/with-allocation-trace {}
+                        nil)]
+        (when trace
+          (is (= 1 (:eval-count trace))))))
+    (testing "accepts custom eval-count"
+      (let [[trace _] (allocation/with-allocation-trace {:eval-count 100}
+                        nil)]
+        (when trace
+          (is (= 100 (:eval-count trace))))))
+    (testing "captures thread-id"
+      (let [current-thread (.getId (Thread/currentThread))
+            [trace _] (allocation/with-allocation-trace {}
+                        nil)]
+        (when trace
+          (is (= current-thread (:thread-id trace))))))
+    (testing "measures elapsed-time"
+      (let [[trace _] (allocation/with-allocation-trace {}
+                        (Thread/sleep 10))]
+        (when trace
+          (is (pos? (:elapsed-time trace)))
+          ;; Should be at least 10ms = 10_000_000 ns
+          (is (>= (:elapsed-time trace) 10000000)))))))

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -193,9 +193,9 @@
         (testing "includes :with-allocation-trace in bench-plan"
           (is (true? (get-in (bench/last-bench) [:bench-plan :with-allocation-trace]))))
         ;; If agent is attached, check allocation data is present
-        (when (:allocation-trace data)
+        (when (get-in data [:samples :allocation-trace])
           (testing "collects allocation trace"
-            (is (allocation/trace? (:allocation-trace data))))
+            (is (allocation/trace? (get-in data [:samples :allocation-trace]))))
           (testing "includes allocation summary"
             (is (= :criterium/allocation-summary
                    (:type (:allocation-summary data)))))
@@ -215,9 +215,9 @@
                                :limit-time-s 0.5))
             data (:data (bench/last-bench))]
         ;; If agent is attached, check allocation data is present
-        (when (:allocation-trace data)
+        (when (get-in data [:samples :allocation-trace])
           (testing "collects allocation trace with warmup"
-            (is (allocation/trace? (:allocation-trace data))))
+            (is (allocation/trace? (get-in data [:samples :allocation-trace]))))
           (testing "outputs allocation views"
             (is (re-find #"Allocation Summary" out))))))
 
@@ -227,7 +227,7 @@
                      :collect-plan :one-shot))
       (let [data (:data (bench/last-bench))]
         (testing "does not include allocation trace"
-          (is (nil? (:allocation-trace data))))
+          (is (nil? (get-in data [:samples :allocation-trace]))))
         (testing "does not include allocation analysis"
           (is (nil? (:allocation-summary data)))
           (is (nil? (:allocation-hotspots data)))

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -1,11 +1,13 @@
 (ns criterium.bench-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [criterium.allocation :as allocation]
    [criterium.analyse]
    [criterium.bench :as bench]
    [criterium.bench-plans :as bench-plans]
    [criterium.bench.config :as bench-config]
    [criterium.bench.impl :as bench-impl]
+   [criterium.types :as types]
    [criterium.viewer.kindly :as kindly]))
 
 (deftest bench-test
@@ -168,3 +170,69 @@
         (let [config (bench-config/config-map {})]
           (is (= :kindly (:viewer config)))))
       (is (= :print (bench/default-viewer))))))
+
+;; Tests for :with-allocation-trace option.
+;; Validates integration of allocation tracing into the bench pipeline.
+;; Agent may or may not be attached in test environment.
+
+(deftest with-allocation-trace-test
+  (testing ":with-allocation-trace option"
+    (testing "returns expression value"
+      (let [result (with-out-str
+                     (bench/bench (+ 1 2)
+                                  :with-allocation-trace true
+                                  :collect-plan :one-shot))]
+        (is (string? result))))
+
+    (testing "with one-shot collect plan"
+      (let [out (with-out-str
+                  (bench/bench (str "allocate" "strings")
+                               :with-allocation-trace true
+                               :collect-plan :one-shot))
+            data (:data (bench/last-bench))]
+        (testing "includes :with-allocation-trace in bench-plan"
+          (is (true? (get-in (bench/last-bench) [:bench-plan :with-allocation-trace]))))
+        ;; If agent is attached, check allocation data is present
+        (when (:allocation-trace data)
+          (testing "collects allocation trace"
+            (is (allocation/trace? (:allocation-trace data))))
+          (testing "includes allocation summary"
+            (is (= :criterium/allocation-summary
+                   (:type (:allocation-summary data)))))
+          (testing "includes allocation hotspots"
+            (is (= :criterium/allocation-hotspots
+                   (:type (:allocation-hotspots data)))))
+          (testing "includes allocation by-type"
+            (is (= :criterium/allocation-by-type
+                   (:type (:allocation-by-type data)))))
+          (testing "outputs allocation views"
+            (is (re-find #"Allocation Summary" out))))))
+
+    (testing "with warmup collect plan"
+      (let [out (with-out-str
+                  (bench/bench (str "allocate" "strings")
+                               :with-allocation-trace true
+                               :limit-time-s 0.5))
+            data (:data (bench/last-bench))]
+        ;; If agent is attached, check allocation data is present
+        (when (:allocation-trace data)
+          (testing "collects allocation trace with warmup"
+            (is (allocation/trace? (:allocation-trace data))))
+          (testing "outputs allocation views"
+            (is (re-find #"Allocation Summary" out))))))
+
+    (testing "without allocation trace option"
+      (with-out-str
+        (bench/bench (str "no" "trace")
+                     :collect-plan :one-shot))
+      (let [data (:data (bench/last-bench))]
+        (testing "does not include allocation trace"
+          (is (nil? (:allocation-trace data))))
+        (testing "does not include allocation analysis"
+          (is (nil? (:allocation-summary data)))
+          (is (nil? (:allocation-hotspots data)))
+          (is (nil? (:allocation-by-type data)))))))
+
+  (testing "config-map accepts :with-allocation-trace"
+    (let [config (bench-config/config-map {:with-allocation-trace true})]
+      (is (true? (:with-allocation-trace config))))))

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -7,7 +7,6 @@
    [criterium.bench-plans :as bench-plans]
    [criterium.bench.config :as bench-config]
    [criterium.bench.impl :as bench-impl]
-   [criterium.types :as types]
    [criterium.viewer.kindly :as kindly]))
 
 (deftest bench-test

--- a/bases/criterium/test/criterium/types_test.clj
+++ b/bases/criterium/test/criterium/types_test.clj
@@ -1,0 +1,75 @@
+(ns criterium.types-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.types :as types]))
+
+;; Tests for allocation-trace? type predicate.
+;; Validates the allocation trace type used by the allocation
+;; tracking pipeline.
+
+(deftest allocation-trace?-test
+  (testing "allocation-trace?"
+    (testing "returns true for valid allocation trace"
+      (is (true? (types/allocation-trace?
+                  {:type :criterium/allocation-trace
+                   :records []
+                   :thread-id 1
+                   :eval-count 100
+                   :elapsed-time 1.5e9}))))
+    (testing "returns true when records is non-empty"
+      (is (true? (types/allocation-trace?
+                  {:type :criterium/allocation-trace
+                   :records [{:object-type "Ljava/lang/String;"
+                              :object-size 48}]
+                   :thread-id 1
+                   :eval-count 100
+                   :elapsed-time 1.5e9}))))
+    (testing "returns true with extra keys"
+      (is (true? (types/allocation-trace?
+                  {:type :criterium/allocation-trace
+                   :records []
+                   :thread-id 1
+                   :eval-count 100
+                   :elapsed-time 1.5e9
+                   :extra-key "allowed"}))))
+    (testing "returns false for wrong type"
+      (is (false? (types/allocation-trace?
+                   {:type :other
+                    :records []
+                    :thread-id 1
+                    :eval-count 100
+                    :elapsed-time 1.5e9}))))
+    (testing "returns false for missing type"
+      (is (false? (types/allocation-trace?
+                   {:records []
+                    :thread-id 1
+                    :eval-count 100
+                    :elapsed-time 1.5e9}))))
+    (testing "returns false for missing :records"
+      (is (false? (types/allocation-trace?
+                   {:type :criterium/allocation-trace
+                    :thread-id 1
+                    :eval-count 100
+                    :elapsed-time 1.5e9}))))
+    (testing "returns false for missing :thread-id"
+      (is (false? (types/allocation-trace?
+                   {:type :criterium/allocation-trace
+                    :records []
+                    :eval-count 100
+                    :elapsed-time 1.5e9}))))
+    (testing "returns false for missing :eval-count"
+      (is (false? (types/allocation-trace?
+                   {:type :criterium/allocation-trace
+                    :records []
+                    :thread-id 1
+                    :elapsed-time 1.5e9}))))
+    (testing "returns false for missing :elapsed-time"
+      (is (false? (types/allocation-trace?
+                   {:type :criterium/allocation-trace
+                    :records []
+                    :thread-id 1
+                    :eval-count 100}))))
+    (testing "returns false for non-map"
+      (is (false? (types/allocation-trace? nil)))
+      (is (false? (types/allocation-trace? "allocation-trace")))
+      (is (false? (types/allocation-trace? [:criterium/allocation-trace]))))))

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -1,0 +1,108 @@
+(ns criterium.viewer.common-charts-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.viewer.common-charts :as charts]))
+
+;; Tests for treemap-vega-spec function.
+;; Verifies Vega spec generation for treemap visualizations of allocation data.
+
+(def sample-treemap
+  "Sample allocation treemap for testing."
+  {:type :criterium/allocation-treemap
+   :group-by :class→line→type
+   :size-by :bytes
+   :root {:name "allocations"
+          :value 1000
+          :children [{:name "MyClass"
+                      :value 800
+                      :children [{:name "L42"
+                                  :value 500}
+                                 {:name "L50"
+                                  :value 300}]}
+                     {:name "OtherClass"
+                      :value 200}]}})
+
+(deftest treemap-vega-spec-test
+  (testing "treemap-vega-spec"
+    (testing "produces valid Vega spec structure"
+      (let [spec (charts/treemap-vega-spec sample-treemap {})]
+        (is (map? spec))
+        (is (contains? spec :$schema))
+        (is (contains? spec :width))
+        (is (contains? spec :height))
+        (is (contains? spec :data))
+        (is (contains? spec :scales))
+        (is (contains? spec :marks))
+        (is (vector? (:data spec)))
+        (is (vector? (:scales spec)))
+        (is (vector? (:marks spec)))))
+
+    (testing "includes correct $schema"
+      (let [spec (charts/treemap-vega-spec sample-treemap {})]
+        (is (= "https://vega.github.io/schema/vega/v5.json" (:$schema spec)))))
+
+    (testing "data values match input hierarchy"
+      (let [spec (charts/treemap-vega-spec sample-treemap {})
+            tree-data (first (:data spec))
+            values (:values tree-data)]
+        (is (= "tree" (:name tree-data)))
+        (is (= 5 (count values)) "Expected 5 nodes in flattened tree")
+        (is (= "root" (:id (first values))))
+        (is (nil? (:parent (first values))))
+        (is (= "allocations" (:name (first values))))
+        (is (= 1000 (:value (first values))))
+        ;; Check a child node
+        (let [myclass-node (second values)]
+          (is (= "allocations/MyClass" (:id myclass-node)))
+          (is (= "root" (:parent myclass-node)))
+          (is (= "MyClass" (:name myclass-node)))
+          (is (= 800 (:value myclass-node))))))
+
+    (testing "respects width/height options"
+      (let [spec (charts/treemap-vega-spec sample-treemap {:width 500 :height 300})]
+        (is (= 500 (:width spec)))
+        (is (= 300 (:height spec)))))
+
+    (testing "uses default width/height when not specified"
+      (let [spec (charts/treemap-vega-spec sample-treemap {})]
+        (is (= 700 (:width spec)))
+        (is (= 400 (:height spec)))))
+
+    (testing "respects color-scheme option"
+      (let [spec (charts/treemap-vega-spec sample-treemap {:color-scheme "category20"})
+            color-scale (first (:scales spec))]
+        (is (= {:scheme "category20"} (:range color-scale)))))
+
+    (testing "with empty children produces minimal spec"
+      (let [empty-treemap {:type :criterium/allocation-treemap
+                           :root {:name "allocations"
+                                  :value 0}}
+            spec (charts/treemap-vega-spec empty-treemap {})]
+        (is (map? spec))
+        (is (= "https://vega.github.io/schema/vega/v5.json" (:$schema spec)))
+        (let [values (-> spec :data first :values)]
+          (is (= 1 (count values)))
+          (is (= "root" (:id (first values)))))))
+
+    (testing "with nil root produces empty data"
+      (let [nil-treemap {:type :criterium/allocation-treemap
+                         :root nil}
+            spec (charts/treemap-vega-spec nil-treemap {})]
+        (is (map? spec))
+        (is (empty? (-> spec :data first :values)))))
+
+    (testing "includes stratify and treemap transforms"
+      (let [spec (charts/treemap-vega-spec sample-treemap {})
+            transforms (-> spec :data first :transform)]
+        (is (= 2 (count transforms)))
+        (is (= "stratify" (:type (first transforms))))
+        (is (= "treemap" (:type (second transforms))))
+        (is (= "squarify" (:method (second transforms))))))
+
+    (testing "includes three mark types"
+      (let [spec (charts/treemap-vega-spec sample-treemap {})
+            marks (:marks spec)]
+        (is (= 3 (count marks)))
+        (is (= "rect" (:type (first marks))))
+        (is (= "rect" (:type (second marks))))
+        (is (= "text" (:type (nth marks 2))))))))

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -105,10 +105,9 @@
         (is (= "treemap" (:type (second transforms))))
         (is (= "squarify" (:method (second transforms))))))
 
-    (testing "includes three mark types"
+    (testing "includes two rect marks for nodes and leaves"
       (let [spec (charts/treemap-vega-spec sample-treemap {})
             marks (:marks spec)]
-        (is (= 3 (count marks)))
+        (is (= 2 (count marks)))
         (is (= "rect" (:type (first marks))))
-        (is (= "rect" (:type (second marks))))
-        (is (= "text" (:type (nth marks 2))))))))
+        (is (= "rect" (:type (second marks))))))))

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -47,16 +47,21 @@
             values (:values tree-data)]
         (is (= "tree" (:name tree-data)))
         (is (= 5 (count values)) "Expected 5 nodes in flattened tree")
+        ;; Root node (parent) - no value, Vega computes from children
         (is (= "root" (:id (first values))))
         (is (nil? (:parent (first values))))
         (is (= "allocations" (:name (first values))))
-        (is (= 1000 (:value (first values))))
-        ;; Check a child node
+        (is (nil? (:value (first values))) "Parent nodes should not have values")
+        ;; Check an intermediate node (parent)
         (let [myclass-node (second values)]
           (is (= "allocations/MyClass" (:id myclass-node)))
           (is (= "root" (:parent myclass-node)))
           (is (= "MyClass" (:name myclass-node)))
-          (is (= 800 (:value myclass-node))))))
+          (is (nil? (:value myclass-node)) "Parent nodes should not have values"))
+        ;; Check leaf nodes have values
+        (let [leaf-nodes (filter :value values)]
+          (is (= 3 (count leaf-nodes)) "Expected 3 leaf nodes with values")
+          (is (= #{500 300 200} (set (map :value leaf-nodes)))))))
 
     (testing "respects width/height options"
       (let [spec (charts/treemap-vega-spec sample-treemap {:width 500 :height 300})]
@@ -82,7 +87,8 @@
         (is (= "https://vega.github.io/schema/vega/v5.json" (:$schema spec)))
         (let [values (-> spec :data first :values)]
           (is (= 1 (count values)))
-          (is (= "root" (:id (first values)))))))
+          (is (= "root" (:id (first values))))
+          (is (= 0 (:value (first values))) "Single node (leaf) has value"))))
 
     (testing "with nil root produces empty data"
       (let [nil-treemap {:type :criterium/allocation-treemap

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -60,7 +60,7 @@
   (testing "render-ascii-treemap"
     (testing "produces correct tree structure"
       (let [result (common/render-ascii-treemap sample-treemap)
-            lines  (str/split-lines result)]
+            lines (str/split-lines result)]
         (is (string? result))
         (is (str/starts-with? (first lines) "Allocation Treemap"))
         (is (str/includes? (first lines) "bytes"))
@@ -83,7 +83,7 @@
 
     (testing "shows bars only on leaf nodes"
       (let [result (common/render-ascii-treemap sample-treemap)
-            lines  (str/split-lines result)]
+            lines (str/split-lines result)]
         (doseq [line lines]
           (when (str/includes? line "█")
             (is (not (str/ends-with? (first (str/split line #"\[")) "/"))
@@ -112,18 +112,18 @@
         (is (not (str/includes? result "L58")))))
 
     (testing "handles empty children"
-      (let [empty-treemap {:type     :criterium/allocation-treemap
+      (let [empty-treemap {:type :criterium/allocation-treemap
                            :group-by :class→line→type
-                           :size-by  :bytes
-                           :root     {:name "allocations" :value 0}}
-            result        (common/render-ascii-treemap empty-treemap)]
+                           :size-by :bytes
+                           :root {:name "allocations" :value 0}}
+            result (common/render-ascii-treemap empty-treemap)]
         (is (string? result))
         (is (str/includes? result "Allocation Treemap"))
         (is (str/includes? result "allocations/"))))
 
     (testing "handles nil root"
       (let [nil-treemap {:type :criterium/allocation-treemap :root nil}
-            result      (common/render-ascii-treemap nil-treemap)]
+            result (common/render-ascii-treemap nil-treemap)]
         (is (= "" result))))
 
     (testing "formats sizes correctly"
@@ -133,14 +133,14 @@
                 (str/includes? result "bytes")))))
 
     (testing "respects name-width option"
-      (let [result-wide   (common/render-ascii-treemap sample-treemap {:name-width 60})
+      (let [result-wide (common/render-ascii-treemap sample-treemap {:name-width 60})
             result-narrow (common/render-ascii-treemap sample-treemap {:name-width 30})
-            lines-wide    (str/split-lines result-wide)
-            lines-narrow  (str/split-lines result-narrow)]
+            lines-wide (str/split-lines result-wide)
+            lines-narrow (str/split-lines result-narrow)]
         (is (> (count (second lines-wide)) (count (second lines-narrow))))))
 
     (testing "respects bar-width option"
-      (let [result-wide   (common/render-ascii-treemap sample-treemap {:bar-width 30})
+      (let [result-wide (common/render-ascii-treemap sample-treemap {:bar-width 30})
             result-narrow (common/render-ascii-treemap sample-treemap {:bar-width 10})]
         (is (> (count (filter #(= % \█) result-wide))
                (count (filter #(= % \█) result-narrow))))))
@@ -157,3 +157,101 @@
       (is (str/includes?
            (common/render-ascii-treemap (assoc sample-treemap :group-by :type→class→line))
            "type→class→line")))))
+
+(def deep-long-names-treemap
+  "Treemap with deep nesting and long class names for alignment testing."
+  {:type :criterium/allocation-treemap
+   :group-by :class→line→type
+   :size-by :bytes
+   :root {:name "allocations"
+          :value 248
+          :children
+          [{:name "clojure.lang.PersistentVector$TransientVector"
+            :value 112
+            :children [{:name "L767"
+                        :value 72
+                        :children [{:name "clojure.lang.PersistentVector$Node"
+                                    :value 72}]}
+                       {:name "L720"
+                        :value 40
+                        :children [{:name "clojure.lang.PersistentVector"
+                                    :value 40}]}]}
+           {:name "clojure.lang.PersistentVector"
+            :value 72
+            :children [{:name "L69"
+                        :value 72
+                        :children
+                        [{:name "clojure.lang.PersistentVector$TransientVector"
+                          :value 32}
+                         {:name "clojure.lang.PersistentVector$Node"
+                          :value 24}
+                         {:name "java.util.concurrent.atomic.AtomicReference"
+                          :value 16}]}]}
+           {:name "clojure.lang.Compiler"
+            :value 64
+            :children [{:name "L7757"
+                        :value 64
+                        :children [{:name "clojure.lang.PersistentVector"
+                                    :value 40}
+                                   {:name "java.lang.Long"
+                                    :value 24}]}]}]}})
+
+(deftest treemap-alignment-test
+  ;; Tests that treemap leaf bars start in the same column and tree structure
+  ;; is preserved even with deep nesting and long class names that require truncation.
+  (testing "treemap-alignment"
+    (testing "aligns leaf bars in same column"
+      (let [result (common/render-ascii-treemap deep-long-names-treemap)
+            lines (str/split-lines result)
+            leaf-lines (filter #(str/includes? % "█") lines)
+            ;; Extract the position where the bar starts (first █ character)
+            bar-positions (map #(.indexOf ^String % "█") leaf-lines)]
+        ;; All bars should start at the same position
+        (is (apply = bar-positions)
+            (str "Bar positions differ: " (vec bar-positions)
+                 "\nLines:\n" (str/join "\n" leaf-lines)))))
+
+    (testing "preserves tree connectors without corruption"
+      (let [result (common/render-ascii-treemap deep-long-names-treemap)]
+        ;; Should not contain replacement characters
+        (is (not (str/includes? result "�"))
+            "Found replacement character in output")
+        ;; All tree connectors should be intact
+        (is (or (str/includes? result "├── ")
+                (str/includes? result "├──"))
+            "Missing branch connector")
+        (is (or (str/includes? result "└── ")
+                (str/includes? result "└──"))
+            "Missing last-child connector")))
+
+    (testing "truncates long names from left with ellipsis"
+      (let [result (common/render-ascii-treemap deep-long-names-treemap
+                                                {:name-width 40})]
+        ;; Long names should be truncated with ellipsis prefix
+        (is (str/includes? result "…")
+            "Expected ellipsis for truncated names")))
+
+    (testing "maintains fixed column width for all lines"
+      (let [result (common/render-ascii-treemap deep-long-names-treemap
+                                                {:name-width 40})
+            lines (str/split-lines result)
+            ;; Skip header line, check data lines
+            data-lines (rest lines)
+            ;; Find position of first [ in each line (start of size)
+            bracket-positions (map #(.indexOf ^String % "[") data-lines)]
+        ;; All size brackets should start at same position (column 41, 0-indexed 40)
+        (is (apply = bracket-positions)
+            (str "Size column positions differ: " (vec bracket-positions)
+                 "\nLines:\n" (str/join "\n" data-lines)))))
+
+    (testing "handles last-child at multiple nesting levels"
+      ;; This specifically tests the case where continuation prefixes
+      ;; are "    " (spaces) from multiple last-child ancestors
+      (let [result (common/render-ascii-treemap deep-long-names-treemap)
+            lines (str/split-lines result)]
+        ;; The Compiler branch is last at level 1, L7757 is last at level 2
+        ;; Their children should have proper tree structure
+        (is (some #(and (str/includes? % "java.lang.Long")
+                        (str/includes? % "└──"))
+                  lines)
+            "Expected java.lang.Long as last child with └── connector")))))

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -60,7 +60,7 @@
   (testing "render-ascii-treemap"
     (testing "produces correct tree structure"
       (let [result (common/render-ascii-treemap sample-treemap)
-            lines (str/split-lines result)]
+            lines  (str/split-lines result)]
         (is (string? result))
         (is (str/starts-with? (first lines) "Allocation Treemap"))
         (is (str/includes? (first lines) "bytes"))
@@ -83,22 +83,24 @@
 
     (testing "shows bars only on leaf nodes"
       (let [result (common/render-ascii-treemap sample-treemap)
-            lines (str/split-lines result)]
+            lines  (str/split-lines result)]
         (doseq [line lines]
           (when (str/includes? line "█")
             (is (not (str/ends-with? (first (str/split line #"\[")) "/"))
                 (str "Bar found on non-leaf: " line))))))
 
     (testing "respects depth-limit option"
-      (let [result (common/render-ascii-treemap sample-treemap {:depth-limit 1})
-            lines (str/split-lines result)]
+      (let [result (common/render-ascii-treemap
+                    sample-treemap
+                    {:depth-limit 1})]
         (is (not (str/includes? result "L42")))
         (is (not (str/includes? result "java.lang.String")))
         (is (str/includes? result "MyClass/"))))
 
     (testing "respects depth-limit 2"
-      (let [result (common/render-ascii-treemap sample-treemap {:depth-limit 2})
-            lines (str/split-lines result)]
+      (let [result (common/render-ascii-treemap
+                    sample-treemap
+                    {:depth-limit 2})]
         (is (str/includes? result "L42/"))
         (is (not (str/includes? result "java.lang.String")))))
 
@@ -110,18 +112,18 @@
         (is (not (str/includes? result "L58")))))
 
     (testing "handles empty children"
-      (let [empty-treemap {:type :criterium/allocation-treemap
+      (let [empty-treemap {:type     :criterium/allocation-treemap
                            :group-by :class→line→type
-                           :size-by :bytes
-                           :root {:name "allocations" :value 0}}
-            result (common/render-ascii-treemap empty-treemap)]
+                           :size-by  :bytes
+                           :root     {:name "allocations" :value 0}}
+            result        (common/render-ascii-treemap empty-treemap)]
         (is (string? result))
         (is (str/includes? result "Allocation Treemap"))
         (is (str/includes? result "allocations/"))))
 
     (testing "handles nil root"
       (let [nil-treemap {:type :criterium/allocation-treemap :root nil}
-            result (common/render-ascii-treemap nil-treemap)]
+            result      (common/render-ascii-treemap nil-treemap)]
         (is (= "" result))))
 
     (testing "formats sizes correctly"
@@ -131,14 +133,14 @@
                 (str/includes? result "bytes")))))
 
     (testing "respects name-width option"
-      (let [result-wide (common/render-ascii-treemap sample-treemap {:name-width 60})
+      (let [result-wide   (common/render-ascii-treemap sample-treemap {:name-width 60})
             result-narrow (common/render-ascii-treemap sample-treemap {:name-width 30})
-            lines-wide (str/split-lines result-wide)
-            lines-narrow (str/split-lines result-narrow)]
+            lines-wide    (str/split-lines result-wide)
+            lines-narrow  (str/split-lines result-narrow)]
         (is (> (count (second lines-wide)) (count (second lines-narrow))))))
 
     (testing "respects bar-width option"
-      (let [result-wide (common/render-ascii-treemap sample-treemap {:bar-width 30})
+      (let [result-wide   (common/render-ascii-treemap sample-treemap {:bar-width 30})
             result-narrow (common/render-ascii-treemap sample-treemap {:bar-width 10})]
         (is (> (count (filter #(= % \█) result-wide))
                (count (filter #(= % \█) result-narrow))))))

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -1,0 +1,157 @@
+(ns criterium.viewer.common-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [criterium.viewer.common :as common]))
+
+;; Tests for ASCII treemap rendering functions.
+;; Verifies ascii-bar generates proportional bars and render-ascii-treemap
+;; produces correct tree structure with proper formatting, filtering, and depth limits.
+
+(def sample-treemap
+  "Sample allocation treemap for testing."
+  {:type :criterium/allocation-treemap
+   :group-by :class→line→type
+   :size-by :bytes
+   :root {:name "allocations"
+          :value 1000000
+          :children [{:name "MyClass"
+                      :value 800000
+                      :children [{:name "L42"
+                                  :value 600000
+                                  :children [{:name "java.lang.String"
+                                              :value 400000}
+                                             {:name "clojure.lang.Keyword"
+                                              :value 200000}]}
+                                 {:name "L58"
+                                  :value 200000
+                                  :children [{:name "java.lang.Long"
+                                              :value 200000}]}]}
+                     {:name "OtherClass"
+                      :value 200000
+                      :children [{:name "L10"
+                                  :value 200000
+                                  :children [{:name "java.util.HashMap"
+                                              :value 200000}]}]}]}})
+
+(deftest ascii-bar-test
+  (testing "ascii-bar"
+    (testing "produces correct proportional bars"
+      (is (= "████████████████████" (common/ascii-bar 100.0 100.0 20)))
+      (is (= "██████████" (common/ascii-bar 50.0 100.0 20)))
+      (is (= "█████" (common/ascii-bar 25.0 100.0 20)))
+      (is (= "██" (common/ascii-bar 10.0 100.0 20))))
+
+    (testing "handles zero and negative values"
+      (is (= "" (common/ascii-bar 0.0 100.0 20)))
+      (is (= "" (common/ascii-bar -10.0 100.0 20)))
+      (is (= "" (common/ascii-bar 100.0 0.0 20)))
+      (is (= "" (common/ascii-bar 100.0 -10.0 20))))
+
+    (testing "respects width parameter"
+      (is (= "██████████" (common/ascii-bar 100.0 100.0 10)))
+      (is (= "█████" (common/ascii-bar 100.0 100.0 5)))
+      (is (= "██████████████████████████████" (common/ascii-bar 100.0 100.0 30))))
+
+    (testing "caps at max width when value exceeds max"
+      (is (= "████████████████████" (common/ascii-bar 150.0 100.0 20))))))
+
+(deftest render-ascii-treemap-test
+  (testing "render-ascii-treemap"
+    (testing "produces correct tree structure"
+      (let [result (common/render-ascii-treemap sample-treemap)
+            lines (str/split-lines result)]
+        (is (string? result))
+        (is (str/starts-with? (first lines) "Allocation Treemap"))
+        (is (str/includes? (first lines) "bytes"))
+        (is (str/includes? (first lines) "class→line→type"))
+        (is (str/includes? (second lines) "allocations/"))
+        (is (some #(str/includes? % "├──") lines))
+        (is (some #(str/includes? % "└──") lines))
+        (is (some #(str/includes? % "│") lines))))
+
+    (testing "shows non-leaf nodes with trailing slash"
+      (let [result (common/render-ascii-treemap sample-treemap)]
+        (is (str/includes? result "allocations/"))
+        (is (str/includes? result "MyClass/"))
+        (is (str/includes? result "L42/"))))
+
+    (testing "shows leaf nodes without trailing slash"
+      (let [result (common/render-ascii-treemap sample-treemap)]
+        (is (str/includes? result "java.lang.String "))
+        (is (not (str/includes? result "java.lang.String/")))))
+
+    (testing "shows bars only on leaf nodes"
+      (let [result (common/render-ascii-treemap sample-treemap)
+            lines (str/split-lines result)]
+        (doseq [line lines]
+          (when (str/includes? line "█")
+            (is (not (str/ends-with? (first (str/split line #"\[")) "/"))
+                (str "Bar found on non-leaf: " line))))))
+
+    (testing "respects depth-limit option"
+      (let [result (common/render-ascii-treemap sample-treemap {:depth-limit 1})
+            lines (str/split-lines result)]
+        (is (not (str/includes? result "L42")))
+        (is (not (str/includes? result "java.lang.String")))
+        (is (str/includes? result "MyClass/"))))
+
+    (testing "respects depth-limit 2"
+      (let [result (common/render-ascii-treemap sample-treemap {:depth-limit 2})
+            lines (str/split-lines result)]
+        (is (str/includes? result "L42/"))
+        (is (not (str/includes? result "java.lang.String")))))
+
+    (testing "filters by min-percent"
+      (let [result (common/render-ascii-treemap sample-treemap {:min-percent 25})]
+        (is (str/includes? result "MyClass/"))
+        (is (str/includes? result "L42/"))
+        (is (not (str/includes? result "OtherClass")))
+        (is (not (str/includes? result "L58")))))
+
+    (testing "handles empty children"
+      (let [empty-treemap {:type :criterium/allocation-treemap
+                           :group-by :class→line→type
+                           :size-by :bytes
+                           :root {:name "allocations" :value 0}}
+            result (common/render-ascii-treemap empty-treemap)]
+        (is (string? result))
+        (is (str/includes? result "Allocation Treemap"))
+        (is (str/includes? result "allocations/"))))
+
+    (testing "handles nil root"
+      (let [nil-treemap {:type :criterium/allocation-treemap :root nil}
+            result (common/render-ascii-treemap nil-treemap)]
+        (is (= "" result))))
+
+    (testing "formats sizes correctly"
+      (let [result (common/render-ascii-treemap sample-treemap)]
+        (is (or (str/includes? result "Kb")
+                (str/includes? result "Mb")
+                (str/includes? result "bytes")))))
+
+    (testing "respects name-width option"
+      (let [result-wide (common/render-ascii-treemap sample-treemap {:name-width 60})
+            result-narrow (common/render-ascii-treemap sample-treemap {:name-width 30})
+            lines-wide (str/split-lines result-wide)
+            lines-narrow (str/split-lines result-narrow)]
+        (is (> (count (second lines-wide)) (count (second lines-narrow))))))
+
+    (testing "respects bar-width option"
+      (let [result-wide (common/render-ascii-treemap sample-treemap {:bar-width 30})
+            result-narrow (common/render-ascii-treemap sample-treemap {:bar-width 10})]
+        (is (> (count (filter #(= % \█) result-wide))
+               (count (filter #(= % \█) result-narrow))))))
+
+    (testing "shows correct header for different size-by options"
+      (is (str/includes?
+           (common/render-ascii-treemap (assoc sample-treemap :size-by :count))
+           "by count"))
+      (is (str/includes?
+           (common/render-ascii-treemap (assoc sample-treemap :size-by :bytes-per-allocation))
+           "by bytes/alloc")))
+
+    (testing "shows correct header for different group-by options"
+      (is (str/includes?
+           (common/render-ascii-treemap (assoc sample-treemap :group-by :type→class→line))
+           "type→class→line")))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -452,7 +452,7 @@
       (let [data-map (:data (test-data/samples-with-2-values-map))
             ;; Add metric-configs needed by sample-diffs
             data-map (assoc-in data-map [:samples :metric-configs]
-                               [{:path  [:elapsed-time]
+                               [{:path [:elapsed-time]
                                  :label "Elapsed Time"
                                  :scale 1}])]
         (view/sample-diffs* :kindly {} data-map)
@@ -503,12 +503,12 @@
     (testing
      "renders single-impl extract as consolidated table with single-key coords"
       (reset! kindly/accumulated [])
-      (let [data-map {:extract {:type    :criterium/domain-extract
+      (let [data-map {:extract {:type :criterium/domain-extract
                                 :metrics {:elapsed-time
                                           {:metric [:stats :elapsed-time :mean]
-                                           :data   [[{:n 100} 1e6]
-                                                    [{:n 1000} 1e7]
-                                                    [{:n 10000} 1e8]]}}}}]
+                                           :data [[{:n 100} 1e6]
+                                                  [{:n 1000} 1e7]
+                                                  [{:n 10000} 1e8]]}}}}]
         (view/domain-extract* :kindly {} data-map)
         (let [result (kindly/flush)]
           (is (= :kind/fragment (:kindly/kind (meta result))))
@@ -536,13 +536,13 @@
 
     (testing "renders multi-key coords with :coordinate column"
       (reset! kindly/accumulated [])
-      (let [data-map {:extract {:type    :criterium/domain-extract
+      (let [data-map {:extract {:type :criterium/domain-extract
                                 :metrics {:elapsed-time
                                           {:metric [:stats :elapsed-time :mean]
-                                           :data   [[{:n 100 :m 1} 1e6]
-                                                    [{:n 1000 :m 2} 1e7]]}}}}]
+                                           :data [[{:n 100 :m 1} 1e6]
+                                                  [{:n 1000 :m 2} 1e7]]}}}}]
         (view/domain-extract* :kindly {} data-map)
-        (let [result    (kindly/flush)
+        (let [result (kindly/flush)
               [_ table] result]
           (is (every? #(contains? % :coordinate) table)
               "Expected :coordinate column for multi-key coords"))))
@@ -550,19 +550,19 @@
     (testing "renders multi-metric extract as consolidated table"
       (reset! kindly/accumulated [])
       (let [data-map {:extract
-                      {:type    :criterium/domain-extract
+                      {:type :criterium/domain-extract
                        :metrics {:elapsed-time
                                  {:metric [:stats :elapsed-time :mean]
-                                  :data   [[{:n 100} 1e6]
-                                           [{:n 1000} 1e7]]}
+                                  :data [[{:n 100} 1e6]
+                                         [{:n 1000} 1e7]]}
                                  :thread-allocation
                                  {:metric [:stats :thread-allocation :mean]
-                                  :data   [[{:n 100} 1024]
-                                           [{:n 1000} 2048]]}}}}]
+                                  :data [[{:n 100} 1024]
+                                         [{:n 1000} 2048]]}}}}]
         (view/domain-extract* :kindly {} data-map)
-        (let [result    (kindly/flush)
+        (let [result (kindly/flush)
               [_ table] result
-              col-keys  (keys (first table))]
+              col-keys (keys (first table))]
           (is (= 2 (count table))
               "Expected 2 rows")
           (is (some
@@ -577,20 +577,20 @@
     (testing "renders multi-impl extract with impl in column headers"
       (reset! kindly/accumulated [])
       (let [data-map {:extract
-                      {:type            :criterium/domain-extract
-                       :impl-axis       :impl
+                      {:type :criterium/domain-extract
+                       :impl-axis :impl
                        :implementations [:foo :bar]
                        :metrics
                        {:elapsed-time
                         {:metric [:stats :elapsed-time :mean]
-                         :data   [[{:n 100 :impl :foo} 1e6]
-                                  [{:n 100 :impl :bar} 2e6]
-                                  [{:n 1000 :impl :foo} 1e7]
-                                  [{:n 1000 :impl :bar} 2e7]]}}}}]
+                         :data [[{:n 100 :impl :foo} 1e6]
+                                [{:n 100 :impl :bar} 2e6]
+                                [{:n 1000 :impl :foo} 1e7]
+                                [{:n 1000 :impl :bar} 2e7]]}}}}]
         (view/domain-extract* :kindly {} data-map)
-        (let [result    (kindly/flush)
+        (let [result (kindly/flush)
               [_ table] result
-              col-keys  (set (map str (keys (first table))))]
+              col-keys (set (map str (keys (first table))))]
           (is (= 2 (count table))
               "Expected 2 rows (one per n value)")
           ;; Column headers include impl name with newline
@@ -610,17 +610,17 @@
 
     (testing "handles nil values in data"
       (reset! kindly/accumulated [])
-      (let [data-map {:extract {:type    :criterium/domain-extract
+      (let [data-map {:extract {:type :criterium/domain-extract
                                 :metrics {:elapsed-time
                                           {:metric [:stats :elapsed-time :mean]
-                                           :data   [[{:n 100} nil]
-                                                    [{:n 1000} 1e7]]}}}}]
+                                           :data [[{:n 100} nil]
+                                                  [{:n 1000} 1e7]]}}}}]
         (view/domain-extract* :kindly {} data-map)
-        (let [result       (kindly/flush)
-              [_ table]    result
-              col-key      (first (filter #(clojure.string/starts-with?
-                                            (str %) "elapsed-time")
-                                          (keys (first table))))
+        (let [result (kindly/flush)
+              [_ table] result
+              col-key (first (filter #(clojure.string/starts-with?
+                                       (str %) "elapsed-time")
+                                     (keys (first table))))
               ;; Find the row with n=100 (has nil value) - single-key so :n
               ;; column
               row-with-nil (first (filter #(= 100 (:n %)) table))]
@@ -673,8 +673,8 @@
     (testing "renders comparison as heading and table"
       (reset! kindly/accumulated [])
       (let [data-map {:comparison
-                      {:type   :criterium/domain-comparison
-                       :axis   :impl
+                      {:type :criterium/domain-comparison
+                       :axis :impl
                        :metric [:stats :elapsed-time :mean]
                        :data
                        {:foo [{:coord {:n 100 :impl :foo} :value 1e6}
@@ -702,9 +702,9 @@
     (testing "with :implementations shows factors for non-baseline"
       (reset! kindly/accumulated [])
       (let [data-map {:comparison
-                      {:type            :criterium/domain-comparison
-                       :axis            :impl
-                       :metric          [:stats :elapsed-time :mean]
+                      {:type :criterium/domain-comparison
+                       :axis :impl
+                       :metric [:stats :elapsed-time :mean]
                        :implementations [:foo :bar]
                        :data
                        {:foo [{:coord {:n 100 :impl :foo} :value 1e6}
@@ -729,10 +729,10 @@
 
     (testing "handles empty data gracefully"
       (reset! kindly/accumulated [])
-      (let [data-map {:comparison {:type   :criterium/domain-comparison
-                                   :axis   :impl
+      (let [data-map {:comparison {:type :criterium/domain-comparison
+                                   :axis :impl
                                    :metric [:stats :elapsed-time :mean]
-                                   :data   {}}}]
+                                   :data {}}}]
         (view/domain-comparison* :kindly {} data-map)
         (is (nil? (kindly/flush)))))
 
@@ -750,33 +750,33 @@
       (reset! kindly/accumulated [])
       (let [data-map
             {:extract
-             {:type    :criterium/domain-extract
+             {:type :criterium/domain-extract
               :metrics {:elapsed-time
                         {:metric [:stats :elapsed-time :mean]
-                         :data   [[{:n 100} 1e6]
-                                  [{:n 200} 2e6]
-                                  [{:n 400} 4e6]
-                                  [{:n 800} 8e6]]}}}
+                         :data [[{:n 100} 1e6]
+                                [{:n 200} 2e6]
+                                [{:n 400} 4e6]
+                                [{:n 800} 8e6]]}}}
              :regression
              {:type :criterium/domain-regression
               :axis :n
               :regressions
               {:elapsed-time
-               {:metric   [:stats :elapsed-time :mean]
-                :models   [{:id           :linear
-                            :label        "O(n)"
-                            :coefficients {:a 10000.0 :b 0.0}
-                            :equation-str "y = 10000*n + 0"
-                            :predict-fn   (fn [^double x]
-                                            (* 10000.0 x))
-                            :r-squared    0.9999}
-                           {:id           :quadratic
-                            :label        "O(n²)"
-                            :coefficients {:a 0.1 :b 100000.0}
-                            :equation-str "y = 0.1*n² + 100000"
-                            :predict-fn   (fn [^double x]
-                                            (+ (* 0.1 x x) 100000.0))
-                            :r-squared    0.85}]
+               {:metric [:stats :elapsed-time :mean]
+                :models [{:id :linear
+                          :label "O(n)"
+                          :coefficients {:a 10000.0 :b 0.0}
+                          :equation-str "y = 10000*n + 0"
+                          :predict-fn (fn [^double x]
+                                        (* 10000.0 x))
+                          :r-squared 0.9999}
+                         {:id :quadratic
+                          :label "O(n²)"
+                          :coefficients {:a 0.1 :b 100000.0}
+                          :equation-str "y = 0.1*n² + 100000"
+                          :predict-fn (fn [^double x]
+                                        (+ (* 0.1 x x) 100000.0))
+                          :r-squared 0.85}]
                 :best-fit :linear}}}}]
         ;; With default 1% tolerance, only linear (0.9999) is plotted
         ;; quadratic (0.85) is well below threshold (0.9999 * 0.99 = 0.9899)
@@ -812,33 +812,33 @@
       (reset! kindly/accumulated [])
       (let [data-map
             {:extract
-             {:type    :criterium/domain-extract
+             {:type :criterium/domain-extract
               :metrics {:elapsed-time
                         {:metric [:stats :elapsed-time :mean]
-                         :data   [[{:n 100} 1e6]
-                                  [{:n 200} 2e6]
-                                  [{:n 400} 4e6]
-                                  [{:n 800} 8e6]]}}}
+                         :data [[{:n 100} 1e6]
+                                [{:n 200} 2e6]
+                                [{:n 400} 4e6]
+                                [{:n 800} 8e6]]}}}
              :regression
              {:type :criterium/domain-regression
               :axis :n
               :regressions
               {:elapsed-time
-               {:metric   [:stats :elapsed-time :mean]
-                :models   [{:id           :linear
-                            :label        "O(n)"
-                            :coefficients {:a 10000.0 :b 0.0}
-                            :equation-str "y = 10000*n + 0"
-                            :predict-fn   (fn [^double x]
-                                            (* 10000.0 x))
-                            :r-squared    0.9999}
-                           {:id           :n-log-n
-                            :label        "O(n log n)"
-                            :coefficients {:a 1000.0 :b 0.0}
-                            :equation-str "y = 1000*n*log(n) + 0"
-                            :predict-fn   (fn [^double x]
-                                            (* 1000.0 x (Math/log x)))
-                            :r-squared    0.9995}]
+               {:metric [:stats :elapsed-time :mean]
+                :models [{:id :linear
+                          :label "O(n)"
+                          :coefficients {:a 10000.0 :b 0.0}
+                          :equation-str "y = 10000*n + 0"
+                          :predict-fn (fn [^double x]
+                                        (* 10000.0 x))
+                          :r-squared 0.9999}
+                         {:id :n-log-n
+                          :label "O(n log n)"
+                          :coefficients {:a 1000.0 :b 0.0}
+                          :equation-str "y = 1000*n*log(n) + 0"
+                          :predict-fn (fn [^double x]
+                                        (* 1000.0 x (Math/log x)))
+                          :r-squared 0.9995}]
                 :best-fit :linear}}}}]
         ;; Both models within 1% tolerance (0.9999 * 0.99 = 0.9899)
         (view/domain-regression* :kindly {} data-map)
@@ -859,33 +859,33 @@
       (reset! kindly/accumulated [])
       (let [data-map
             {:extract
-             {:type    :criterium/domain-extract
+             {:type :criterium/domain-extract
               :metrics {:elapsed-time
                         {:metric [:stats :elapsed-time :mean]
-                         :data   [[{:n 100} 1e6]
-                                  [{:n 200} 2e6]
-                                  [{:n 400} 4e6]
-                                  [{:n 800} 8e6]]}}}
+                         :data [[{:n 100} 1e6]
+                                [{:n 200} 2e6]
+                                [{:n 400} 4e6]
+                                [{:n 800} 8e6]]}}}
              :regression
              {:type :criterium/domain-regression
               :axis :n
               :regressions
               {:elapsed-time
-               {:metric   [:stats :elapsed-time :mean]
-                :models   [{:id           :linear
-                            :label        "O(n)"
-                            :coefficients {:a 10000.0 :b 0.0}
-                            :equation-str "y = 10000*n + 0"
-                            :predict-fn   (fn [^double x]
-                                            (* 10000.0 x))
-                            :r-squared    0.9999}
-                           {:id           :quadratic
-                            :label        "O(n²)"
-                            :coefficients {:a 0.1 :b 100000.0}
-                            :equation-str "y = 0.1*n² + 100000"
-                            :predict-fn   (fn [^double x]
-                                            (+ (* 0.1 x x) 100000.0))
-                            :r-squared    0.85}]
+               {:metric [:stats :elapsed-time :mean]
+                :models [{:id :linear
+                          :label "O(n)"
+                          :coefficients {:a 10000.0 :b 0.0}
+                          :equation-str "y = 10000*n + 0"
+                          :predict-fn (fn [^double x]
+                                        (* 10000.0 x))
+                          :r-squared 0.9999}
+                         {:id :quadratic
+                          :label "O(n²)"
+                          :coefficients {:a 0.1 :b 100000.0}
+                          :equation-str "y = 0.1*n² + 100000"
+                          :predict-fn (fn [^double x]
+                                        (+ (* 0.1 x x) 100000.0))
+                          :r-squared 0.85}]
                 :best-fit :linear}}}}]
         ;; With 20% tolerance, quadratic (0.85) is within threshold
         ;; (0.9999 * 0.80 = 0.7999)
@@ -907,14 +907,14 @@
                        :axis :n
                        :regressions
                        {:elapsed-time
-                        {:metric   [:stats :elapsed-time :mean]
-                         :models   [{:id           :linear
-                                     :label        "O(n)"
-                                     :coefficients {:a 10000.0 :b 0.0}
-                                     :equation-str "y = 10000*n + 0"
-                                     :predict-fn   (fn [^double x]
-                                                     (* 10000.0 x))
-                                     :r-squared    0.9999}]
+                        {:metric [:stats :elapsed-time :mean]
+                         :models [{:id :linear
+                                   :label "O(n)"
+                                   :coefficients {:a 10000.0 :b 0.0}
+                                   :equation-str "y = 10000*n + 0"
+                                   :predict-fn (fn [^double x]
+                                                 (* 10000.0 x))
+                                   :r-squared 0.9999}]
                          :best-fit :linear}}}}]
         (view/domain-regression* :kindly {} data-map)
         (let [result (kindly/flush)]
@@ -927,11 +927,11 @@
     (testing "handles empty models gracefully"
       (reset! kindly/accumulated [])
       (let [data-map {:regression
-                      {:type        :criterium/domain-regression
-                       :axis        :n
+                      {:type :criterium/domain-regression
+                       :axis :n
                        :regressions {:elapsed-time
-                                     {:metric   [:stats :elapsed-time :mean]
-                                      :models   []
+                                     {:metric [:stats :elapsed-time :mean]
+                                      :models []
                                       :best-fit nil}}}}]
         (view/domain-regression* :kindly {} data-map)
         (let [result (kindly/flush)]
@@ -946,7 +946,7 @@
 (deftest allocation-summary-view-test
   ;; Tests the view/allocation-summary* multimethod for :kindly viewer.
   ;; Verifies that allocation summary data is rendered as a heading and table
-  ;; with metrics for total allocated/freed, retained, counts, and ratio.
+  ;; with metrics for total allocated/freed, retained, counts, and ratio (based on bytes).
   (testing "view/allocation-summary* :kindly"
     (testing "renders summary as heading and table"
       (reset! kindly/accumulated [])
@@ -972,10 +972,10 @@
             (is (every? #(contains? % :value) table)
                 "Expected :value column")
             (let [metrics-by-name (into {} (map (juxt :metric :value) table))]
-              (is (string? (get metrics-by-name "Total allocated"))
-                  "Expected formatted byte value")
-              (is (string? (get metrics-by-name "Freed ratio"))
-                  "Expected percentage string"))))))
+              (is (= "1048576 bytes" (get metrics-by-name "Total allocated"))
+                  "Expected byte value with unit")
+              (is (= "50.0%" (get metrics-by-name "Freed ratio"))
+                  "Expected percentage string based on bytes"))))))
 
     (testing "handles zero allocations gracefully"
       (reset! kindly/accumulated [])
@@ -1000,7 +1000,7 @@
 (deftest allocation-hotspots-view-test
   ;; Tests the view/allocation-hotspots* multimethod for :kindly viewer.
   ;; Verifies that hotspots data is rendered as a heading and table with
-  ;; call-site, count, bytes, freed-count, and freed-bytes columns.
+  ;; call-site, object-type, count, bytes, freed-count, and freed-bytes columns.
   (testing "view/allocation-hotspots* :kindly"
     (testing "renders hotspots as heading and table"
       (reset! kindly/accumulated [])
@@ -1010,6 +1010,7 @@
                                                :call-method "invoke"
                                                :call-file "my_ns.clj"
                                                :call-line 42}
+                                   :object-type "Ljava/lang/String;"
                                    :count 100
                                    :bytes 4096
                                    :freed-count 50
@@ -1018,6 +1019,7 @@
                                                :call-method "invoke"
                                                :call-file "other_ns.clj"
                                                :call-line 10}
+                                   :object-type "[B"
                                    :count 50
                                    :bytes 2048
                                    :freed-count 25
@@ -1038,9 +1040,11 @@
                   "Expected call-site to contain class name")
               (is (str/includes? (:call-site first-row) "my_ns.clj:42")
                   "Expected call-site to contain file:line")
+              (is (= "Ljava/lang/String;" (:object-type first-row))
+                  "Expected object-type to be present")
               (is (= 100 (:count first-row)))
-              (is (string? (:bytes first-row))
-                  "Expected formatted byte value")
+              (is (= 4096 (:bytes first-row))
+                  "Expected integer byte value")
               (is (= 50 (:freed-count first-row))))))))
 
     (testing "handles empty hotspots gracefully"
@@ -1091,8 +1095,8 @@
                 "Expected long array last (lowest bytes)")
             (let [first-row (first table)]
               (is (= 50 (:count first-row)))
-              (is (string? (:bytes first-row))
-                  "Expected formatted byte value"))))))
+              (is (integer? (:bytes first-row))
+                  "Expected integer byte value"))))))
 
     (testing "handles empty by-type gracefully"
       (reset! kindly/accumulated [])

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -942,3 +942,167 @@
       (reset! kindly/accumulated [])
       (view/domain-regression* :kindly {} {:regression nil})
       (is (nil? (kindly/flush))))))
+
+(deftest allocation-summary-view-test
+  ;; Tests the view/allocation-summary* multimethod for :kindly viewer.
+  ;; Verifies that allocation summary data is rendered as a heading and table
+  ;; with metrics for total allocated/freed, retained, counts, and ratio.
+  (testing "view/allocation-summary* :kindly"
+    (testing "renders summary as heading and table"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-summary
+                      {:type :criterium/allocation-summary
+                       :total-allocated 1048576
+                       :total-freed 524288
+                       :num-allocations 100
+                       :num-freed 50}}]
+        (view/allocation-summary* :kindly {} data-map)
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result))
+              "Expected heading and table")
+          (let [[heading table] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Allocation Summary**"] heading))
+            (is (= :kind/table (:kindly/kind (meta table))))
+            (is (= 6 (count table))
+                "Expected 6 metrics")
+            (is (every? #(contains? % :metric) table)
+                "Expected :metric column")
+            (is (every? #(contains? % :value) table)
+                "Expected :value column")
+            (let [metrics-by-name (into {} (map (juxt :metric :value) table))]
+              (is (string? (get metrics-by-name "Total allocated"))
+                  "Expected formatted byte value")
+              (is (string? (get metrics-by-name "Freed ratio"))
+                  "Expected percentage string"))))))
+
+    (testing "handles zero allocations gracefully"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-summary
+                      {:type :criterium/allocation-summary
+                       :total-allocated 0
+                       :total-freed 0
+                       :num-allocations 0
+                       :num-freed 0}}]
+        (view/allocation-summary* :kindly {} data-map)
+        (let [result (kindly/flush)
+              [_ table] result
+              metrics-by-name (into {} (map (juxt :metric :value) table))]
+          (is (= "N/A" (get metrics-by-name "Freed ratio"))
+              "Expected N/A for zero allocations"))))
+
+    (testing "handles nil summary gracefully"
+      (reset! kindly/accumulated [])
+      (view/allocation-summary* :kindly {} {:allocation-summary nil})
+      (is (nil? (kindly/flush))))))
+
+(deftest allocation-hotspots-view-test
+  ;; Tests the view/allocation-hotspots* multimethod for :kindly viewer.
+  ;; Verifies that hotspots data is rendered as a heading and table with
+  ;; call-site, count, bytes, freed-count, and freed-bytes columns.
+  (testing "view/allocation-hotspots* :kindly"
+    (testing "renders hotspots as heading and table"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-hotspots
+                      {:type :criterium/allocation-hotspots
+                       :hotspots [{:call-site {:call-class "my.ns$fn"
+                                               :call-method "invoke"
+                                               :call-file "my_ns.clj"
+                                               :call-line 42}
+                                   :count 100
+                                   :bytes 4096
+                                   :freed-count 50
+                                   :freed-bytes 2048}
+                                  {:call-site {:call-class "other.ns$bar"
+                                               :call-method "invoke"
+                                               :call-file "other_ns.clj"
+                                               :call-line 10}
+                                   :count 50
+                                   :bytes 2048
+                                   :freed-count 25
+                                   :freed-bytes 1024}]}}]
+        (view/allocation-hotspots* :kindly {} data-map)
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result))
+              "Expected heading and table")
+          (let [[heading table] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Allocation Hotspots**"] heading))
+            (is (= :kind/table (:kindly/kind (meta table))))
+            (is (= 2 (count table))
+                "Expected 2 hotspot rows")
+            (let [first-row (first table)]
+              (is (str/includes? (:call-site first-row) "my.ns$fn")
+                  "Expected call-site to contain class name")
+              (is (str/includes? (:call-site first-row) "my_ns.clj:42")
+                  "Expected call-site to contain file:line")
+              (is (= 100 (:count first-row)))
+              (is (string? (:bytes first-row))
+                  "Expected formatted byte value")
+              (is (= 50 (:freed-count first-row))))))))
+
+    (testing "handles empty hotspots gracefully"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-hotspots
+                      {:type :criterium/allocation-hotspots
+                       :hotspots []}}]
+        (view/allocation-hotspots* :kindly {} data-map)
+        (is (nil? (kindly/flush)))))
+
+    (testing "handles nil hotspots gracefully"
+      (reset! kindly/accumulated [])
+      (view/allocation-hotspots* :kindly {} {:allocation-hotspots nil})
+      (is (nil? (kindly/flush))))))
+
+(deftest allocation-by-type-view-test
+  ;; Tests the view/allocation-by-type* multimethod for :kindly viewer.
+  ;; Verifies that by-type data is rendered as a heading and table with
+  ;; type, count, bytes, freed-count, and freed-bytes columns, sorted by bytes.
+  (testing "view/allocation-by-type* :kindly"
+    (testing "renders by-type as heading and table sorted by bytes"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-by-type
+                      {:type :criterium/allocation-by-type
+                       :by-type {"[B" {:count 10 :bytes 1024
+                                       :freed-count 5 :freed-bytes 512}
+                                 "java.lang.String" {:count 50 :bytes 4096
+                                                     :freed-count 25 :freed-bytes 2048}
+                                 "[J" {:count 5 :bytes 512
+                                       :freed-count 2 :freed-bytes 256}}}}]
+        (view/allocation-by-type* :kindly {} data-map)
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result))
+              "Expected heading and table")
+          (let [[heading table] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Allocations by Type**"] heading))
+            (is (= :kind/table (:kindly/kind (meta table))))
+            (is (= 3 (count table))
+                "Expected 3 type rows")
+            ;; Verify sorted by bytes descending
+            (is (= "java.lang.String" (:type (first table)))
+                "Expected String first (highest bytes)")
+            (is (= "[B" (:type (second table)))
+                "Expected byte array second")
+            (is (= "[J" (:type (nth table 2)))
+                "Expected long array last (lowest bytes)")
+            (let [first-row (first table)]
+              (is (= 50 (:count first-row)))
+              (is (string? (:bytes first-row))
+                  "Expected formatted byte value"))))))
+
+    (testing "handles empty by-type gracefully"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-by-type
+                      {:type :criterium/allocation-by-type
+                       :by-type {}}}]
+        (view/allocation-by-type* :kindly {} data-map)
+        (is (nil? (kindly/flush)))))
+
+    (testing "handles nil by-type gracefully"
+      (reset! kindly/accumulated [])
+      (view/allocation-by-type* :kindly {} {:allocation-by-type nil})
+      (is (nil? (kindly/flush))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -955,7 +955,8 @@
                        :total-allocated 1048576
                        :total-freed 524288
                        :num-allocations 100
-                       :num-freed 50}}]
+                       :num-freed 50
+                       :freed-ratio 0.5}}]
         (view/allocation-summary* :kindly {} data-map)
         (let [result (kindly/flush)]
           (is (= :kind/fragment (:kindly/kind (meta result))))
@@ -977,20 +978,21 @@
               (is (= "50.0%" (get metrics-by-name "Freed ratio"))
                   "Expected percentage string based on bytes"))))))
 
-    (testing "handles zero allocations gracefully"
+    (testing "handles zero allocations"
       (reset! kindly/accumulated [])
       (let [data-map {:allocation-summary
                       {:type :criterium/allocation-summary
                        :total-allocated 0
                        :total-freed 0
                        :num-allocations 0
-                       :num-freed 0}}]
+                       :num-freed 0
+                       :freed-ratio 0.0}}]
         (view/allocation-summary* :kindly {} data-map)
         (let [result (kindly/flush)
               [_ table] result
               metrics-by-name (into {} (map (juxt :metric :value) table))]
-          (is (= "N/A" (get metrics-by-name "Freed ratio"))
-              "Expected N/A for zero allocations"))))
+          (is (= "0.0%" (get metrics-by-name "Freed ratio"))
+              "Expected 0.0% for zero allocations"))))
 
     (testing "handles nil summary gracefully"
       (reset! kindly/accumulated [])

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -1110,3 +1110,56 @@
       (reset! kindly/accumulated [])
       (view/allocation-by-type* :kindly {} {:allocation-by-type nil})
       (is (nil? (kindly/flush))))))
+
+(deftest allocation-treemap-view-test
+  ;; Tests the view/allocation-treemap* multimethod for :kindly viewer.
+  ;; Verifies that treemap data is rendered as a heading and Vega chart.
+  (testing "view/allocation-treemap* :kindly"
+    (testing "renders treemap as heading and vega chart"
+      (reset! kindly/accumulated [])
+      (let [data-map {:allocation-treemap
+                      {:type :criterium/allocation-treemap
+                       :size-by :bytes
+                       :root {:name "root"
+                              :value 1000
+                              :children [{:name "java.lang.String"
+                                          :value 600
+                                          :children [{:name "L42" :value 600}]}
+                                         {:name "[B"
+                                          :value 400
+                                          :children [{:name "L10" :value 400}]}]}}}]
+        (view/allocation-treemap* :kindly {} data-map)
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result)) "Expected heading and chart")
+          (let [[heading vega-spec] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Allocation Treemap**"] heading))
+            (is (= :kind/vega (:kindly/kind (meta vega-spec))))
+            (is (str/includes? (:$schema vega-spec) "vega/v5.json"))
+            (is (contains? vega-spec :data))
+            (is (contains? vega-spec :marks))))))
+
+    (testing "uses custom treemap-id"
+      (reset! kindly/accumulated [])
+      (let [data-map {:my-treemap
+                      {:type :criterium/allocation-treemap
+                       :root {:name "root"
+                              :value 100
+                              :children [{:name "type1" :value 100}]}}}]
+        (view/allocation-treemap* :kindly {:treemap-id :my-treemap} data-map)
+        (let [result (kindly/flush)
+              [heading _vega-spec] result]
+          (is (= ["**Allocation Treemap**"] heading)))))
+
+    (testing "handles nil treemap data gracefully"
+      (reset! kindly/accumulated [])
+      (view/allocation-treemap* :kindly {} {:allocation-treemap nil})
+      (is (nil? (kindly/flush))))
+
+    (testing "handles missing root gracefully"
+      (reset! kindly/accumulated [])
+      (view/allocation-treemap* :kindly {}
+                                {:allocation-treemap
+                                 {:type :criterium/allocation-treemap}})
+      (is (nil? (kindly/flush))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -493,3 +493,200 @@
           (is (empty? @v))
           (finally
             (remove-tap f)))))))
+
+;;; Allocation View Tests
+
+(deftest portal-allocation-summary-test
+  ;; Tests the portal viewer output for allocation-summary results.
+  ;; Verifies table generation with allocation metrics.
+  (testing "allocation-summary*"
+    (testing "produces table with allocation metrics"
+      (let [[title table] (with-tap-out
+                            (view/allocation-summary*
+                             :portal
+                             {}
+                             {:allocation-summary
+                              {:type :criterium/allocation-summary
+                               :total-allocated 1024000
+                               :total-freed 512000
+                               :num-allocations 100
+                               :num-freed 50}}))]
+        (is (= [:b "Allocation Summary"] title))
+        (is (= 6 (count table)) "Expected 6 rows")
+        (is (= "Total allocated" (:metric (first table))))
+        (is (= 1024000 (:value (first table))))
+        (is (= "Retained" (:metric (nth table 2))))
+        (is (= 512000 (:value (nth table 2))))
+        (is (= "Freed ratio" (:metric (last table))))
+        (is (str/includes? (:value (last table)) "50.0%"))))
+
+    (testing "uses custom summary-id"
+      (let [[title _table] (with-tap-out
+                             (view/allocation-summary*
+                              :portal
+                              {:summary-id :my-summary}
+                              {:my-summary
+                               {:type :criterium/allocation-summary
+                                :total-allocated 1000
+                                :total-freed 500
+                                :num-allocations 10
+                                :num-freed 5}}))]
+        (is (= [:b "Allocation Summary"] title))))
+
+    (testing "handles nil summary gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-summary* :portal {} {:allocation-summary nil})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))
+
+(deftest portal-allocation-hotspots-test
+  ;; Tests the portal viewer output for allocation-hotspots results.
+  ;; Verifies table generation with call-site and allocation stats.
+  (testing "allocation-hotspots*"
+    (testing "produces table with hotspot data"
+      (let [[title table] (with-tap-out
+                            (view/allocation-hotspots*
+                             :portal
+                             {}
+                             {:allocation-hotspots
+                              {:type :criterium/allocation-hotspots
+                               :hotspots [{:call-site {:call-class "my.ns$fn"
+                                                       :call-method "invoke"
+                                                       :call-file "my_ns.clj"
+                                                       :call-line 42}
+                                           :count 50
+                                           :bytes 4800
+                                           :freed-count 30
+                                           :freed-bytes 2880}
+                                          {:call-site {:call-class "other.ns$g"
+                                                       :call-method "invoke"
+                                                       :call-file "other.clj"
+                                                       :call-line 10}
+                                           :count 25
+                                           :bytes 2400
+                                           :freed-count 10
+                                           :freed-bytes 960}]}}))
+            first-row (first table)]
+        (is (= [:b "Allocation Hotspots"] title))
+        (is (= 2 (count table)) "Expected 2 rows")
+        (is (str/includes? (:call-site first-row) "my.ns$fn"))
+        (is (str/includes? (:call-site first-row) "my_ns.clj:42"))
+        (is (= 50 (:count first-row)))
+        (is (= 4800 (:bytes first-row)))
+        (is (= 30 (:freed-count first-row)))
+        (is (= 2880 (:freed-bytes first-row)))))
+
+    (testing "uses custom hotspots-id"
+      (let [[title _table] (with-tap-out
+                             (view/allocation-hotspots*
+                              :portal
+                              {:hotspots-id :my-hotspots}
+                              {:my-hotspots
+                               {:type :criterium/allocation-hotspots
+                                :hotspots [{:call-site {:call-class "x"
+                                                        :call-method "y"
+                                                        :call-file "z"
+                                                        :call-line 1}
+                                            :count 1
+                                            :bytes 10
+                                            :freed-count 0
+                                            :freed-bytes 0}]}}))]
+        (is (= [:b "Allocation Hotspots"] title))))
+
+    (testing "handles empty hotspots gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-hotspots* :portal {} {:allocation-hotspots
+                                                 {:type :criterium/allocation-hotspots
+                                                  :hotspots []}})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))
+
+    (testing "handles nil hotspots-map gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-hotspots* :portal {} {:allocation-hotspots nil})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))
+
+(deftest portal-allocation-by-type-test
+  ;; Tests the portal viewer output for allocation-by-type results.
+  ;; Verifies table generation with type names and allocation stats,
+  ;; sorted by bytes descending.
+  (testing "allocation-by-type*"
+    (testing "produces table sorted by bytes descending"
+      (let [[title table] (with-tap-out
+                            (view/allocation-by-type*
+                             :portal
+                             {}
+                             {:allocation-by-type
+                              {:type :criterium/allocation-by-type
+                               :by-type {"[B" {:count 10 :bytes 1000
+                                               :freed-count 5 :freed-bytes 500}
+                                         "Ljava/lang/String;" {:count 50
+                                                               :bytes 4800
+                                                               :freed-count 30
+                                                               :freed-bytes 2880}
+                                         "[Ljava/lang/Object;" {:count 5
+                                                                :bytes 200
+                                                                :freed-count 2
+                                                                :freed-bytes 80}}}}))
+            types (mapv :type table)]
+        (is (= [:b "Allocations by Type"] title))
+        (is (= 3 (count table)) "Expected 3 rows")
+        (is (= ["Ljava/lang/String;" "[B" "[Ljava/lang/Object;"] types)
+            "Expected sorted by bytes descending")
+        (let [first-row (first table)]
+          (is (= "Ljava/lang/String;" (:type first-row)))
+          (is (= 50 (:count first-row)))
+          (is (= 4800 (:bytes first-row)))
+          (is (= 30 (:freed-count first-row)))
+          (is (= 2880 (:freed-bytes first-row))))))
+
+    (testing "uses custom by-type-id"
+      (let [[title _table] (with-tap-out
+                             (view/allocation-by-type*
+                              :portal
+                              {:by-type-id :my-by-type}
+                              {:my-by-type
+                               {:type :criterium/allocation-by-type
+                                :by-type {"[I" {:count 1 :bytes 10
+                                                :freed-count 0 :freed-bytes 0}}}}))]
+        (is (= [:b "Allocations by Type"] title))))
+
+    (testing "handles empty by-type gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-by-type* :portal {} {:allocation-by-type
+                                                {:type :criterium/allocation-by-type
+                                                 :by-type {}}})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))
+
+    (testing "handles nil by-type-map gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-by-type* :portal {} {:allocation-by-type nil})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -694,3 +694,68 @@
           (is (empty? @v))
           (finally
             (remove-tap f)))))))
+
+(deftest portal-allocation-treemap-test
+  ;; Tests the portal viewer output for allocation-treemap results.
+  ;; Verifies Vega spec generation with treemap visualization.
+  (testing "allocation-treemap*"
+    (testing "produces vega output with treemap spec"
+      (let [[title vega-spec] (with-tap-out
+                                (view/allocation-treemap*
+                                 :portal
+                                 {}
+                                 {:allocation-treemap
+                                  {:type :criterium/allocation-treemap
+                                   :size-by :bytes
+                                   :root {:name "root"
+                                          :value 1000
+                                          :children [{:name "java.lang.String"
+                                                      :value 600
+                                                      :children [{:name "L42"
+                                                                  :value 600}]}
+                                                     {:name "[B"
+                                                      :value 400
+                                                      :children [{:name "L10"
+                                                                  :value 400}]}]}}}))
+            viewer-meta (meta vega-spec)]
+        (is (= [:b "Allocation Treemap"] title))
+        (is (= :portal.viewer/vega (:portal.viewer/default viewer-meta)))
+        (is (str/includes? (:$schema vega-spec) "vega/v5.json"))
+        (is (contains? vega-spec :data))
+        (is (contains? vega-spec :marks))))
+
+    (testing "uses custom treemap-id"
+      (let [[title _spec] (with-tap-out
+                            (view/allocation-treemap*
+                             :portal
+                             {:treemap-id :my-treemap}
+                             {:my-treemap
+                              {:type :criterium/allocation-treemap
+                               :root {:name "root"
+                                      :value 100
+                                      :children [{:name "type1" :value 100}]}}}))]
+        (is (= [:b "Allocation Treemap"] title))))
+
+    (testing "handles nil treemap data gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-treemap* :portal {} {:allocation-treemap nil})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))
+
+    (testing "handles missing root gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/allocation-treemap* :portal {}
+                                    {:allocation-treemap
+                                     {:type :criterium/allocation-treemap}})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -356,14 +356,14 @@
                              :portal
                              {}
                              {:comparison
-                              {:type    :criterium/domain-comparison
-                               :axis    :impl
+                              {:type :criterium/domain-comparison
+                               :axis :impl
                                :metrics {:elapsed-time
                                          {:metric [:stats :elapsed-time :mean]
-                                          :data   {:foo [{:coord {:impl :foo :n 100}
-                                                          :value 1e-7}]
-                                                   :bar [{:coord {:impl :bar :n 100}
-                                                          :value 2e-7}]}}}}}))]
+                                          :data {:foo [{:coord {:impl :foo :n 100}
+                                                        :value 1e-7}]
+                                                 :bar [{:coord {:impl :bar :n 100}
+                                                        :value 2e-7}]}}}}}))]
         (is (string? (second title)))
         (is (str/includes? (second title) "Domain Comparison"))
         (is (= 1 (count table)) "Expected 1 row for single n value")
@@ -376,24 +376,24 @@
                              :portal
                              {}
                              {:comparison
-                              {:type            :criterium/domain-comparison
-                               :axis            :impl
-                               :metrics         {:elapsed-time
-                                                 {:metric [:stats :elapsed-time :mean]
-                                                  :data   {:foo [{:coord {:impl :foo :n 100}
-                                                                  :value 1e-7}
-                                                                 {:coord {:impl :foo :n 200}
-                                                                  :value 2e-7}]
-                                                           :bar [{:coord {:impl :bar :n 100}
-                                                                  :value 2e-7}
-                                                                 {:coord {:impl :bar :n 200}
-                                                                  :value 4e-7}]}}}
+                              {:type :criterium/domain-comparison
+                               :axis :impl
+                               :metrics {:elapsed-time
+                                         {:metric [:stats :elapsed-time :mean]
+                                          :data {:foo [{:coord {:impl :foo :n 100}
+                                                        :value 1e-7}
+                                                       {:coord {:impl :foo :n 200}
+                                                        :value 2e-7}]
+                                                 :bar [{:coord {:impl :bar :n 100}
+                                                        :value 2e-7}
+                                                       {:coord {:impl :bar :n 200}
+                                                        :value 4e-7}]}}}
                                :implementations [:foo :bar]}}))]
         (is (str/includes? (second title) "Domain Comparison"))
         (is (= 2 (count table)) "Expected 2 rows")
         ;; Check that baseline impl has absolute values and factor impl has ×
         (let [first-row (first table)
-              col-keys  (set (map str (keys first-row)))]
+              col-keys (set (map str (keys first-row)))]
           (is (some #(str/includes? % "foo") col-keys)
               "Expected foo column")
           (is (some #(and (str/includes? % "bar")
@@ -422,29 +422,29 @@
                       (view/domain-regression*
                        :portal
                        {}
-                       {:extract    {:type    :criterium/domain-extract
-                                     :metrics {:elapsed-time
-                                               {:metric [:stats :elapsed-time :mean]
-                                                :data   [[{:n 100} 1e6]
-                                                         [{:n 200} 2e6]
-                                                         [{:n 400} 4e6]
-                                                         [{:n 800} 8e6]]}}}
-                        :regression {:type        :criterium/domain-regression
-                                     :axis        :n
+                       {:extract {:type :criterium/domain-extract
+                                  :metrics {:elapsed-time
+                                            {:metric [:stats :elapsed-time :mean]
+                                             :data [[{:n 100} 1e6]
+                                                    [{:n 200} 2e6]
+                                                    [{:n 400} 4e6]
+                                                    [{:n 800} 8e6]]}}}
+                        :regression {:type :criterium/domain-regression
+                                     :axis :n
                                      :regressions {:elapsed-time
-                                                   {:metric   [:stats :elapsed-time :mean]
-                                                    :models   [{:id           :linear
-                                                                :label        "O(n)"
-                                                                :coefficients {:a 10000.0 :b 0.0}
-                                                                :equation-str "y = 10000*n + 0"
-                                                                :predict-fn   (fn [x] (* 10000.0 x))
-                                                                :r-squared    0.9999}
-                                                               {:id           :quadratic
-                                                                :label        "O(n²)"
-                                                                :coefficients {:a 0.1 :b 100000.0}
-                                                                :equation-str "y = 0.1*n² + 100000"
-                                                                :predict-fn   (fn [x] (+ (* 0.1 x x) 100000.0))
-                                                                :r-squared    0.85}]
+                                                   {:metric [:stats :elapsed-time :mean]
+                                                    :models [{:id :linear
+                                                              :label "O(n)"
+                                                              :coefficients {:a 10000.0 :b 0.0}
+                                                              :equation-str "y = 10000*n + 0"
+                                                              :predict-fn (fn [x] (* 10000.0 x))
+                                                              :r-squared 0.9999}
+                                                             {:id :quadratic
+                                                              :label "O(n²)"
+                                                              :coefficients {:a 0.1 :b 100000.0}
+                                                              :equation-str "y = 0.1*n² + 100000"
+                                                              :predict-fn (fn [x] (+ (* 0.1 x x) 100000.0))
+                                                              :r-squared 0.85}]
                                                     :best-fit :linear}}}}))]
         (is (>= (count outputs) 2) "Expected at least heading and table")
         (let [[heading table] outputs]
@@ -460,22 +460,22 @@
                       (view/domain-regression*
                        :portal
                        {}
-                       {:extract    {:type    :criterium/domain-extract
-                                     :metrics {:elapsed-time
-                                               {:metric [:stats :elapsed-time :mean]
-                                                :data   [[{:n 100} 1e6]
-                                                         [{:n 200} 2e6]
-                                                         [{:n 400} 4e6]]}}}
-                        :regression {:type        :criterium/domain-regression
-                                     :axis        :n
+                       {:extract {:type :criterium/domain-extract
+                                  :metrics {:elapsed-time
+                                            {:metric [:stats :elapsed-time :mean]
+                                             :data [[{:n 100} 1e6]
+                                                    [{:n 200} 2e6]
+                                                    [{:n 400} 4e6]]}}}
+                        :regression {:type :criterium/domain-regression
+                                     :axis :n
                                      :regressions {:elapsed-time
-                                                   {:metric   [:stats :elapsed-time :mean]
-                                                    :models   [{:id           :linear
-                                                                :label        "O(n)"
-                                                                :coefficients {:a 10000.0 :b 0.0}
-                                                                :equation-str "y = 10000*n + 0"
-                                                                :predict-fn   (fn [x] (* 10000.0 x))
-                                                                :r-squared    0.9999}]
+                                                   {:metric [:stats :elapsed-time :mean]
+                                                    :models [{:id :linear
+                                                              :label "O(n)"
+                                                              :coefficients {:a 10000.0 :b 0.0}
+                                                              :equation-str "y = 10000*n + 0"
+                                                              :predict-fn (fn [x] (* 10000.0 x))
+                                                              :r-squared 0.9999}]
                                                     :best-fit :linear}}}}))]
         ;; Should have heading, table, chart, residual heading, residual chart
         (is (>= (count outputs) 4) "Expected heading, table, chart, residual outputs")
@@ -546,9 +546,9 @@
 
 (deftest portal-allocation-hotspots-test
   ;; Tests the portal viewer output for allocation-hotspots results.
-  ;; Verifies table generation with call-site and allocation stats.
+  ;; Verifies table generation with call-site, object-type, and allocation stats.
   (testing "allocation-hotspots*"
-    (testing "produces table with hotspot data"
+    (testing "produces table with hotspot data including object-type"
       (let [[title table] (with-tap-out
                             (view/allocation-hotspots*
                              :portal
@@ -559,6 +559,7 @@
                                                        :call-method "invoke"
                                                        :call-file "my_ns.clj"
                                                        :call-line 42}
+                                           :object-type "Ljava/lang/String;"
                                            :count 50
                                            :bytes 4800
                                            :freed-count 30
@@ -567,6 +568,7 @@
                                                        :call-method "invoke"
                                                        :call-file "other.clj"
                                                        :call-line 10}
+                                           :object-type "[B"
                                            :count 25
                                            :bytes 2400
                                            :freed-count 10
@@ -576,6 +578,7 @@
         (is (= 2 (count table)) "Expected 2 rows")
         (is (str/includes? (:call-site first-row) "my.ns$fn"))
         (is (str/includes? (:call-site first-row) "my_ns.clj:42"))
+        (is (= "Ljava/lang/String;" (:object-type first-row)))
         (is (= 50 (:count first-row)))
         (is (= 4800 (:bytes first-row)))
         (is (= 30 (:freed-count first-row)))
@@ -592,6 +595,7 @@
                                                         :call-method "y"
                                                         :call-file "z"
                                                         :call-line 1}
+                                            :object-type "Ljava/lang/Object;"
                                             :count 1
                                             :bytes 10
                                             :freed-count 0

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -510,7 +510,8 @@
                                :total-allocated 1024000
                                :total-freed 512000
                                :num-allocations 100
-                               :num-freed 50}}))]
+                               :num-freed 50
+                               :freed-ratio 0.5}}))]
         (is (= [:b "Allocation Summary"] title))
         (is (= 6 (count table)) "Expected 6 rows")
         (is (= "Total allocated" (:metric (first table))))
@@ -530,7 +531,8 @@
                                 :total-allocated 1000
                                 :total-freed 500
                                 :num-allocations 10
-                                :num-freed 5}}))]
+                                :num-freed 5
+                                :freed-ratio 0.5}}))]
         (is (= [:b "Allocation Summary"] title))))
 
     (testing "handles nil summary gracefully"

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -1,5 +1,6 @@
 (ns criterium.viewer.pprint-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
    [criterium.test-data :as test-data]
@@ -349,4 +350,66 @@
                                   :models []
                                   :best-fit nil}}}}))))))))
 
+(deftest allocation-treemap-pprint-test
+  ;; Tests the pprint viewer output for allocation-treemap results.
+  ;; Verifies that ASCII treemap is rendered (same as print viewer).
+  (testing "allocation-treemap*"
+    (testing "prints ASCII tree structure with header"
+      (let [treemap-data {:type :criterium/allocation-treemap
+                          :group-by :class→line→type
+                          :size-by :bytes
+                          :root {:name "allocations"
+                                 :value 1024
+                                 :children [{:name "MyClass"
+                                             :value 1024
+                                             :children [{:name "L42"
+                                                         :value 1024
+                                                         :children [{:name "String"
+                                                                     :value 1024}]}]}]}}
+            output (with-out-str
+                     (view/allocation-treemap*
+                      :pprint
+                      {}
+                      {:allocation-treemap treemap-data}))
+            lines (str/split-lines output)]
+        (is (str/includes? (first (drop-while str/blank? lines))
+                           "Allocation Treemap"))
+        (is (str/includes? output "class→line→type"))
+        (is (str/includes? output "bytes"))
+        (is (str/includes? output "allocations/"))
+        (is (str/includes? output "MyClass/"))
+        (is (str/includes? output "L42/"))
+        (is (str/includes? output "String"))))
 
+    (testing "handles missing treemap data"
+      (let [output (with-out-str
+                     (view/allocation-treemap*
+                      :pprint
+                      {}
+                      {}))]
+        (is (str/blank? output))))
+
+    (testing "handles nil root"
+      (let [output (with-out-str
+                     (view/allocation-treemap*
+                      :pprint
+                      {}
+                      {:allocation-treemap {:type :criterium/allocation-treemap
+                                            :root nil}}))]
+        (is (str/blank? output))))
+
+    (testing "uses custom treemap-id"
+      (let [treemap-data {:type :criterium/allocation-treemap
+                          :group-by :type→class→line
+                          :size-by :count
+                          :root {:name "allocations"
+                                 :value 100
+                                 :children [{:name "Object" :value 100}]}}
+            output (with-out-str
+                     (view/allocation-treemap*
+                      :pprint
+                      {:treemap-id :my-treemap}
+                      {:my-treemap treemap-data}))]
+        (is (str/includes? output "type→class→line"))
+        (is (str/includes? output "count"))
+        (is (str/includes? output "Object"))))))

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -693,7 +693,8 @@
                    :total-allocated 1024
                    :total-freed 512
                    :num-allocations 100
-                   :num-freed 50}}))))))
+                   :num-freed 50
+                   :freed-ratio 0.5}}))))))
     (testing "handles zero allocations"
       (is (= [""
               "Allocation Summary:"
@@ -701,7 +702,8 @@
               "Total freed:            0 bytes"
               "Retained:            0 bytes"
               "Allocation count:            0"
-              "Freed count:            0"]
+              "Freed count:            0"
+              "Freed ratio:          0.0%"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-summary*
@@ -712,7 +714,8 @@
                    :total-allocated 0
                    :total-freed 0
                    :num-allocations 0
-                   :num-freed 0}}))))))
+                   :num-freed 0
+                   :freed-ratio 0.0}}))))))
     (testing "uses custom summary-id"
       (is (= [""
               "Allocation Summary:"
@@ -732,7 +735,8 @@
                    :total-allocated 256
                    :total-freed 128
                    :num-allocations 10
-                   :num-freed 5}}))))))))
+                   :num-freed 5
+                   :freed-ratio 0.5}}))))))))
 
 (deftest allocation-hotspots-print-test
   ;; Tests the print viewer output for allocation-hotspots results.

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -668,5 +668,179 @@
                                             :r-squared 0.95}]
                                   :best-fit :linear}}}}))))))))
 
+;;; Allocation View Tests
 
+(deftest allocation-summary-print-test
+  ;; Tests the print viewer output for allocation-summary results.
+  ;; Verifies display of totals, counts, and freed ratio.
+  (testing "allocation-summary*"
+    (testing "prints summary statistics"
+      (is (= ["Allocation Summary:"
+              "Total allocated: 1.00 Kb"
+              "Total freed: 512 bytes"
+              "Retained: 512 bytes"
+              "Allocation count: 100"
+              "Freed count: 50"
+              "Freed ratio: 50.0%"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-summary*
+                 :print
+                 {}
+                 {:allocation-summary
+                  {:type :criterium/allocation-summary
+                   :total-allocated 1024
+                   :total-freed 512
+                   :num-allocations 100
+                   :num-freed 50}}))))))
+    (testing "handles zero allocations"
+      (is (= ["Allocation Summary:"
+              "Total allocated: 0.00 bytes"
+              "Total freed: 0.00 bytes"
+              "Retained: 0.00 bytes"
+              "Allocation count: 0"
+              "Freed count: 0"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-summary*
+                 :print
+                 {}
+                 {:allocation-summary
+                  {:type :criterium/allocation-summary
+                   :total-allocated 0
+                   :total-freed 0
+                   :num-allocations 0
+                   :num-freed 0}}))))))
+    (testing "uses custom summary-id"
+      (is (= ["Allocation Summary:"
+              "Total allocated: 256 bytes"
+              "Total freed: 128 bytes"
+              "Retained: 128 bytes"
+              "Allocation count: 10"
+              "Freed count: 5"
+              "Freed ratio: 50.0%"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-summary*
+                 :print
+                 {:summary-id :my-summary}
+                 {:my-summary
+                  {:type :criterium/allocation-summary
+                   :total-allocated 256
+                   :total-freed 128
+                   :num-allocations 10
+                   :num-freed 5}}))))))))
 
+(deftest allocation-hotspots-print-test
+  ;; Tests the print viewer output for allocation-hotspots results.
+  ;; Verifies table format with call site, counts, and byte amounts.
+  (testing "allocation-hotspots*"
+    (testing "prints hotspots table"
+      (is (= ["Allocation Hotspots:"
+              "Count        Bytes    Freed  Freed Bytes  Call Site"
+              (apply str (repeat 80 "-"))
+              "100      1.00 Kb       50    512 bytes  my.ns$fn.invoke (my_ns.clj:42)"
+              "50    256 bytes       25    128 bytes  other.ns$g.apply (other.clj:10)"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-hotspots*
+                 :print
+                 {}
+                 {:allocation-hotspots
+                  {:type :criterium/allocation-hotspots
+                   :hotspots [{:call-site {:call-class "my.ns$fn"
+                                           :call-method "invoke"
+                                           :call-file "my_ns.clj"
+                                           :call-line 42}
+                               :count 100
+                               :bytes 1024
+                               :freed-count 50
+                               :freed-bytes 512}
+                              {:call-site {:call-class "other.ns$g"
+                                           :call-method "apply"
+                                           :call-file "other.clj"
+                                           :call-line 10}
+                               :count 50
+                               :bytes 256
+                               :freed-count 25
+                               :freed-bytes 128}]}}))))))
+    (testing "handles empty hotspots gracefully"
+      (let [output (with-out-str
+                     (view/allocation-hotspots*
+                      :print
+                      {}
+                      {:allocation-hotspots
+                       {:type :criterium/allocation-hotspots
+                        :hotspots []}}))]
+        (is (str/blank? output))))
+    (testing "uses custom hotspots-id"
+      (is (= ["Allocation Hotspots:"
+              "Count        Bytes    Freed  Freed Bytes  Call Site"
+              (apply str (repeat 80 "-"))
+              "10    100 bytes        5   50.0 bytes  x.y$z.run (z.clj:1)"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-hotspots*
+                 :print
+                 {:hotspots-id :my-hotspots}
+                 {:my-hotspots
+                  {:type :criterium/allocation-hotspots
+                   :hotspots [{:call-site {:call-class "x.y$z"
+                                           :call-method "run"
+                                           :call-file "z.clj"
+                                           :call-line 1}
+                               :count 10
+                               :bytes 100
+                               :freed-count 5
+                               :freed-bytes 50}]}}))))))))
+
+(deftest allocation-by-type-print-test
+  ;; Tests the print viewer output for allocation-by-type results.
+  ;; Verifies table format sorted by bytes descending.
+  (testing "allocation-by-type*"
+    (testing "prints by-type table sorted by bytes"
+      (is (= ["Allocations by Type:"
+              "Count        Bytes    Freed  Freed Bytes  Type"
+              (apply str (repeat 80 "-"))
+              "100      1.00 Kb       50    512 bytes  [B"
+              "50    256 bytes       25    128 bytes  Ljava/lang/String;"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-by-type*
+                 :print
+                 {}
+                 {:allocation-by-type
+                  {:type :criterium/allocation-by-type
+                   :by-type {"Ljava/lang/String;" {:count 50
+                                                   :bytes 256
+                                                   :freed-count 25
+                                                   :freed-bytes 128}
+                             "[B" {:count 100
+                                   :bytes 1024
+                                   :freed-count 50
+                                   :freed-bytes 512}}}}))))))
+    (testing "handles empty by-type gracefully"
+      (let [output (with-out-str
+                     (view/allocation-by-type*
+                      :print
+                      {}
+                      {:allocation-by-type
+                       {:type :criterium/allocation-by-type
+                        :by-type {}}}))]
+        (is (str/blank? output))))
+    (testing "uses custom by-type-id"
+      (is (= ["Allocations by Type:"
+              "Count        Bytes    Freed  Freed Bytes  Type"
+              (apply str (repeat 80 "-"))
+              "10    100 bytes        5   50.0 bytes  Ljava/lang/Object;"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-by-type*
+                 :print
+                 {:by-type-id :my-by-type}
+                 {:my-by-type
+                  {:type :criterium/allocation-by-type
+                   :by-type {"Ljava/lang/Object;" {:count 10
+                                                   :bytes 100
+                                                   :freed-count 5
+                                                   :freed-bytes 50}}}}))))))))

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -878,3 +878,67 @@
                                                    :bytes 100
                                                    :freed-count 5
                                                    :freed-bytes 50}}}}))))))))
+
+(deftest allocation-treemap-print-test
+  ;; Tests the print viewer output for allocation-treemap results.
+  ;; Verifies that ASCII treemap is rendered with proper structure.
+  (testing "allocation-treemap*"
+    (testing "prints ASCII tree structure with header"
+      (let [treemap-data {:type :criterium/allocation-treemap
+                          :group-by :class→line→type
+                          :size-by :bytes
+                          :root {:name "allocations"
+                                 :value 1024
+                                 :children [{:name "MyClass"
+                                             :value 1024
+                                             :children [{:name "L42"
+                                                         :value 1024
+                                                         :children [{:name "String"
+                                                                     :value 1024}]}]}]}}
+            output (with-out-str
+                     (view/allocation-treemap*
+                      :print
+                      {}
+                      {:allocation-treemap treemap-data}))
+            lines (str/split-lines output)]
+        (is (str/includes? (first (drop-while str/blank? lines))
+                           "Allocation Treemap"))
+        (is (str/includes? output "class→line→type"))
+        (is (str/includes? output "bytes"))
+        (is (str/includes? output "allocations/"))
+        (is (str/includes? output "MyClass/"))
+        (is (str/includes? output "L42/"))
+        (is (str/includes? output "String"))))
+
+    (testing "handles missing treemap data"
+      (let [output (with-out-str
+                     (view/allocation-treemap*
+                      :print
+                      {}
+                      {}))]
+        (is (str/blank? output))))
+
+    (testing "handles nil root"
+      (let [output (with-out-str
+                     (view/allocation-treemap*
+                      :print
+                      {}
+                      {:allocation-treemap {:type :criterium/allocation-treemap
+                                            :root nil}}))]
+        (is (str/blank? output))))
+
+    (testing "uses custom treemap-id"
+      (let [treemap-data {:type :criterium/allocation-treemap
+                          :group-by :type→class→line
+                          :size-by :count
+                          :root {:name "allocations"
+                                 :value 100
+                                 :children [{:name "Object" :value 100}]}}
+            output (with-out-str
+                     (view/allocation-treemap*
+                      :print
+                      {:treemap-id :my-treemap}
+                      {:my-treemap treemap-data}))]
+        (is (str/includes? output "type→class→line"))
+        (is (str/includes? output "count"))
+        (is (str/includes? output "Object"))))))

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -508,7 +508,7 @@
              {:type :criterium/domain-comparison
               :axis :impl
               :metric [:stats :elapsed-time :mean]
-              :implementations [:default]  ; Mismatched - doesn't exist in data
+              :implementations [:default] ; Mismatched - doesn't exist in data
               :data {:foo [{:coord {:impl :foo :n 100} :value 100}]
                      :bar [{:coord {:impl :bar :n 100} :value 200}]}}}))))))
 
@@ -672,16 +672,17 @@
 
 (deftest allocation-summary-print-test
   ;; Tests the print viewer output for allocation-summary results.
-  ;; Verifies display of totals, counts, and freed ratio.
+  ;; Verifies display of totals, counts, and freed ratio (based on bytes).
   (testing "allocation-summary*"
-    (testing "prints summary statistics"
-      (is (= ["Allocation Summary:"
-              "Total allocated: 1.00 Kb"
-              "Total freed: 512 bytes"
-              "Retained: 512 bytes"
-              "Allocation count: 100"
-              "Freed count: 50"
-              "Freed ratio: 50.0%"]
+    (testing "prints summary statistics with right-justified numbers"
+      (is (= [""
+              "Allocation Summary:"
+              "Total allocated:         1024 bytes"
+              "Total freed:          512 bytes"
+              "Retained:          512 bytes"
+              "Allocation count:          100"
+              "Freed count:           50"
+              "Freed ratio:         50.0%"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-summary*
@@ -694,12 +695,13 @@
                    :num-allocations 100
                    :num-freed 50}}))))))
     (testing "handles zero allocations"
-      (is (= ["Allocation Summary:"
-              "Total allocated: 0.00 bytes"
-              "Total freed: 0.00 bytes"
-              "Retained: 0.00 bytes"
-              "Allocation count: 0"
-              "Freed count: 0"]
+      (is (= [""
+              "Allocation Summary:"
+              "Total allocated:            0 bytes"
+              "Total freed:            0 bytes"
+              "Retained:            0 bytes"
+              "Allocation count:            0"
+              "Freed count:            0"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-summary*
@@ -712,13 +714,14 @@
                    :num-allocations 0
                    :num-freed 0}}))))))
     (testing "uses custom summary-id"
-      (is (= ["Allocation Summary:"
-              "Total allocated: 256 bytes"
-              "Total freed: 128 bytes"
-              "Retained: 128 bytes"
-              "Allocation count: 10"
-              "Freed count: 5"
-              "Freed ratio: 50.0%"]
+      (is (= [""
+              "Allocation Summary:"
+              "Total allocated:          256 bytes"
+              "Total freed:          128 bytes"
+              "Retained:          128 bytes"
+              "Allocation count:           10"
+              "Freed count:            5"
+              "Freed ratio:         50.0%"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-summary*
@@ -733,14 +736,16 @@
 
 (deftest allocation-hotspots-print-test
   ;; Tests the print viewer output for allocation-hotspots results.
-  ;; Verifies table format with call site, counts, and byte amounts.
+  ;; Verifies table format with call site, object type, counts, and byte amounts.
+  ;; Object type is truncated from the start to fit the 30-char column.
   (testing "allocation-hotspots*"
-    (testing "prints hotspots table"
-      (is (= ["Allocation Hotspots:"
-              "Count        Bytes    Freed  Freed Bytes  Call Site"
-              (apply str (repeat 80 "-"))
-              "100      1.00 Kb       50    512 bytes  my.ns$fn.invoke (my_ns.clj:42)"
-              "50    256 bytes       25    128 bytes  other.ns$g.apply (other.clj:10)"]
+    (testing "prints hotspots table with object type"
+      (is (= [""
+              "Allocation Hotspots:"
+              "Count        Bytes    Freed  Freed Bytes  Object Type                     Call Site"
+              (apply str (repeat 110 "-"))
+              "100         1024       50          512  Ljava/lang/String;              my.ns$fn.invoke (my_ns.clj:42)"
+              "50          256       25          128  Ljava/lang/Object;              other.ns$g.apply (other.clj:10)"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-hotspots*
@@ -752,6 +757,7 @@
                                            :call-method "invoke"
                                            :call-file "my_ns.clj"
                                            :call-line 42}
+                               :object-type "Ljava/lang/String;"
                                :count 100
                                :bytes 1024
                                :freed-count 50
@@ -760,10 +766,35 @@
                                            :call-method "apply"
                                            :call-file "other.clj"
                                            :call-line 10}
+                               :object-type "Ljava/lang/Object;"
                                :count 50
                                :bytes 256
                                :freed-count 25
                                :freed-bytes 128}]}}))))))
+    (testing "truncates long object type from the start"
+      ;; "Ljava/util/concurrent/ArrayBlockingQueue;" is 41 chars
+      ;; With 30-char column, keeps last 29 chars + ellipsis
+      (is (= [""
+              "Allocation Hotspots:"
+              "Count        Bytes    Freed  Freed Bytes  Object Type                     Call Site"
+              (apply str (repeat 110 "-"))
+              "10          100        5           50  …oncurrent/ArrayBlockingQueue;  x.y$z.run (z.clj:1)"]
+             (trimmed-lines
+              (with-out-str
+                (view/allocation-hotspots*
+                 :print
+                 {:hotspots-id :my-hotspots}
+                 {:my-hotspots
+                  {:type :criterium/allocation-hotspots
+                   :hotspots [{:call-site {:call-class "x.y$z"
+                                           :call-method "run"
+                                           :call-file "z.clj"
+                                           :call-line 1}
+                               :object-type "Ljava/util/concurrent/ArrayBlockingQueue;"
+                               :count 10
+                               :bytes 100
+                               :freed-count 5
+                               :freed-bytes 50}]}}))))))
     (testing "handles empty hotspots gracefully"
       (let [output (with-out-str
                      (view/allocation-hotspots*
@@ -773,11 +804,12 @@
                        {:type :criterium/allocation-hotspots
                         :hotspots []}}))]
         (is (str/blank? output))))
-    (testing "uses custom hotspots-id"
-      (is (= ["Allocation Hotspots:"
-              "Count        Bytes    Freed  Freed Bytes  Call Site"
-              (apply str (repeat 80 "-"))
-              "10    100 bytes        5   50.0 bytes  x.y$z.run (z.clj:1)"]
+    (testing "handles nil object-type"
+      (is (= [""
+              "Allocation Hotspots:"
+              "Count        Bytes    Freed  Freed Bytes  Object Type                     Call Site"
+              (apply str (repeat 110 "-"))
+              "10          100        5           50                                  x.y$z.run (z.clj:1)"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-hotspots*
@@ -799,11 +831,12 @@
   ;; Verifies table format sorted by bytes descending.
   (testing "allocation-by-type*"
     (testing "prints by-type table sorted by bytes"
-      (is (= ["Allocations by Type:"
+      (is (= [""
+              "Allocations by Type:"
               "Count        Bytes    Freed  Freed Bytes  Type"
               (apply str (repeat 80 "-"))
-              "100      1.00 Kb       50    512 bytes  [B"
-              "50    256 bytes       25    128 bytes  Ljava/lang/String;"]
+              "100         1024       50          512  [B"
+              "50          256       25          128  Ljava/lang/String;"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-by-type*
@@ -829,10 +862,11 @@
                         :by-type {}}}))]
         (is (str/blank? output))))
     (testing "uses custom by-type-id"
-      (is (= ["Allocations by Type:"
+      (is (= [""
+              "Allocations by Type:"
               "Count        Bytes    Freed  Freed Bytes  Type"
               (apply str (repeat 80 "-"))
-              "10    100 bytes        5   50.0 bytes  Ljava/lang/Object;"]
+              "10          100        5           50  Ljava/lang/Object;"]
              (trimmed-lines
               (with-out-str
                 (view/allocation-by-type*

--- a/bases/notebooks/src/criterium/allocation_bench_notebook.clj
+++ b/bases/notebooks/src/criterium/allocation_bench_notebook.clj
@@ -1,4 +1,6 @@
-(ns criterium.allocation-bench-notebook
+(ns
+ ^{:kindly/options {:kinds-that-hide-code #{:kind/hidden}}}
+ criterium.allocation-bench-notebook
   "Benchmarking with integrated allocation analysis."
   (:require
    [clojure.string :as str]
@@ -6,6 +8,9 @@
    [criterium.bench :as bench]
    [criterium.notebook.helpers :refer [bench-display]]
    [scicloj.kindly.v4.kind :as kind]))
+
+(kind/hidden
+ (bench/set-default-viewer! :kindly))
 
 ;; # Allocation Analysis with bench
 ;;
@@ -29,9 +34,7 @@
 ;;
 ;; Add `:with-allocation-trace true` to any bench call:
 
-^:kindly/hide-code
-(bench-display
- (bench/bench (vec (range 100)) :with-allocation-trace true))
+(bench/bench (vec (range 100)) :with-allocation-trace true)
 
 ;; The output now includes three additional sections:
 ;; - **Allocation Summary** - Aggregate allocation statistics
@@ -57,9 +60,7 @@
 ;;
 ;; The hotspots section identifies where allocations originate:
 
-^:kindly/hide-code
-(bench-display
- (bench/bench (mapv str (range 50)) :with-allocation-trace true))
+(bench/bench (mapv str (range 50)) :with-allocation-trace true)
 
 ;; Each hotspot entry shows:
 ;; - **Call Site** - The file, class, method, and line triggering allocation
@@ -74,10 +75,8 @@
 ;;
 ;; The by-type breakdown shows which object types are being created:
 
-^:kindly/hide-code
-(bench-display
- (bench/bench (into {} (map (fn [i] [(keyword (str i)) i]) (range 20)))
-              :with-allocation-trace true))
+(bench/bench (into {} (map (fn [i] [(keyword (str i)) i]) (range 20)))
+             :with-allocation-trace true)
 
 ;; This reveals:
 ;; - Primitive array allocations (e.g., `[J` for long arrays)
@@ -90,48 +89,36 @@
 
 ;; ### String Building Comparison
 
-^:kindly/hide-code
-(kind/md "**Using str with apply:**")
+;; **Using str with apply:**
 
-^:kindly/hide-code
-(bench-display
- (let [words ["the" "quick" "brown" "fox" "jumps"]]
-   (bench/bench (apply str (interpose " " words))
-                :with-allocation-trace true
-                :collect-plan :one-shot)))
+(let [words ["the" "quick" "brown" "fox" "jumps"]]
+  (bench/bench (apply str (interpose " " words))
+               :with-allocation-trace true
+               :collect-plan :one-shot))
 
-^:kindly/hide-code
-(kind/md "**Using clojure.string/join:**")
+;; **Using clojure.string/join:**
 
-^:kindly/hide-code
-(bench-display
- (let [words ["the" "quick" "brown" "fox" "jumps"]]
-   (bench/bench (str/join " " words)
-                :with-allocation-trace true
-                :collect-plan :one-shot)))
+(let [words ["the" "quick" "brown" "fox" "jumps"]]
+  (bench/bench (str/join " " words)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
 
 ;; The `:one-shot` collect plan is useful for quick allocation comparisons
 ;; since allocation patterns are typically consistent across runs.
 
 ;; ### Collection Creation Comparison
 
-^:kindly/hide-code
-(kind/md "**Using vec on range:**")
+;; **Using vec on range:**
 
-^:kindly/hide-code
-(bench-display
- (bench/bench (vec (range 100))
-              :with-allocation-trace true
-              :collect-plan :one-shot))
+(bench/bench (vec (range 100))
+             :with-allocation-trace true
+             :collect-plan :one-shot)
 
-^:kindly/hide-code
-(kind/md "**Using into []:**")
+;; **Using into []:**
 
-^:kindly/hide-code
-(bench-display
- (bench/bench (into [] (range 100))
-              :with-allocation-trace true
-              :collect-plan :one-shot))
+(bench/bench (into [] (range 100))
+             :with-allocation-trace true
+             :collect-plan :one-shot)
 
 ;; ## Graceful Degradation
 ;;
@@ -144,12 +131,12 @@
 ;; This means code using `:with-allocation-trace` works on any system,
 ;; with allocation data appearing only when the agent is available.
 
-^:kindly/hide-code
-(kind/code
- ";; Same code works with or without agent
+;; Same code works with or without agent
+
 (bench/bench (vec (range 100)) :with-allocation-trace true)
+
 ;; Without agent: shows timing only
-;; With agent: shows timing + allocation analysis")
+;; With agent: shows timing + allocation analysis)
 
 ;; ## Using Different Viewers
 ;;
@@ -159,12 +146,12 @@
 ;;
 ;; Shows the raw data structures:
 
-^:kindly/hide-code
 (bench-display
  (bench/bench (vec (range 50))
               :with-allocation-trace true
               :viewer :pprint
-              :collect-plan :one-shot))
+              :collect-plan :one-shot
+              :return-value [:nil]))
 
 ;; ### :kindly Viewer
 ;;
@@ -180,14 +167,16 @@
 ;; Sends allocation tables to Portal for interactive exploration.
 ;; Ensure Portal is connected before using:
 
-(comment
-  (require '[portal.api :as p])
-  (def p (p/open))
-  (add-tap #'p/submit)
+(require '[portal.api :as p])
+(require 'criterium.viewer.portal)
+(def p (p/open))
+(def submit (criterium.viewer.portal/submit #'portal.api/submit))
+(add-tap #'submit)
 
-  (bench/bench (vec (range 100))
-               :with-allocation-trace true
-               :viewer :portal))
+(bench/bench (vec (range 100))
+             :with-allocation-trace true
+             :viewer :portal
+             :return-value [:nil])
 
 ;; ## Accessing Results Programmatically
 ;;
@@ -213,19 +202,25 @@
     {:total-allocated (:total-allocated summary)
      :num-allocations (:num-allocations summary)}))
 
+(kind/hidden
+ (bench/set-default-viewer! :print))
+
 ;; ## Best Practices
 ;;
-;; 1. **Use :one-shot for allocation comparisons** - Allocation patterns are
-;;    consistent, so a single run suffices for comparing implementations.
+;; 1. **Use :one-shot for allocation comparisons**
+;;    Allocation patterns are consistent, so a single run suffices for comparing
+;;    implementations.
 ;;
-;; 2. **Focus on hotspots first** - The top allocation sites usually reveal
-;;    the most impactful optimization opportunities.
+;; 2. **Focus on hotspots first**
+;;    The top allocation sites usually reveal the most impactful optimization
+;;    opportunities.
 ;;
-;; 3. **Watch the freed ratio** - High freed counts indicate temporary objects
-;;    that add GC pressure.
+;; 3. **Watch the freed ratio**
+;;    High freed counts indicate temporary objects that add GC pressure.
 ;;
-;; 4. **Compare similar workloads** - When comparing implementations, use
-;;    identical input sizes for meaningful comparisons.
+;; 4. **Compare similar workloads**
+;;    When comparing implementations, use identical input sizes for meaningful
+;;    comparisons.
 ;;
-;; 5. **Consider memory vs time tradeoffs** - Lower allocations often correlate
-;;    with better performance, but not always.
+;; 5. **Consider memory vs time tradeoffs**
+;;    Lower allocations often correlate with better performance, but not always.

--- a/bases/notebooks/src/criterium/allocation_bench_notebook.clj
+++ b/bases/notebooks/src/criterium/allocation_bench_notebook.clj
@@ -1,0 +1,231 @@
+(ns criterium.allocation-bench-notebook
+  "Benchmarking with integrated allocation analysis."
+  (:require
+   [clojure.string :as str]
+   [criterium.agent :as agent]
+   [criterium.bench :as bench]
+   [criterium.notebook.helpers :refer [bench-display]]
+   [scicloj.kindly.v4.kind :as kind]))
+
+;; # Allocation Analysis with bench
+;;
+;; The `:with-allocation-trace` option integrates allocation tracking directly
+;; into the bench macro. This provides automatic collection, analysis, and
+;; display of allocation data alongside timing metrics.
+
+;; ## Agent Requirements
+;;
+;; Allocation tracing requires the native JVMTI agent. Check availability:
+
+{:agent-attached? (agent/attached?)
+ :agent-loaded?   (agent/loaded?)}
+
+;; If the agent is not attached, add the JVM argument from `agent/jvm-opts`
+;; when starting your REPL. See the
+;; [Allocation Tracking notebook](./criterium.allocation_tracking_notebook.html)
+;; for detailed setup instructions.
+
+;; ## Basic Usage
+;;
+;; Add `:with-allocation-trace true` to any bench call:
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (vec (range 100)) :with-allocation-trace true))
+
+;; The output now includes three additional sections:
+;; - **Allocation Summary** - Aggregate allocation statistics
+;; - **Allocation Hotspots** - Top allocation sites by bytes/count
+;; - **Allocations by Type** - Breakdown by object type
+
+;; ## Understanding Allocation Summary
+;;
+;; The allocation summary provides aggregate statistics:
+
+^:kindly/hide-code
+(kind/table
+ {:column-names ["Metric" "Description"]
+  :row-vectors  [["Total Allocated" "Total bytes allocated during trace"]
+                 ["Total Freed" "Bytes from objects garbage collected"]
+                 ["Num Allocations" "Total object allocations"]
+                 ["Num Freed" "Objects that were garbage collected"]]})
+
+;; A high "freed" count indicates short-lived temporary objects, which may
+;; signal optimization opportunities.
+
+;; ## Interpreting Hotspots
+;;
+;; The hotspots section identifies where allocations originate:
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (mapv str (range 50)) :with-allocation-trace true))
+
+;; Each hotspot entry shows:
+;; - **Call Site** - The file, class, method, and line triggering allocation
+;; - **Count** - Number of allocations from this site
+;; - **Bytes** - Total bytes allocated
+;; - **Freed Count/Bytes** - How many were garbage collected
+
+;; Hotspots are sorted by bytes allocated, making it easy to identify the
+;; most memory-intensive code paths.
+
+;; ## Analyzing by Type
+;;
+;; The by-type breakdown shows which object types are being created:
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (into {} (map (fn [i] [(keyword (str i)) i]) (range 20)))
+              :with-allocation-trace true))
+
+;; This reveals:
+;; - Primitive array allocations (e.g., `[J` for long arrays)
+;; - Collection overhead (persistent data structure nodes)
+;; - String allocations from conversions
+
+;; ## Comparing Code Variants
+;;
+;; Allocation tracing is valuable for comparing implementation approaches.
+
+;; ### String Building Comparison
+
+^:kindly/hide-code
+(kind/md "**Using str with apply:**")
+
+^:kindly/hide-code
+(bench-display
+ (let [words ["the" "quick" "brown" "fox" "jumps"]]
+   (bench/bench (apply str (interpose " " words))
+                :with-allocation-trace true
+                :collect-plan :one-shot)))
+
+^:kindly/hide-code
+(kind/md "**Using clojure.string/join:**")
+
+^:kindly/hide-code
+(bench-display
+ (let [words ["the" "quick" "brown" "fox" "jumps"]]
+   (bench/bench (str/join " " words)
+                :with-allocation-trace true
+                :collect-plan :one-shot)))
+
+;; The `:one-shot` collect plan is useful for quick allocation comparisons
+;; since allocation patterns are typically consistent across runs.
+
+;; ### Collection Creation Comparison
+
+^:kindly/hide-code
+(kind/md "**Using vec on range:**")
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (vec (range 100))
+              :with-allocation-trace true
+              :collect-plan :one-shot))
+
+^:kindly/hide-code
+(kind/md "**Using into []:**")
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (into [] (range 100))
+              :with-allocation-trace true
+              :collect-plan :one-shot))
+
+;; ## Graceful Degradation
+;;
+;; When the agent is not attached, `:with-allocation-trace` has no effect:
+;; - The benchmark runs normally
+;; - Timing and other metrics are collected as usual
+;; - Allocation sections are simply omitted from output
+;; - No errors are thrown
+
+;; This means code using `:with-allocation-trace` works on any system,
+;; with allocation data appearing only when the agent is available.
+
+^:kindly/hide-code
+(kind/code
+ ";; Same code works with or without agent
+(bench/bench (vec (range 100)) :with-allocation-trace true)
+;; Without agent: shows timing only
+;; With agent: shows timing + allocation analysis")
+
+;; ## Using Different Viewers
+;;
+;; Allocation analysis works with all bench viewers.
+
+;; ### :pprint Viewer
+;;
+;; Shows the raw data structures:
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (vec (range 50))
+              :with-allocation-trace true
+              :viewer :pprint
+              :collect-plan :one-shot))
+
+;; ### :kindly Viewer
+;;
+;; Returns Kindly-annotated tables for Clay rendering:
+
+(bench/bench (vec (range 50))
+             :with-allocation-trace true
+             :viewer :kindly
+             :collect-plan :one-shot)
+
+;; ### :portal Viewer
+;;
+;; Sends allocation tables to Portal for interactive exploration.
+;; Ensure Portal is connected before using:
+
+(comment
+  (require '[portal.api :as p])
+  (def p (p/open))
+  (add-tap #'p/submit)
+
+  (bench/bench (vec (range 100))
+               :with-allocation-trace true
+               :viewer :portal))
+
+;; ## Accessing Results Programmatically
+;;
+;; The allocation data is available in `last-bench` results:
+
+(do
+  (bench/bench (mapv inc (range 100))
+               :with-allocation-trace true
+               :viewer :none)
+  (let [data (:data (bench/last-bench))]
+    {:has-trace?    (contains? data :allocation-trace)
+     :has-summary?  (contains? data :allocation-summary)
+     :has-hotspots? (contains? data :allocation-hotspots)
+     :has-by-type?  (contains? data :allocation-by-type)}))
+
+;; Access specific analysis results:
+
+(do
+  (bench/bench (vec (range 100))
+               :with-allocation-trace true
+               :viewer :none)
+  (when-let [summary (get-in (bench/last-bench) [:data :allocation-summary])]
+    {:total-allocated (:total-allocated summary)
+     :num-allocations (:num-allocations summary)}))
+
+;; ## Best Practices
+;;
+;; 1. **Use :one-shot for allocation comparisons** - Allocation patterns are
+;;    consistent, so a single run suffices for comparing implementations.
+;;
+;; 2. **Focus on hotspots first** - The top allocation sites usually reveal
+;;    the most impactful optimization opportunities.
+;;
+;; 3. **Watch the freed ratio** - High freed counts indicate temporary objects
+;;    that add GC pressure.
+;;
+;; 4. **Compare similar workloads** - When comparing implementations, use
+;;    identical input sizes for meaningful comparisons.
+;;
+;; 5. **Consider memory vs time tradeoffs** - Lower allocations often correlate
+;;    with better performance, but not always.

--- a/bases/notebooks/src/criterium/index.clj
+++ b/bases/notebooks/src/criterium/index.clj
@@ -21,6 +21,7 @@
 ;; - [Sampled Functions](./criterium.sampled_fn_notebook.html) - Memory-efficient function sampling with t-digest aggregation
 ;; - [Instrumented Functions](./criterium.instrument_fn_notebook.html) - Instrument functions for continuous performance sampling
 ;; - [Allocation Tracking](./criterium.allocation_tracking_notebook.html) - Memory allocation analysis with the native agent
+;; - [Allocation Bench](./criterium.allocation_bench_notebook.html) - Benchmarking with integrated allocation analysis
 ;; - [Domain Bench](./criterium.domain_bench_notebook.html) - Simplified domain benchmarking with domain/bench
 ;; - [Domain Analysis](./criterium.analyse_domain_notebook.html) - Manual domain construction and analysis
 ;; - [Domain Builder](./criterium.domain_builder_notebook.html) - Automated domain construction and workflows

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
     poly/notebooks {:local/root "bases/notebooks"}
     lambdaisland/kaocha {:mvn/version "1.87.1366"}
     lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
-    org.clojure/clojure {:mvn/version "1.12.0"}}
+    org.clojure/clojure {:mvn/version "1.12.4"}}
    :jvm-opts ["-Djdk.attach.allowAttachSelf"]}
   :test {:extra-paths ["bases/criterium/test"
                        "bases/blackhole/test"


### PR DESCRIPTION
## Summary

Integrates allocation tracing into criterium using a separate processing pipeline that feeds into the shared view infrastructure.

### Key Changes:
- **Data model**: New `:criterium/allocation-trace` type with predicates in `criterium.types`
- **Collection**: `criterium.allocation` namespace with `with-allocation-trace` macro wrapping the native agent
- **Analysis**: `criterium.allocation.analysis` with summary, hotspots, by-type, and treemap functions
- **Views**: Print, pprint, Portal, and Kindly viewers for all allocation analysis types
- **Integration**: `:with-allocation-trace` option in `bench/bench` macro

### Features:
- Allocation summary with total/freed bytes, counts, and freed ratio
- Hotspot detection grouped by (call-site, object-type) pairs
- Hierarchical treemap visualization (Vega for Portal/Kindly, ASCII for print/pprint)
- Graceful degradation when native agent not attached

### Design:
- Separate namespace tree (`criterium.allocation.*`) for clean separation from metrics pipeline
- Optional collection via `:with-allocation-trace` flag
- Thread filtering defaults to benchmarked thread
- Integrates with standard analysis pipeline (analysis functions no-op when trace absent)

## Test plan
- [x] Unit tests for allocation predicates, analysis functions, and viewers
- [x] Integration testing with bench macro
- [x] Notebook demonstrating usage patterns