### PR TITLE
test(ziggurat): add autocorrelation tests and extract statistical helpers

### DIFF
--- a/bases/criterium/test/criterium/test_utils.clj
+++ b/bases/criterium/test/criterium/test_utils.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
-   [clojure.test.check.generators :as gen]))
+   [clojure.test.check.generators :as gen]
+   [criterium.util.stats :as stats]))
 
 (defn abs-error
   ^double [^double expected ^double actual]
@@ -178,3 +179,75 @@
     (is (approx= 1.0 (plus-frac 1.0 0.1)))
     (is (approx= [1.0] [(plus-frac 1.0 0.1)]))
     (is (approx= [1.0] [(plus-frac 1.0 1e-9)]))))
+
+;;; Statistical test helpers
+
+(defn autocorrelation
+  "Compute sample autocorrelation at a given lag.
+
+  Returns the correlation coefficient between x[i] and x[i+lag] for
+  i = 0 to n-lag-1. Result is in [-1, 1] where 0 indicates no
+  correlation.
+
+  Requires lag < (count samples)."
+  ^double [samples ^long lag]
+  (assert (< lag (count samples)) "lag must be less than sample count")
+  (let [samples  (double-array samples)
+        n        (long (alength samples))
+        sum-all  (double (areduce samples i sum 0.0 (+ sum (aget samples i))))
+        mean     (/ sum-all (double n))
+        ;; Compute variance (denominator)
+        var     (double
+                 (areduce samples i sum 0.0
+                          (let [d (- (aget samples i) mean)]
+                            (+ sum (* d d)))))
+        ;; Compute covariance at lag (numerator)
+        limit   (- n lag)
+        cov     (double
+                 (loop [i   (long 0)
+                        sum 0.0]
+                   (if (< i limit)
+                     (recur (inc i)
+                            (+ sum (* (- (aget samples i) mean)
+                                      (- (aget samples (+ i lag)) mean))))
+                     sum)))]
+    (if (zero? var)
+      0.0
+      (/ cov var))))
+
+(defn variance-ratio
+  "Compute the ratio of observed batch-sum variance to expected variance.
+
+  For independent samples, batch sums have variance n*σ² where σ² is
+  the individual sample variance. Returns observed/expected ratio.
+  A ratio of 1.0 indicates independent samples; higher values suggest
+  positive autocorrelation.
+
+  Parameters:
+    samples - vector of samples
+    batch-size - number of samples per batch
+    expected-individual-variance - expected variance of individual samples (default 1.0)
+
+  Expects samples to be a vector."
+  (^double [samples ^long batch-size]
+   (variance-ratio samples batch-size 1.0))
+  (^double [samples ^long batch-size ^double expected-individual-variance]
+   (let [n            (count samples)
+         num-batches  (quot n batch-size)
+         batches      (mapv (fn [^long i]
+                              (subvec samples (* i batch-size) (* (inc i) batch-size)))
+                            (range num-batches))
+         batch-sums   (mapv #(reduce + %) batches)
+         ;; Expected variance for sum of batch-size independent samples
+         ;; Var(sum) = batch-size * expected-individual-variance
+         expected-var (* batch-size expected-individual-variance)
+         observed-var (stats/variance batch-sums)]
+     (/ observed-var expected-var))))
+
+(defn variance-ratio-uniform
+  "Compute variance ratio for uniform [0,1) samples.
+
+  Convenience function that calls variance-ratio with
+  expected-individual-variance of 1/12 (the variance of U(0,1))."
+  ^double [samples ^long batch-size]
+  (variance-ratio samples batch-size (/ 1.0 12)))

--- a/bases/criterium/test/criterium/test_utils.clj
+++ b/bases/criterium/test/criterium/test_utils.clj
@@ -251,3 +251,26 @@
   expected-individual-variance of 1/12 (the variance of U(0,1))."
   ^double [samples ^long batch-size]
   (variance-ratio samples batch-size (/ 1.0 12)))
+
+;;; Xoshiro RNG helpers (JDK 17+)
+
+(defn xoshiro-available?
+  "Check if Xoshiro256PlusPlus is available (JDK 17+)."
+  []
+  (try
+    (Class/forName "java.util.random.RandomGeneratorFactory")
+    true
+    (catch ClassNotFoundException _ false)))
+
+(defn make-xoshiro-rng
+  "Create a Xoshiro256PlusPlus RNG instance using reflection.
+
+  Returns nil if not available (JDK < 17)."
+  [^long seed]
+  (try
+    (let [factory-class (Class/forName "java.util.random.RandomGeneratorFactory")
+          of-method     (.getMethod factory-class "of" (into-array Class [String]))
+          factory       (.invoke of-method nil (object-array ["Xoshiro256PlusPlus"]))
+          create-method (.getMethod (class factory) "create" (into-array Class [Long/TYPE]))]
+      (.invoke create-method factory (object-array [seed])))
+    (catch Exception _ nil)))

--- a/bases/criterium/test/criterium/util/well_test.clj
+++ b/bases/criterium/test/criterium/util/well_test.clj
@@ -5,66 +5,12 @@
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
-   [criterium.test-utils :refer [gen-bounded test-max-error]]
+   [criterium.test-utils :refer [autocorrelation
+                                 gen-bounded
+                                 test-max-error
+                                 variance-ratio-uniform]]
    [criterium.util.stats :as stats]
    [criterium.util.well :as well]))
-
-;;; Autocorrelation test helpers
-
-(defn- autocorrelation
-  "Compute sample autocorrelation at a given lag.
-
-  Returns the correlation coefficient between x[i] and x[i+lag] for
-  i = 0 to n-lag-1. Result is in [-1, 1] where 0 indicates no
-  correlation.
-
-  Requires lag < (count samples)."
-  ^double [samples ^long lag]
-  (assert (< lag (count samples)) "lag must be less than sample count")
-  (let [samples  (double-array samples)
-        n        (long (alength samples))
-        sum-all  (double (areduce samples i sum 0.0 (+ sum (aget samples i))))
-        mean     (/ sum-all (double n))
-        ;; Compute variance (denominator)
-        var     (double
-                 (areduce samples i sum 0.0
-                          (let [d (- (aget samples i) mean)]
-                            (+ sum (* d d)))))
-        ;; Compute covariance at lag (numerator)
-        limit   (- n lag)
-        cov     (double
-                 (loop [i   (long 0)
-                        sum 0.0]
-                   (if (< i limit)
-                     (recur (inc i)
-                            (+ sum (* (- (aget samples i) mean)
-                                      (- (aget samples (+ i lag)) mean))))
-                     sum)))]
-    (if (zero? var)
-      0.0
-      (/ cov var))))
-
-(defn- variance-ratio
-  "Compute the ratio of observed batch-sum variance to expected variance.
-
-  For independent uniform samples, batch sums have variance n*σ² where
-  σ² is the individual variance. Returns observed/expected ratio.
-  A ratio of 1.0 indicates independent samples; higher values suggest
-  positive autocorrelation.
-
-  Expects samples to be a vector."
-  ^double [samples ^long batch-size]
-  (let [n            (count samples)
-        num-batches  (quot n batch-size)
-        batches      (mapv (fn [^long i]
-                             (subvec samples (* i batch-size) (* (inc i) batch-size)))
-                           (range num-batches))
-        batch-sums   (mapv #(reduce + %) batches)
-        ;; Expected variance for sum of batch-size independent U(0,1)
-        ;; Var(U) = 1/12, Var(sum) = batch-size/12
-        expected-var (/ batch-size 12.0)
-        observed-var (stats/variance batch-sums)]
-    (/ observed-var expected-var)))
 
 (deftest bit-shift-right-ns-test
   (is (= 4 (well/bit-shift-right-ns 8 1)))
@@ -134,7 +80,7 @@
       (let [seed       42
             samples    (vec (take 100000 (well/well-rng-1024a seed)))
             batch-size 500
-            ratio      (variance-ratio samples batch-size)]
+            ratio      (variance-ratio-uniform samples batch-size)]
         (is (< 0.75 ratio 1.25)
             (format "variance ratio %.3f outside [0.75, 1.25]" ratio))))))
 
@@ -151,8 +97,8 @@
             batch-size 500
             ;; WELL RNG for comparison
             well-samples (vec (take 100000 (well/well-rng-1024a seed)))
-            lcg-ratio    (variance-ratio samples batch-size)
-            well-ratio   (variance-ratio well-samples batch-size)]
+            lcg-ratio    (variance-ratio-uniform samples batch-size)
+            well-ratio   (variance-ratio-uniform well-samples batch-size)]
         ;; Document: LCG may show variance inflation or correlation
         ;; This test documents observed behavior rather than asserting failure
         (is (< (Math/abs (- well-ratio 1.0)) 0.25)
@@ -219,7 +165,7 @@
          compute-metrics
          (fn [name samples]
            (let [ac-vals (mapv #(autocorrelation samples %) lags)
-                 vr      (variance-ratio samples batch-size)]
+                 vr      (variance-ratio-uniform samples batch-size)]
              (into {:rng name :variance-ratio (fmt-4sf vr)}
                    (map vector
                         (map #(keyword (str "ac-lag-" %)) lags)

--- a/bases/criterium/test/criterium/util/well_test.clj
+++ b/bases/criterium/test/criterium/util/well_test.clj
@@ -7,8 +7,10 @@
    [clojure.test.check.properties :as prop]
    [criterium.test-utils :refer [autocorrelation
                                  gen-bounded
+                                 make-xoshiro-rng
                                  test-max-error
-                                 variance-ratio-uniform]]
+                                 variance-ratio-uniform
+                                 xoshiro-available?]]
    [criterium.util.stats :as stats]
    [criterium.util.well :as well]))
 
@@ -109,28 +111,6 @@
         (is (number? lcg-ratio)
             (format "LCG ratio: %.3f, WELL ratio: %.3f"
                     lcg-ratio well-ratio))))))
-
-;;; RNG comparison table helpers
-
-(defn- xoshiro-available?
-  "Check if Xoshiro256PlusPlus is available (JDK 17+)."
-  []
-  (try
-    (Class/forName "java.util.random.RandomGeneratorFactory")
-    true
-    (catch ClassNotFoundException _ false)))
-
-(defn- make-xoshiro-rng
-  "Create a Xoshiro256PlusPlus RNG instance using reflection.
-  Returns nil if not available."
-  [^long seed]
-  (try
-    (let [factory-class (Class/forName "java.util.random.RandomGeneratorFactory")
-          of-method     (.getMethod factory-class "of" (into-array Class [String]))
-          factory       (.invoke of-method nil (object-array ["Xoshiro256PlusPlus"]))
-          create-method (.getMethod (class factory) "create" (into-array Class [Long/TYPE]))]
-      (.invoke create-method factory (object-array [seed])))
-    (catch Exception _ nil)))
 
 ;;; RNG comparison table
 

--- a/bases/criterium/test/criterium/util/ziggurat_test.clj
+++ b/bases/criterium/test/criterium/util/ziggurat_test.clj
@@ -1,5 +1,6 @@
 (ns criterium.util.ziggurat-test
   (:require
+   [clojure.pprint :as pprint]
    [clojure.test :refer [deftest is testing]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
@@ -64,3 +65,111 @@
               (format "mean %.4f exceeds tolerance 0.02" mean))
           (is (< (Math/abs (- variance 1.0)) 0.1)
               (format "variance %.4f not within 0.1 of 1.0" variance)))))))
+
+;;; Normal sample comparison table helpers
+
+(defn- xoshiro-available?
+  "Check if Xoshiro256PlusPlus is available (JDK 17+)."
+  []
+  (try
+    (Class/forName "java.util.random.RandomGeneratorFactory")
+    true
+    (catch ClassNotFoundException _ false)))
+
+(defn- make-xoshiro-rng
+  "Create a Xoshiro256PlusPlus RNG instance using reflection.
+  Returns nil if not available."
+  [^long seed]
+  (try
+    (let [factory-class (Class/forName "java.util.random.RandomGeneratorFactory")
+          of-method     (.getMethod factory-class "of" (into-array Class [String]))
+          factory       (.invoke of-method nil (object-array ["Xoshiro256PlusPlus"]))
+          create-method (.getMethod (class factory) "create" (into-array Class [Long/TYPE]))]
+      (.invoke create-method factory (object-array [seed])))
+    (catch Exception _ nil)))
+
+;;; Normal sample comparison table
+
+(defn print-ziggurat-comparison-table
+  "Print a table comparing normal sample sources.
+
+  Computes and displays mean, variance, autocorrelation at various lags,
+  and variance ratio for each available normal sample source:
+  - LCG (java.util.Random) + ziggurat
+  - WELL-1024a + ziggurat
+  - Xoshiro256++ + ziggurat (JDK 17+)
+  - Xoshiro256++ nextGaussian (JDK 17+, native normal generation)
+
+  This function is for manual exploration and is not called in tests."
+  ([]
+   (print-ziggurat-comparison-table {}))
+  ([{:keys [seed n batch-size lags]
+     :or   {seed 42, n 100000, batch-size 500, lags [1 2 5 10]}}]
+   (let [;; Format to 4 significant figures
+         fmt-4sf (fn [x] (format "%.4g" (double x)))
+
+         ;; Generate normal samples from each source
+         lcg           (java.util.Random. seed)
+         lcg-rng-seq   (repeatedly #(.nextDouble lcg))
+         lcg-samples   (vec (take n (ziggurat/random-normal-zig lcg-rng-seq)))
+         well-samples  (vec (take n (ziggurat/random-normal-zig
+                                     (well/well-rng-1024a seed))))
+
+         ;; Xoshiro256++ + ziggurat if available
+         xoshiro-zig-samples
+         (when (xoshiro-available?)
+           (when-let [rng (make-xoshiro-rng seed)]
+             (let [next-double (.getMethod (class rng) "nextDouble"
+                                           (into-array Class []))
+                   rng-seq     (repeatedly #(.invoke next-double rng (object-array [])))]
+               (vec (take n (ziggurat/random-normal-zig rng-seq))))))
+
+         ;; Xoshiro256++ nextGaussian (native normal) if available
+         xoshiro-gaussian-samples
+         (when (xoshiro-available?)
+           (when-let [rng (make-xoshiro-rng seed)]
+             (let [next-gaussian (.getMethod (class rng) "nextGaussian"
+                                             (into-array Class []))]
+               (vec (repeatedly n #(.invoke next-gaussian rng (object-array [])))))))
+
+         ;; Compute metrics for each source
+         compute-metrics
+         (fn [name samples]
+           (let [mean      (stats/mean samples)
+                 variance  (stats/variance samples)
+                 ac-vals   (mapv #(autocorrelation samples %) lags)
+                 ;; Normal samples have variance 1.0
+                 vr        (variance-ratio samples batch-size 1.0)]
+             (into {:source         name
+                    :mean           (fmt-4sf mean)
+                    :variance       (fmt-4sf variance)
+                    :variance-ratio (fmt-4sf vr)}
+                   (map vector
+                        (map #(keyword (str "ac-lag-" %)) lags)
+                        (map fmt-4sf ac-vals)))))
+
+         results
+         (cond-> [(compute-metrics "LCG + ziggurat" lcg-samples)
+                  (compute-metrics "WELL + ziggurat" well-samples)]
+           xoshiro-zig-samples
+           (conj (compute-metrics "Xoshiro++ + ziggurat" xoshiro-zig-samples))
+           xoshiro-gaussian-samples
+           (conj (compute-metrics "Xoshiro++ nextGaussian" xoshiro-gaussian-samples)))]
+
+     (println "\nNormal Sample Source Comparison")
+     (println (str "Samples: " n ", Batch size: " batch-size ", Lags: " lags))
+     (println)
+     (pprint/print-table
+      (into [:source :mean :variance]
+            (concat (map #(keyword (str "ac-lag-" %)) lags)
+                    [:variance-ratio]))
+      results)
+     (println)
+     (println "Expected values for standard normal:")
+     (println "  - Mean ≈ 0, Variance ≈ 1")
+     (println "  - Autocorrelation ≈ 0 (threshold: |ac| < 0.02)")
+     (println "  - Variance ratio ≈ 1.0 (threshold: 0.9 to 1.1)"))))
+
+(comment
+  (print-ziggurat-comparison-table)
+  (print-ziggurat-comparison-table {:n 50000}))

--- a/bases/criterium/test/criterium/util/ziggurat_test.clj
+++ b/bases/criterium/test/criterium/util/ziggurat_test.clj
@@ -5,7 +5,11 @@
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
-   [criterium.test-utils :refer [abs-error autocorrelation variance-ratio]]
+   [criterium.test-utils :refer [abs-error
+                                 autocorrelation
+                                 make-xoshiro-rng
+                                 variance-ratio
+                                 xoshiro-available?]]
    [criterium.util.stats :as stats]
    [criterium.util.well :as well]
    [criterium.util.ziggurat :as ziggurat]))
@@ -64,28 +68,6 @@
               (format "mean %.4f exceeds tolerance 0.02" mean))
           (is (< (Math/abs (- variance 1.0)) 0.1)
               (format "variance %.4f not within 0.1 of 1.0" variance)))))))
-
-;;; Normal sample comparison table helpers
-
-(defn- xoshiro-available?
-  "Check if Xoshiro256PlusPlus is available (JDK 17+)."
-  []
-  (try
-    (Class/forName "java.util.random.RandomGeneratorFactory")
-    true
-    (catch ClassNotFoundException _ false)))
-
-(defn- make-xoshiro-rng
-  "Create a Xoshiro256PlusPlus RNG instance using reflection.
-  Returns nil if not available."
-  [^long seed]
-  (try
-    (let [factory-class (Class/forName "java.util.random.RandomGeneratorFactory")
-          of-method     (.getMethod factory-class "of" (into-array Class [String]))
-          factory       (.invoke of-method nil (object-array ["Xoshiro256PlusPlus"]))
-          create-method (.getMethod (class factory) "create" (into-array Class [Long/TYPE]))]
-      (.invoke create-method factory (object-array [seed])))
-    (catch Exception _ nil)))
 
 ;;; Normal sample comparison table
 

--- a/bases/criterium/test/criterium/util/ziggurat_test.clj
+++ b/bases/criterium/test/criterium/util/ziggurat_test.clj
@@ -13,9 +13,8 @@
 (defspec random-normal-zig-test-property 10
   (prop/for-all
    [random-seed gen/small-integer]
-   (let [random-source  (java.util.Random. random-seed)
-         values         (->> #(.nextDouble random-source)
-                             repeatedly
+   (let [rng            (well/well-rng-1024a random-seed)
+         values         (->> rng
                              ziggurat/random-normal-zig
                              (take 10000)
                              vec)
@@ -24,7 +23,7 @@
          mean-error     (abs-error mean 0.0)
          variance-error (abs-error variance 1.0)
          mean-tol       1e-1
-         variance-tol   15e-1]
+         variance-tol   1e-1]
      (is (< mean-error mean-tol))
      (is (< variance-error variance-tol))
      (and (< mean-error mean-tol)

--- a/bases/criterium/test/criterium/util/ziggurat_test.clj
+++ b/bases/criterium/test/criterium/util/ziggurat_test.clj
@@ -1,11 +1,12 @@
 (ns criterium.util.ziggurat-test
   (:require
-   [clojure.test :refer [is]]
+   [clojure.test :refer [deftest is testing]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
-   [criterium.test-utils :refer [abs-error]]
+   [criterium.test-utils :refer [abs-error autocorrelation variance-ratio]]
    [criterium.util.stats :as stats]
+   [criterium.util.well :as well]
    [criterium.util.ziggurat :as ziggurat]))
 
 (defspec random-normal-zig-test-property 10
@@ -27,3 +28,39 @@
      (is (< variance-error variance-tol))
      (and (< mean-error mean-tol)
           (< variance-error variance-tol)))))
+
+;;; Autocorrelation tests
+;; Verify that ziggurat with WELL RNG produces normal samples with negligible
+;; autocorrelation and correct marginal distribution. The ziggurat algorithm
+;; consumes 2-3+ uniform values per output, which can amplify RNG correlations.
+
+(deftest ziggurat-well-rng-autocorrelation-test
+  ;; Verify ziggurat produces independent normal samples when using WELL RNG.
+  ;; With n=100,000, SE ≈ 1/√n ≈ 0.003, so threshold of 0.02 is conservative.
+  (testing "random-normal-zig with WELL RNG"
+    (let [seed    42
+          n       100000
+          samples (vec (take n (ziggurat/random-normal-zig
+                                (well/well-rng-1024a seed))))]
+      (testing "has negligible autocorrelation at multiple lags"
+        (let [lags [1 2 5 10]]
+          (doseq [lag lags]
+            (let [ac (autocorrelation samples lag)]
+              (is (< (Math/abs ac) 0.02)
+                  (format "lag %d: autocorrelation %.4f exceeds threshold"
+                          lag ac))))))
+
+      (testing "has batch-sum variance ratio near 1.0"
+        (let [batch-size 500
+              ;; Normal distribution has variance 1.0
+              ratio      (variance-ratio samples batch-size 1.0)]
+          (is (< 0.9 ratio 1.1)
+              (format "variance ratio %.3f outside [0.9, 1.1]" ratio))))
+
+      (testing "has correct marginal distribution"
+        (let [mean     (stats/mean samples)
+              variance (stats/variance samples)]
+          (is (< (Math/abs mean) 0.02)
+              (format "mean %.4f exceeds tolerance 0.02" mean))
+          (is (< (Math/abs (- variance 1.0)) 0.1)
+              (format "variance %.4f not within 0.1 of 1.0" variance)))))))


### PR DESCRIPTION
## Summary

Add tests to verify that the ziggurat algorithm produces samples with negligible auto-correlation when given an appropriate RNG source (WELL RNG). The ziggurat algorithm consumes a variable number of uniform random values per output (2-3+ depending on acceptance/rejection path), which can amplify correlations in the underlying RNG.

**Changes:**
- Extract shared statistical test helpers (`autocorrelation`, `variance-ratio`, `variance-ratio-uniform`) to `criterium.test-utils`
- Extract Xoshiro RNG helpers (`xoshiro-available?`, `make-xoshiro-rng`) to eliminate duplication
- Add ziggurat autocorrelation tests validating: |autocorrelation| < 0.02 at lags 1,2,5,10, variance-ratio in [0.9,1.1], mean ≈ 0, variance ≈ 1
- Add `print-ziggurat-comparison-table` function for manual RNG exploration (compares LCG, WELL, and Xoshiro256++ with ziggurat)
- Fix existing defspec test to use WELL RNG with tighter variance tolerance (1.5 → 0.1)
- Update `well_test.clj` to use helpers from test-utils

## Test plan

- [ ] Run `clojure -M:kaocha:dev:test --reporter dots` to verify all tests pass
- [ ] Verify ziggurat autocorrelation tests pass with WELL RNG
- [ ] Verify defspec test uses WELL RNG and stricter tolerance