### PR TITLE
feat: add KDE analysis step for benchmark samples

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,7 +2,7 @@
   (clojure-indent-style . 'always-align)
   (clojure-special-arg-indent-factor . 1) ; for cljfmt equivalence
   (cider-preferred-build-tool . "clojure-cli")
-  (cider-clojure-cli-aliases . "dev:test:with-agent-mac")
+  (cider-clojure-cli-aliases . "dev:test:with-agent-mac:blackhole")
   (eval .
         (define-clojure-indent
           ;; Please keep this list sorted

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -339,7 +339,7 @@
   "Calculate kernel density estimation for sample measurements.
 
   Returns a function that computes KDE for quantitative metrics, providing
-  density estimates, bandwidth selection, confidence bands, and mode detection.
+  density estimates, bandwidth selection, and confidence bands.
 
   Parameters:
     opts - Optional map with keys:
@@ -349,7 +349,6 @@
       :metric-ids  - Set of metric ids to analyze (default: all quantitative)
       :n-points    - Grid size for density evaluation (default: 512)
       :n-bootstrap - Bootstrap samples for confidence bands (default: 200)
-      :n-modes     - Maximum modes to detect (default: 5)
       :alpha       - Confidence level (default: 0.05)
 
   The returned function:
@@ -360,14 +359,16 @@
     - bandwidth: ISJ-selected bandwidth
     - grid/density: evaluation points and density values
     - lower-band/upper-band: bootstrap confidence bands
-    - modes: detected peaks with confidence intervals
+
+  Note: Mode detection is now a separate analysis step. Use `modes` function
+  after KDE to compute statistically validated modes with Silverman's test.
 
   Example:
   (let [analyze (kde {:n-points 256})
         result (analyze {:log-samples {...} :outliers {...}})]
     (get-in result [:kde :elapsed-time]))"
   ([] (kde {}))
-  ([{:keys [id samples-id outliers-id metric-ids n-points n-bootstrap n-modes alpha]
+  ([{:keys [id samples-id outliers-id metric-ids n-points n-bootstrap alpha]
      :as _options}]
    (let [samples-id (or samples-id :log-samples)
          id (or id :kde)
@@ -386,7 +387,6 @@
                  kde-options (cond-> {}
                                n-points (assoc :n-points n-points)
                                n-bootstrap (assoc :n-bootstrap n-bootstrap)
-                               n-modes (assoc :n-modes n-modes)
                                alpha (assoc :alpha alpha))
                  kde-result (methods/kde
                              metrics-samples
@@ -403,6 +403,76 @@
                                 :batch-size (:batch-size metrics-samples)}
                                kde-result))]
                  (assoc data-map id kde-map))
+               data-map))))))))
+
+(defn modes
+  "Calculate statistically validated mode analysis for KDE output.
+
+  Returns a function that computes modes with Silverman's test for significance.
+  Tests from k=1 up to max-modes to determine the statistically supported
+  number of modes. For k=1, applies Hall-York correction for better calibration.
+
+  Parameters:
+    opts - Optional map with keys:
+      :id          - Key for modes results in output (default: :modes)
+      :kde-id      - Key for source KDE data (default: :kde)
+      :samples-id  - Key for raw samples (default: :log-samples)
+      :outliers-id - Key for outlier data (default: :outliers)
+      :metric-ids  - Set of metric ids to analyze (default: all from KDE)
+      :max-modes   - Maximum modes to test (default: 5)
+      :n-bootstrap - Bootstrap samples for CIs and Silverman test (default: 200)
+      :alpha       - Significance level (default: 0.05)
+
+  The returned function:
+  - Takes a data map containing KDE and samples
+  - Returns the map with mode analysis added under :id key
+  - For each metric provides:
+    - modes: detected peaks with CIs and significance flags
+    - n-modes: statistically validated mode count
+    - silverman: test results with p-values and critical bandwidths
+
+  Example:
+  (let [analyze (comp (modes) (kde))
+        result (analyze {:log-samples {...}})]
+    (get-in result [:modes :elapsed-time :n-modes]))"
+  ([] (modes {}))
+  ([{:keys [id kde-id samples-id outliers-id metric-ids max-modes n-bootstrap alpha]
+     :as _options}]
+   (let [id (or id :modes)
+         kde-id (or kde-id :kde)
+         samples-id (or samples-id :log-samples)
+         outliers-id (or outliers-id :outliers)]
+     (fn [data-map]
+       (let [kde-map (get data-map kde-id)
+             samples (get data-map samples-id)]
+         (if-not (and kde-map samples)
+           data-map
+           (let [outliers (when outliers-id (get data-map outliers-id))
+                 metrics-defs (-> (have (:metrics-defs kde-map))
+                                  (metric/select-metrics metric-ids)
+                                  (metric/filter-metrics
+                                   (metric/type-pred :quantitative)))
+                 metric-configs (metric/all-metric-configs metrics-defs)
+                 modes-options (cond-> {}
+                                 max-modes (assoc :max-modes max-modes)
+                                 n-bootstrap (assoc :n-bootstrap n-bootstrap)
+                                 alpha (assoc :alpha alpha))
+                 modes-result (methods/modes
+                               kde-map
+                               samples
+                               outliers
+                               metric-configs
+                               modes-options)]
+             (if modes-result
+               (let [modes-map (util/->modes-map
+                                (merge
+                                 {:type :criterium/modes
+                                  :metrics-defs metrics-defs
+                                  :source-id kde-id
+                                  :samples-id samples-id
+                                  :outliers-id outliers-id}
+                                 modes-result))]
+                 (assoc data-map id modes-map))
                data-map))))))))
 
 (defn- min-f

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -345,6 +345,7 @@
     opts - Optional map with keys:
       :id          - Key for KDE results in output (default: :kde)
       :samples-id  - Key for source samples (default: :log-samples)
+      :outliers-id - Key for outlier analysis if available (default: :outliers)
       :metric-ids  - Set of metric ids to analyze (default: all quantitative)
       :n-points    - Grid size for density evaluation (default: 512)
       :n-bootstrap - Bootstrap samples for confidence bands (default: 200)
@@ -363,18 +364,21 @@
 
   Example:
   (let [analyze (kde {:n-points 256})
-        result (analyze {:log-samples {...}})]
+        result (analyze {:log-samples {...} :outliers {...}})]
     (get-in result [:kde :elapsed-time]))"
   ([] (kde {}))
-  ([{:keys [id samples-id metric-ids n-points n-bootstrap n-modes alpha]
+  ([{:keys [id samples-id outliers-id metric-ids n-points n-bootstrap n-modes alpha]
      :as _options}]
    (let [samples-id (or samples-id :log-samples)
-         id (or id :kde)]
+         id (or id :kde)
+         outliers-id (or outliers-id :outliers)]
      (fn [data-map]
        (let [metrics-samples (get data-map samples-id)]
          (if-not metrics-samples
            data-map
-           (let [metrics-defs (-> (have (:metrics-defs metrics-samples))
+           (let [outliers (when outliers-id
+                            (data-map outliers-id))
+                 metrics-defs (-> (have (:metrics-defs metrics-samples))
                                   (metric/select-metrics metric-ids)
                                   (metric/filter-metrics
                                    (metric/type-pred :quantitative)))
@@ -386,6 +390,7 @@
                                alpha (assoc :alpha alpha))
                  kde-result (methods/kde
                              metrics-samples
+                             outliers
                              metric-configs
                              kde-options)]
              (if kde-result
@@ -394,6 +399,7 @@
                                {:type :criterium/kde
                                 :metrics-defs metrics-defs
                                 :source-id samples-id
+                                :outliers-id outliers-id
                                 :batch-size (:batch-size metrics-samples)}
                                kde-result))]
                  (assoc data-map id kde-map))

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -425,6 +425,10 @@
       :method      - Test method, :acr (default) or :silverman
                      :acr uses excess mass statistic (better calibrated)
                      :silverman uses bootstrap mode count
+      :mode-method - Mode finding method (default: :isj)
+                     :isj - find modes from KDE density at ISJ bandwidth
+                     :critical - find modes at critical bandwidth for validated k
+                     When :critical, output includes :antimodes and :mode-bandwidth
 
   The returned function:
   - Takes a data map containing KDE and samples
@@ -433,6 +437,9 @@
     - modes: detected peaks with CIs and significance flags
     - n-modes: statistically validated mode count
     - test-results: p-values, critical bandwidths, and method used
+    - When :mode-method is :critical:
+      - antimodes: local minima between modes
+      - mode-bandwidth: critical bandwidth used for mode finding
 
   Example:
   (let [analyze (comp (modes) (kde))
@@ -440,7 +447,7 @@
     (get-in result [:modes :elapsed-time :n-modes]))"
   ([] (modes {}))
   ([{:keys [id kde-id samples-id outliers-id metric-ids max-modes n-bootstrap alpha
-            method]
+            method mode-method]
      :as _options}]
    (let [id (or id :modes)
          kde-id (or kde-id :kde)
@@ -461,7 +468,8 @@
                                  max-modes (assoc :max-modes max-modes)
                                  n-bootstrap (assoc :n-bootstrap n-bootstrap)
                                  alpha (assoc :alpha alpha)
-                                 method (assoc :method method))
+                                 method (assoc :method method)
+                                 mode-method (assoc :mode-method mode-method))
                  modes-result (methods/modes
                                kde-map
                                samples

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -408,9 +408,9 @@
 (defn modes
   "Calculate statistically validated mode analysis for KDE output.
 
-  Returns a function that computes modes with Silverman's test for significance.
+  Returns a function that computes modes with multimodality testing for significance.
   Tests from k=1 up to max-modes to determine the statistically supported
-  number of modes. For k=1, applies Hall-York correction for better calibration.
+  number of modes.
 
   Parameters:
     opts - Optional map with keys:
@@ -420,8 +420,11 @@
       :outliers-id - Key for outlier data (default: :outliers)
       :metric-ids  - Set of metric ids to analyze (default: all from KDE)
       :max-modes   - Maximum modes to test (default: 5)
-      :n-bootstrap - Bootstrap samples for CIs and Silverman test (default: 200)
+      :n-bootstrap - Bootstrap samples for CIs and test (default: 200)
       :alpha       - Significance level (default: 0.05)
+      :method      - Test method, :acr (default) or :silverman
+                     :acr uses excess mass statistic (better calibrated)
+                     :silverman uses bootstrap mode count
 
   The returned function:
   - Takes a data map containing KDE and samples
@@ -429,14 +432,15 @@
   - For each metric provides:
     - modes: detected peaks with CIs and significance flags
     - n-modes: statistically validated mode count
-    - silverman: test results with p-values and critical bandwidths
+    - test-results: p-values, critical bandwidths, and method used
 
   Example:
   (let [analyze (comp (modes) (kde))
         result (analyze {:log-samples {...}})]
     (get-in result [:modes :elapsed-time :n-modes]))"
   ([] (modes {}))
-  ([{:keys [id kde-id samples-id outliers-id metric-ids max-modes n-bootstrap alpha]
+  ([{:keys [id kde-id samples-id outliers-id metric-ids max-modes n-bootstrap alpha
+            method]
      :as _options}]
    (let [id (or id :modes)
          kde-id (or kde-id :kde)
@@ -456,7 +460,8 @@
                  modes-options (cond-> {}
                                  max-modes (assoc :max-modes max-modes)
                                  n-bootstrap (assoc :n-bootstrap n-bootstrap)
-                                 alpha (assoc :alpha alpha))
+                                 alpha (assoc :alpha alpha)
+                                 method (assoc :method method))
                  modes-result (methods/modes
                                kde-map
                                samples

--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -335,6 +335,70 @@
                              histogram))]
          (assoc data-map id histogram-map))))))
 
+(defn kde
+  "Calculate kernel density estimation for sample measurements.
+
+  Returns a function that computes KDE for quantitative metrics, providing
+  density estimates, bandwidth selection, confidence bands, and mode detection.
+
+  Parameters:
+    opts - Optional map with keys:
+      :id          - Key for KDE results in output (default: :kde)
+      :samples-id  - Key for source samples (default: :log-samples)
+      :metric-ids  - Set of metric ids to analyze (default: all quantitative)
+      :n-points    - Grid size for density evaluation (default: 512)
+      :n-bootstrap - Bootstrap samples for confidence bands (default: 200)
+      :n-modes     - Maximum modes to detect (default: 5)
+      :alpha       - Confidence level (default: 0.05)
+
+  The returned function:
+  - Takes a sampled data map containing samples
+  - Returns the map with KDE analysis added under :id key
+  - Returns data-map unchanged if samples unavailable (e.g., digest-based)
+  - For each metric provides:
+    - bandwidth: ISJ-selected bandwidth
+    - grid/density: evaluation points and density values
+    - lower-band/upper-band: bootstrap confidence bands
+    - modes: detected peaks with confidence intervals
+
+  Example:
+  (let [analyze (kde {:n-points 256})
+        result (analyze {:log-samples {...}})]
+    (get-in result [:kde :elapsed-time]))"
+  ([] (kde {}))
+  ([{:keys [id samples-id metric-ids n-points n-bootstrap n-modes alpha]
+     :as _options}]
+   (let [samples-id (or samples-id :log-samples)
+         id (or id :kde)]
+     (fn [data-map]
+       (let [metrics-samples (get data-map samples-id)]
+         (if-not metrics-samples
+           data-map
+           (let [metrics-defs (-> (have (:metrics-defs metrics-samples))
+                                  (metric/select-metrics metric-ids)
+                                  (metric/filter-metrics
+                                   (metric/type-pred :quantitative)))
+                 metric-configs (metric/all-metric-configs metrics-defs)
+                 kde-options (cond-> {}
+                               n-points (assoc :n-points n-points)
+                               n-bootstrap (assoc :n-bootstrap n-bootstrap)
+                               n-modes (assoc :n-modes n-modes)
+                               alpha (assoc :alpha alpha))
+                 kde-result (methods/kde
+                             metrics-samples
+                             metric-configs
+                             kde-options)]
+             (if kde-result
+               (let [kde-map (util/->kde-map
+                              (merge
+                               {:type :criterium/kde
+                                :metrics-defs metrics-defs
+                                :source-id samples-id
+                                :batch-size (:batch-size metrics-samples)}
+                               kde-result))]
+                 (assoc data-map id kde-map))
+               data-map))))))))
+
 (defn- min-f
   ^double [f ^double q ^double r]
   (min ^double (f q) ^double (f r)))

--- a/bases/criterium/src/criterium/analyse/digest_samples.clj
+++ b/bases/criterium/src/criterium/analyse/digest_samples.clj
@@ -18,7 +18,7 @@
 
 (defmethod methods/transform :criterium/digest
   [digest-samples metric-configs f inv-f _options]
-  (let [metric->digest  (util/metric->digest digest-samples)
+  (let [metric->digest (util/metric->digest digest-samples)
         metric->digest' (reduce
                          (fn x-path [result path]
                            (assoc
@@ -35,33 +35,33 @@
       digest-samples-keys)
      (merge
       {:metric->digest metric->digest'
-       :transform      {:sample-> inv-f :->sample f}}))))
+       :transform {:sample-> inv-f :->sample f}}))))
 
 (defmethod methods/quantiles :criterium/digest
   [digest-samples metric-configs options]
   (let [metric->digest (util/metric->digest digest-samples)
-        quantiles      (into [0.25 0.5 0.75] (:quantiles options))
-        quantiles      (reduce
-                        (fn qs [result path]
-                          (let [digest (metric->digest path)]
-                            (assoc-in
-                             result path
-                             (zipmap
-                              quantiles
-                              (mapv
-                               (partial t-digest/quantile digest)
-                               quantiles)))))
-                        {}
-                        (mapv :path metric-configs))]
-    {:type      :criterium/quantiles
+        quantiles (into [0.25 0.5 0.75] (:quantiles options))
+        quantiles (reduce
+                   (fn qs [result path]
+                     (let [digest (metric->digest path)]
+                       (assoc-in
+                        result path
+                        (zipmap
+                         quantiles
+                         (mapv
+                          (partial t-digest/quantile digest)
+                          quantiles)))))
+                   {}
+                   (mapv :path metric-configs))]
+    {:type :criterium/quantiles
      :quantiles quantiles
      :transform collect-plan/identity-transforms}))
 
 (defn outlier-count
   [low-severe low-mild high-mild high-severe]
-  {:low-severe  low-severe
-   :low-mild    low-mild
-   :high-mild   high-mild
+  {:low-severe low-severe
+   :low-mild low-mild
+   :high-mild high-mild
    :high-severe high-severe})
 
 (defn classifier
@@ -69,94 +69,94 @@
   (fn [^double x i]
     (when-not (<= low-mild x high-mild)
       [i (cond
-           (<= x low-severe)           :low-severe
-           (< low-severe x low-mild)   :low-mild
+           (<= x low-severe) :low-severe
+           (< low-severe x low-mild) :low-mild
            (> high-severe x high-mild) :high-mild
-           (>= x high-severe)          :high-severe)])))
+           (>= x high-severe) :high-severe)])))
 
 (defn digest-outliers
   [digest quantiles]
-  (let [thresholds     (stats/boxplot-outlier-thresholds
-                        (get quantiles 0.25)
-                        (get quantiles 0.75))
-        classifier     (classifier thresholds)
-        outliers       (when (apply not= thresholds)
-                         (into {}
-                               (mapv classifier
-                                     (t-digest/centroid-means digest)
-                                     (range))))
+  (let [thresholds (stats/boxplot-outlier-thresholds
+                    (get quantiles 0.25)
+                    (get quantiles 0.75))
+        classifier (classifier thresholds)
+        outliers (when (apply not= thresholds)
+                   (into {}
+                         (mapv classifier
+                               (t-digest/centroid-means digest)
+                               (range))))
         outlier-counts (reduce-kv
                         (fn [counts _i v]
                           (update counts v inc))
                         (outlier-count 0 0 0 0)
                         outliers)]
-    {:thresholds     thresholds
-     :outliers       outliers
+    {:thresholds thresholds
+     :outliers outliers
      :outlier-counts outlier-counts}))
 
 (defmethod methods/outliers :criterium/digest
   [digest-samples all-quantiles metric-configs _options]
   (let [metric->digest (util/metric->digest digest-samples)
-        quantiles      (util/quantiles all-quantiles)
-        outliers       (reduce
-                        (fn qs [result path]
-                          (let [digest    (metric->digest path)
-                                quantiles (get-in quantiles path)]
-                            (assoc-in
-                             result path
-                             (digest-outliers digest quantiles))))
-                        {}
-                        (mapv :path metric-configs))]
-    {:type        :criterium/outliers
-     :outliers    outliers
+        quantiles (util/quantiles all-quantiles)
+        outliers (reduce
+                  (fn qs [result path]
+                    (let [digest (metric->digest path)
+                          quantiles (get-in quantiles path)]
+                      (assoc-in
+                       result path
+                       (digest-outliers digest quantiles))))
+                  {}
+                  (mapv :path metric-configs))]
+    {:type :criterium/outliers
+     :outliers outliers
      :num-samples (t-digest/sample-count (first (vals metric->digest)))
-     :transform   collect-plan/identity-transforms}))
+     :transform collect-plan/identity-transforms}))
 
 (defn- digest-sample-stats
   [digest]
-  (let [mean        (t-digest/mean digest)
-        variance    (t-digest/variance digest mean)
-        sigma       (Math/sqrt variance)
+  (let [mean (t-digest/mean digest)
+        variance (t-digest/variance digest mean)
+        sigma (Math/sqrt variance)
         three-sigma (* 3.0 sigma)]
-    {:n                 (t-digest/sample-count digest)
-     :mean              mean
-     :variance          variance
-     :sigma             sigma
-     :mean-plus-3sigma  (+ mean three-sigma)
+    {:n (t-digest/sample-count digest)
+     :mean mean
+     :variance variance
+     :sigma sigma
+     :mean-plus-3sigma (+ mean three-sigma)
      :mean-minus-3sigma (- mean three-sigma)
-     :min-val           (t-digest/minimum digest)
-     :max-val           (t-digest/maximum digest)}))
+     :min-val (t-digest/minimum digest)
+     :max-val (t-digest/maximum digest)}))
 
 (defmethod methods/stats :criterium/digest
   [digest-samples outliers metric-configs _options]
   (let [metric->digest (util/metric->digest digest-samples)
-        outliers       (when outliers (util/outliers outliers))
-        stats          (reduce
-                        (fn qs [result path]
-                          (let [digest   (have (metric->digest path))
-                                digest   (t-digest/compress digest)
-                                outliers (when outliers (get-in outliers path))
-                                digest   (if outliers
-                                           (t-digest/filter-outliers
-                                            digest
-                                            outliers)
-                                           digest)]
-                            (assoc-in
-                             result path
-                             (digest-sample-stats digest))))
-                        {}
-                        (mapv :path metric-configs))]
-    {:type      :criterium/stats
-     :stats     stats
+        outliers (when outliers (util/outliers outliers))
+        stats (reduce
+               (fn qs [result path]
+                 (let [digest (have (metric->digest path))
+                       digest (t-digest/compress digest)
+                       outliers (when outliers (get-in outliers path))
+                       digest (if outliers
+                                (t-digest/filter-outliers
+                                 digest
+                                 outliers)
+                                digest)]
+                   (assoc-in
+                    result path
+                    (digest-sample-stats digest))))
+               {}
+               (mapv :path metric-configs))]
+    {:type :criterium/stats
+     :stats stats
      :transform collect-plan/identity-transforms}))
 
 (defn histogram
   [metric->digest quantiles outliers metric-config]
   (try
-    (let [p            (:path metric-config)
-          iqr      (when-let [qs (get-in quantiles p)]
-                     (- (double (get qs 0.75)) (double (get qs 0.25))))
-          digest   (metric->digest p)
+    (let [p (:path metric-config)
+          iqr (when-let [qs (get-in quantiles p)]
+                (- (double (get qs 0.75)) (double (get qs 0.25))))
+          digest (metric->digest p)
           _outliers (get-in outliers p)
           #_#__samples (if-let [ols (:outliers outliers)]
                          (remove-outliers samples ols)
@@ -180,6 +180,11 @@
                                  %)))
                         (filterv (comp some? second))
                         (into {}))]
-    {:type       :criterium/histogram
+    {:type :criterium/histogram
      :histograms histograms
-     :transform  collect-plan/identity-transforms}))
+     :transform collect-plan/identity-transforms}))
+
+(defmethod methods/kde :criterium/digest
+  [_digest-samples _metric-configs _options]
+  ;; KDE requires raw sample values which t-digest doesn't preserve
+  nil)

--- a/bases/criterium/src/criterium/analyse/digest_samples.clj
+++ b/bases/criterium/src/criterium/analyse/digest_samples.clj
@@ -185,6 +185,6 @@
      :transform collect-plan/identity-transforms}))
 
 (defmethod methods/kde :criterium/digest
-  [_digest-samples _metric-configs _options]
+  [_digest-samples _outliers _metric-configs _options]
   ;; KDE requires raw sample values which t-digest doesn't preserve
   nil)

--- a/bases/criterium/src/criterium/analyse/methods.clj
+++ b/bases/criterium/src/criterium/analyse/methods.clj
@@ -36,3 +36,10 @@
   Returns nil if sample data is not available (e.g., digest-based samples)."
   (fn [sample-map _outliers _metric-configs _options]
     (:type sample-map)))
+
+(defmulti modes
+  "Calculate mode analysis with statistical validation.
+  Takes KDE output and computes modes with Silverman's test for significance.
+  Returns nil if raw sample data is not available."
+  (fn [kde-map _samples _outliers _metric-configs _options]
+    (:type kde-map)))

--- a/bases/criterium/src/criterium/analyse/methods.clj
+++ b/bases/criterium/src/criterium/analyse/methods.clj
@@ -30,3 +30,9 @@
   "Calculate histogram."
   (fn [sample-map _quantiles _outliers _metric-configs _options]
     (:type sample-map)))
+
+(defmulti kde
+  "Calculate kernel density estimation.
+  Returns nil if sample data is not available (e.g., digest-based samples)."
+  (fn [sample-map _metric-configs _options]
+    (:type sample-map)))

--- a/bases/criterium/src/criterium/analyse/methods.clj
+++ b/bases/criterium/src/criterium/analyse/methods.clj
@@ -39,7 +39,8 @@
 
 (defmulti modes
   "Calculate mode analysis with statistical validation.
-  Takes KDE output and computes modes with Silverman's test for significance.
+  Takes KDE output and computes modes with multimodality testing for significance.
+  Supports :acr (default) and :silverman test methods via :method option.
   Returns nil if raw sample data is not available."
   (fn [kde-map _samples _outliers _metric-configs _options]
     (:type kde-map)))

--- a/bases/criterium/src/criterium/analyse/methods.clj
+++ b/bases/criterium/src/criterium/analyse/methods.clj
@@ -34,5 +34,5 @@
 (defmulti kde
   "Calculate kernel density estimation.
   Returns nil if sample data is not available (e.g., digest-based samples)."
-  (fn [sample-map _metric-configs _options]
+  (fn [sample-map _outliers _metric-configs _options]
     (:type sample-map)))

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -5,6 +5,7 @@
    [criterium.util.helpers :as util]
    [criterium.util.histogram :as histogram]
    [criterium.util.invariant :refer [have]]
+   [criterium.util.kde :as kde]
    [criterium.util.sampled-stats :as sampled-stats]
    [criterium.util.stats :as stats]))
 
@@ -23,7 +24,7 @@
 
 (defmethod methods/transform :criterium/metrics-samples
   [metrics-samples metric-configs f inv-f _options]
-  (let [metric->values  (util/metric->values metrics-samples)
+  (let [metric->values (util/metric->values metrics-samples)
         metric->values' (reduce
                          (fn x-path [result path]
                            (assoc
@@ -38,7 +39,7 @@
       (disj metrics-samples-keys :metrics-defs))
      (merge
       {:metric->values metric->values'
-       :transform      {:sample-> inv-f :->sample f}}))))
+       :transform {:sample-> inv-f :->sample f}}))))
 
 (defmethod methods/quantiles :criterium/metrics-samples
   [metrics-samples metric-configs options]
@@ -46,15 +47,15 @@
                    (util/metric->values metrics-samples)
                    metric-configs
                    options)]
-    {:type      :criterium/quantiles
+    {:type :criterium/quantiles
      :quantiles quantiles
      :transform collect-plan/identity-transforms}))
 
 (defn outlier-count
   [low-severe low-mild high-mild high-severe]
-  {:low-severe  low-severe
-   :low-mild    low-mild
-   :high-mild   high-mild
+  {:low-severe low-severe
+   :low-mild low-mild
+   :high-mild high-mild
    :high-severe high-severe})
 
 (defn classifier
@@ -62,26 +63,26 @@
   (fn [^double x i]
     (when-not (<= low-mild x high-mild)
       [i (cond
-           (<= x low-severe)           :low-severe
-           (< low-severe x low-mild)   :low-mild
+           (<= x low-severe) :low-severe
+           (< low-severe x low-mild) :low-mild
            (> high-severe x high-mild) :high-mild
-           (>= x high-severe)          :high-severe)])))
+           (>= x high-severe) :high-severe)])))
 
 (defn samples-outliers [metric-configs all-quantiles samples]
   (reduce
    (fn sample-m [result metric-config]
-     (let [path           (:path metric-config)
-           quantiles      (have map? (get-in all-quantiles path)
-                                {:all-quantiles all-quantiles})
-           thresholds     (stats/boxplot-outlier-thresholds
-                           (get quantiles 0.25)
-                           (get quantiles 0.75))
-           classifier     (classifier thresholds)
-           outliers       (when (apply not= thresholds)
-                            (into {}
-                                  (mapv classifier
-                                        (get samples path)
-                                        (range))))
+     (let [path (:path metric-config)
+           quantiles (have map? (get-in all-quantiles path)
+                           {:all-quantiles all-quantiles})
+           thresholds (stats/boxplot-outlier-thresholds
+                       (get quantiles 0.25)
+                       (get quantiles 0.75))
+           classifier (classifier thresholds)
+           outliers (when (apply not= thresholds)
+                      (into {}
+                            (mapv classifier
+                                  (get samples path)
+                                  (range))))
            outlier-counts (reduce-kv
                            (fn [counts _i v]
                              (update counts v inc))
@@ -101,33 +102,33 @@
                   metric-configs
                   (util/quantiles all-quantiles)
                   (util/metric->values metrics-samples))]
-    {:type        :criterium/outliers
-     :outliers    outliers
+    {:type :criterium/outliers
+     :outliers outliers
      :num-samples (:num-samples metrics-samples)
-     :transform   collect-plan/identity-transforms}))
+     :transform collect-plan/identity-transforms}))
 
 (defmethod methods/stats :criterium/metrics-samples
   [metrics-samples outliers metric-configs options]
   (let [metric->values (util/metric->values metrics-samples)
-        stats          (sampled-stats/sample-stats
-                        metric->values
-                        (when outliers (util/outliers outliers))
-                        metric-configs
-                        options)]
-    {:type      :criterium/stats
-     :stats     stats
+        stats (sampled-stats/sample-stats
+               metric->values
+               (when outliers (util/outliers outliers))
+               metric-configs
+               options)]
+    {:type :criterium/stats
+     :stats stats
      :transform collect-plan/identity-transforms}))
 
 (defmethod methods/event-stats :criterium/metrics-samples
   [metrics-samples metrics-defs _options]
   (let [metric->values (util/metric->values metrics-samples)
-        event-stats    (sampled-stats/event-stats
-                        metrics-defs
-                        metric->values)]
-    {:type        :criterium/event-stats
+        event-stats (sampled-stats/event-stats
+                     metrics-defs
+                     metric->values)]
+    {:type :criterium/event-stats
      :event-stats event-stats
-     :batch-size  (:batch-size metrics-samples)
-     :transform   collect-plan/identity-transforms}))
+     :batch-size (:batch-size metrics-samples)
+     :transform collect-plan/identity-transforms}))
 
 (defn- remove-outliers
   [samples outliers]
@@ -140,14 +141,14 @@
 (defn histogram
   [metric->values quantiles outliers metric-config]
   (try
-    (let [p        (:path metric-config)
-          iqr      (when-let [qs (get-in quantiles p)]
-                     (- (double (get qs 0.75)) (double (get qs 0.25))))
-          samples  (metric->values p)
+    (let [p (:path metric-config)
+          iqr (when-let [qs (get-in quantiles p)]
+                (- (double (get qs 0.75)) (double (get qs 0.25))))
+          samples (metric->values p)
           outliers (get-in outliers p)
-          samples  (if-let [ols (:outliers outliers)]
-                     (remove-outliers samples ols)
-                     samples)]
+          samples (if-let [ols (:outliers outliers)]
+                    (remove-outliers samples ols)
+                    samples)]
       (histogram/histogram samples iqr))
     (catch clojure.lang.ExceptionInfo e
       (let [data (ex-data e)]
@@ -167,6 +168,33 @@
                                  %)))
                         (filterv (comp some? second))
                         (into {}))]
-    {:type       :criterium/histogram
+    {:type :criterium/histogram
      :histograms histograms
-     :transform  collect-plan/identity-transforms}))
+     :transform collect-plan/identity-transforms}))
+
+(defn kde-for-metric
+  "Compute KDE for a single metric's samples."
+  [metric->values metric-config options]
+  (try
+    (let [p (:path metric-config)
+          samples (metric->values p)]
+      (when (seq samples)
+        (kde/kde samples options)))
+    (catch clojure.lang.ExceptionInfo e
+      (let [data (ex-data e)]
+        (when-not (#{:kde/no-data :kde/constant-data} (:error data))
+          (throw e))))))
+
+(defmethod methods/kde :criterium/metrics-samples
+  [metrics-samples metric-configs options]
+  (let [metric->values (util/metric->values metrics-samples)
+        kdes (->> metric-configs
+                  (mapv
+                   (juxt :path
+                         #(kde-for-metric metric->values % options)))
+                  (filterv (comp some? second))
+                  (into {}))]
+    (when (seq kdes)
+      {:type :criterium/kde
+       :kdes kdes
+       :transform collect-plan/identity-transforms})))

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -214,6 +214,8 @@
     (let [{:keys [grid density bandwidth]} kde-data
           {:keys [max-modes n-bootstrap alpha n-points]
            :or {max-modes 5 n-bootstrap 200 alpha 0.05 n-points 512}} options
+          max-modes (long max-modes)
+          alpha (double alpha)
           p (:path metric-config)
           ;; Filter outliers from samples
           outliers-data (get-in outliers p)
@@ -224,10 +226,11 @@
           grid-arr (double-array grid)
           density-arr (double-array density)
           all-modes (kde/find-modes grid-arr density-arr)
+          n-all-modes (long (count all-modes))
           ;; Run Silverman's test for each k from 1 to max-modes
           silverman-results
           (into {}
-                (for [k (range 1 (inc (min max-modes (count all-modes))))]
+                (for [k (range 1 (inc (min max-modes n-all-modes)))]
                   [k (kde/silverman-test samples k
                                          {:n-bootstrap n-bootstrap
                                           :n-points n-points
@@ -235,10 +238,10 @@
           ;; Determine validated number of modes
           ;; Find smallest k where p-value >= alpha (fail to reject H0: <= k modes)
           validated-k (or (some (fn [k]
-                                  (when (>= (get-in silverman-results [k :p-value]) alpha)
+                                  (when (>= (double (get-in silverman-results [k :p-value])) alpha)
                                     k))
-                                (range 1 (inc (min max-modes (count all-modes)))))
-                          (count all-modes))
+                                (range 1 (inc (min max-modes n-all-modes))))
+                          n-all-modes)
           ;; Compute confidence intervals for modes
           modes-with-ci (kde/mode-confidence-intervals
                          samples bandwidth grid-arr validated-k
@@ -248,10 +251,10 @@
           modes-with-significance
           (vec (map-indexed
                 (fn [i mode]
-                  (let [k (inc i)
+                  (let [k (inc (long i))
                         test-result (get silverman-results k)
                         significant? (and test-result
-                                          (< (:p-value test-result) alpha))]
+                                          (< (double (:p-value test-result)) alpha))]
                     (assoc mode :significant? significant?)))
                 modes-with-ci))]
       {:modes modes-with-significance

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -210,15 +210,18 @@
   Takes KDE output and raw samples, runs multimodality test for k=1 up to max-modes,
   and computes confidence intervals for detected modes.
 
-  Supports two test methods:
-  - :acr (default) - ACR test using excess mass statistic, better calibrated
-  - :silverman - Silverman's bootstrap test using mode count"
+  Options:
+  - :method - test method, :acr (default) or :silverman
+  - :mode-method - mode finding method:
+    - :isj (default) - find modes from KDE density at ISJ bandwidth
+    - :critical - find modes at critical bandwidth for validated k modes
+  - :max-modes, :n-bootstrap, :alpha, :n-points - as usual"
   [kde-data samples outliers metric-config options]
   (try
     (let [{:keys [grid density bandwidth]} kde-data
-          {:keys [max-modes n-bootstrap alpha n-points method]
+          {:keys [max-modes n-bootstrap alpha n-points method mode-method]
            :or {max-modes 5 n-bootstrap 200 alpha 0.05 n-points 512
-                method :acr}} options
+                method :acr mode-method :isj}} options
           max-modes (long max-modes)
           alpha (double alpha)
           test-fn (case method
@@ -230,7 +233,7 @@
           samples (if-let [ols (:outliers outliers-data)]
                     (remove-outliers samples ols)
                     samples)
-          ;; Find modes from existing KDE density
+          ;; Find modes from existing KDE density (for initial mode count)
           grid-arr (double-array grid)
           density-arr (double-array density)
           all-modes (kde/find-modes grid-arr density-arr)
@@ -250,11 +253,37 @@
                                     k))
                                 (range 1 (inc (min max-modes n-all-modes))))
                           n-all-modes)
-          ;; Compute confidence intervals for modes
-          modes-with-ci (kde/mode-confidence-intervals
-                         samples bandwidth grid-arr validated-k
-                         {:n-bootstrap n-bootstrap
-                          :alpha alpha})
+          ;; Get mode locations based on mode-method
+          {:keys [modes-with-ci mode-bandwidth antimodes]}
+          (case mode-method
+            :critical
+            ;; Use critical bandwidth to find modes
+            (let [locate-result (kde/locate-modes samples validated-k
+                                                  {:n-points n-points})
+                  h-crit (:critical-bandwidth locate-result)
+                  ;; Build mode CIs at critical bandwidth
+                  sample-min (double (reduce min samples))
+                  sample-max (double (reduce max samples))
+                  sample-range (- sample-max sample-min)
+                  grid-step (/ sample-range (double (dec (long n-points))))
+                  crit-grid (double-array (range sample-min
+                                                 (+ sample-max 0.1)
+                                                 grid-step))
+                  modes-ci (kde/mode-confidence-intervals
+                            samples h-crit crit-grid validated-k
+                            {:n-bootstrap n-bootstrap
+                             :alpha alpha})]
+              {:modes-with-ci modes-ci
+               :mode-bandwidth h-crit
+               :antimodes (:antimodes locate-result)})
+
+            ;; :isj - use existing KDE density from ISJ bandwidth
+            {:modes-with-ci (kde/mode-confidence-intervals
+                             samples bandwidth grid-arr validated-k
+                             {:n-bootstrap n-bootstrap
+                              :alpha alpha})
+             :mode-bandwidth bandwidth
+             :antimodes nil})
           ;; Mark significance based on test results
           modes-with-significance
           (vec (map-indexed
@@ -265,18 +294,22 @@
                                           (< (double (:p-value test-result)) alpha))]
                     (assoc mode :significant? significant?)))
                 modes-with-ci))]
-      {:modes modes-with-significance
-       :n-modes validated-k
-       :test-results {:method method
-                      :k-tested (vec (keys test-results))
-                      :p-values (into {} (map (fn [[k v]] [k (:p-value v)])
-                                              test-results))
-                      :critical-bandwidths (into {} (map (fn [[k v]]
-                                                           [k (:critical-bandwidth v)])
-                                                         test-results))
-                      :excess-mass (when (= method :acr)
-                                     (into {} (map (fn [[k v]] [k (:excess-mass v)])
-                                                   test-results)))}})
+      (cond-> {:modes modes-with-significance
+               :n-modes validated-k
+               :test-results {:method method
+                              :k-tested (vec (keys test-results))
+                              :p-values (into {} (map (fn [[k v]] [k (:p-value v)])
+                                                      test-results))
+                              :critical-bandwidths (into {} (map (fn [[k v]]
+                                                                   [k (:critical-bandwidth v)])
+                                                                 test-results))
+                              :excess-mass (when (= method :acr)
+                                             (into {} (map (fn [[k v]] [k (:excess-mass v)])
+                                                           test-results)))}}
+        ;; Include mode-method and mode-bandwidth when using critical
+        (= mode-method :critical) (assoc :mode-method :critical
+                                         :mode-bandwidth mode-bandwidth
+                                         :antimodes antimodes)))
     (catch Exception e
       (when-not (#{:kde/no-data :kde/constant-data}
                  (:error (ex-data e)))

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -285,15 +285,20 @@
              :mode-bandwidth bandwidth
              :antimodes nil})
           ;; Mark significance based on test results
+          ;; For ACR, all validated modes are significant by construction
+          ;; (validated-k is the number of modes supported by the test)
           modes-with-significance
-          (vec (map-indexed
-                (fn [i mode]
-                  (let [k (inc (long i))
-                        test-result (get test-results k)
-                        significant? (and test-result
-                                          (< (double (:p-value test-result)) alpha))]
-                    (assoc mode :significant? significant?)))
-                modes-with-ci))]
+          (if (= method :acr)
+            (mapv #(assoc % :significant? true) modes-with-ci)
+            ;; For Silverman, use per-k p-value check
+            (vec (map-indexed
+                  (fn [i mode]
+                    (let [k (inc (long i))
+                          test-result (get test-results k)
+                          significant? (and test-result
+                                            (< (double (:p-value test-result)) alpha))]
+                      (assoc mode :significant? significant?)))
+                  modes-with-ci)))]
       (cond-> {:modes modes-with-significance
                :n-modes validated-k
                :test-results {:method method

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -206,16 +206,24 @@
 
 (defn modes-for-metric
   "Compute modes with statistical validation for a single metric.
-  
-  Takes KDE output and raw samples, runs Silverman's test for k=1 up to max-modes,
-  and computes confidence intervals for detected modes."
+
+  Takes KDE output and raw samples, runs multimodality test for k=1 up to max-modes,
+  and computes confidence intervals for detected modes.
+
+  Supports two test methods:
+  - :acr (default) - ACR test using excess mass statistic, better calibrated
+  - :silverman - Silverman's bootstrap test using mode count"
   [kde-data samples outliers metric-config options]
   (try
     (let [{:keys [grid density bandwidth]} kde-data
-          {:keys [max-modes n-bootstrap alpha n-points]
-           :or {max-modes 5 n-bootstrap 200 alpha 0.05 n-points 512}} options
+          {:keys [max-modes n-bootstrap alpha n-points method]
+           :or {max-modes 5 n-bootstrap 200 alpha 0.05 n-points 512
+                method :acr}} options
           max-modes (long max-modes)
           alpha (double alpha)
+          test-fn (case method
+                    :acr kde/acr-test
+                    :silverman kde/silverman-test)
           p (:path metric-config)
           ;; Filter outliers from samples
           outliers-data (get-in outliers p)
@@ -227,18 +235,18 @@
           density-arr (double-array density)
           all-modes (kde/find-modes grid-arr density-arr)
           n-all-modes (long (count all-modes))
-          ;; Run Silverman's test for each k from 1 to max-modes
-          silverman-results
+          ;; Run multimodality test for each k from 1 to max-modes
+          test-results
           (into {}
                 (for [k (range 1 (inc (min max-modes n-all-modes)))]
-                  [k (kde/silverman-test samples k
-                                         {:n-bootstrap n-bootstrap
-                                          :n-points n-points
-                                          :alpha alpha})]))
+                  [k (test-fn samples k
+                              {:n-bootstrap n-bootstrap
+                               :n-points n-points
+                               :alpha alpha})]))
           ;; Determine validated number of modes
           ;; Find smallest k where p-value >= alpha (fail to reject H0: <= k modes)
           validated-k (or (some (fn [k]
-                                  (when (>= (double (get-in silverman-results [k :p-value])) alpha)
+                                  (when (>= (double (get-in test-results [k :p-value])) alpha)
                                     k))
                                 (range 1 (inc (min max-modes n-all-modes))))
                           n-all-modes)
@@ -247,24 +255,28 @@
                          samples bandwidth grid-arr validated-k
                          {:n-bootstrap n-bootstrap
                           :alpha alpha})
-          ;; Mark significance based on Silverman results
+          ;; Mark significance based on test results
           modes-with-significance
           (vec (map-indexed
                 (fn [i mode]
                   (let [k (inc (long i))
-                        test-result (get silverman-results k)
+                        test-result (get test-results k)
                         significant? (and test-result
                                           (< (double (:p-value test-result)) alpha))]
                     (assoc mode :significant? significant?)))
                 modes-with-ci))]
       {:modes modes-with-significance
        :n-modes validated-k
-       :silverman {:k-tested (vec (keys silverman-results))
-                   :p-values (into {} (map (fn [[k v]] [k (:p-value v)])
-                                           silverman-results))
-                   :critical-bandwidths (into {} (map (fn [[k v]]
-                                                        [k (:critical-bandwidth v)])
-                                                      silverman-results))}})
+       :test-results {:method method
+                      :k-tested (vec (keys test-results))
+                      :p-values (into {} (map (fn [[k v]] [k (:p-value v)])
+                                              test-results))
+                      :critical-bandwidths (into {} (map (fn [[k v]]
+                                                           [k (:critical-bandwidth v)])
+                                                         test-results))
+                      :excess-mass (when (= method :acr)
+                                     (into {} (map (fn [[k v]] [k (:excess-mass v)])
+                                                   test-results)))}})
     (catch Exception e
       (when-not (#{:kde/no-data :kde/constant-data}
                  (:error (ex-data e)))

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -173,11 +173,15 @@
      :transform collect-plan/identity-transforms}))
 
 (defn kde-for-metric
-  "Compute KDE for a single metric's samples."
-  [metric->values metric-config options]
+  "Compute KDE for a single metric's samples, filtering outliers if present."
+  [metric->values outliers metric-config options]
   (try
     (let [p (:path metric-config)
-          samples (metric->values p)]
+          samples (metric->values p)
+          outliers (get-in outliers p)
+          samples (if-let [ols (:outliers outliers)]
+                    (remove-outliers samples ols)
+                    samples)]
       (when (seq samples)
         (kde/kde samples options)))
     (catch clojure.lang.ExceptionInfo e
@@ -186,12 +190,13 @@
           (throw e))))))
 
 (defmethod methods/kde :criterium/metrics-samples
-  [metrics-samples metric-configs options]
+  [metrics-samples outliers metric-configs options]
   (let [metric->values (util/metric->values metrics-samples)
+        outliers (when outliers (util/outliers outliers))
         kdes (->> metric-configs
                   (mapv
                    (juxt :path
-                         #(kde-for-metric metric->values % options)))
+                         #(kde-for-metric metric->values outliers % options)))
                   (filterv (comp some? second))
                   (into {}))]
     (when (seq kdes)

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -203,3 +203,88 @@
       {:type :criterium/kde
        :kdes kdes
        :transform collect-plan/identity-transforms})))
+
+(defn modes-for-metric
+  "Compute modes with statistical validation for a single metric.
+  
+  Takes KDE output and raw samples, runs Silverman's test for k=1 up to max-modes,
+  and computes confidence intervals for detected modes."
+  [kde-data samples outliers metric-config options]
+  (try
+    (let [{:keys [grid density bandwidth]} kde-data
+          {:keys [max-modes n-bootstrap alpha n-points]
+           :or {max-modes 5 n-bootstrap 200 alpha 0.05 n-points 512}} options
+          p (:path metric-config)
+          ;; Filter outliers from samples
+          outliers-data (get-in outliers p)
+          samples (if-let [ols (:outliers outliers-data)]
+                    (remove-outliers samples ols)
+                    samples)
+          ;; Find modes from existing KDE density
+          grid-arr (double-array grid)
+          density-arr (double-array density)
+          all-modes (kde/find-modes grid-arr density-arr)
+          ;; Run Silverman's test for each k from 1 to max-modes
+          silverman-results
+          (into {}
+                (for [k (range 1 (inc (min max-modes (count all-modes))))]
+                  [k (kde/silverman-test samples k
+                                         {:n-bootstrap n-bootstrap
+                                          :n-points n-points
+                                          :alpha alpha})]))
+          ;; Determine validated number of modes
+          ;; Find smallest k where p-value >= alpha (fail to reject H0: <= k modes)
+          validated-k (or (some (fn [k]
+                                  (when (>= (get-in silverman-results [k :p-value]) alpha)
+                                    k))
+                                (range 1 (inc (min max-modes (count all-modes)))))
+                          (count all-modes))
+          ;; Compute confidence intervals for modes
+          modes-with-ci (kde/mode-confidence-intervals
+                         samples bandwidth grid-arr validated-k
+                         {:n-bootstrap n-bootstrap
+                          :alpha alpha})
+          ;; Mark significance based on Silverman results
+          modes-with-significance
+          (vec (map-indexed
+                (fn [i mode]
+                  (let [k (inc i)
+                        test-result (get silverman-results k)
+                        significant? (and test-result
+                                          (< (:p-value test-result) alpha))]
+                    (assoc mode :significant? significant?)))
+                modes-with-ci))]
+      {:modes modes-with-significance
+       :n-modes validated-k
+       :silverman {:k-tested (vec (keys silverman-results))
+                   :p-values (into {} (map (fn [[k v]] [k (:p-value v)])
+                                           silverman-results))
+                   :critical-bandwidths (into {} (map (fn [[k v]]
+                                                        [k (:critical-bandwidth v)])
+                                                      silverman-results))}})
+    (catch Exception e
+      (when-not (#{:kde/no-data :kde/constant-data}
+                 (:error (ex-data e)))
+        (throw e)))))
+
+(defmethod methods/modes :criterium/kde
+  [kde-map samples outliers metric-configs options]
+  (let [kdes (:kdes kde-map)
+        metric->values (util/metric->values samples)
+        outliers (when outliers (util/outliers outliers))
+        modes-results
+        (->> metric-configs
+             (mapv
+              (fn [metric-config]
+                (let [p (:path metric-config)
+                      kde-data (get kdes p)
+                      sample-values (metric->values p)]
+                  (when (and kde-data sample-values)
+                    [p (modes-for-metric kde-data sample-values outliers
+                                         metric-config options)]))))
+             (filterv (comp some? second))
+             (into {}))]
+    (when (seq modes-results)
+      {:type :criterium/modes
+       :modes modes-results
+       :transform (:transform kde-map)})))

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -21,28 +21,28 @@
 
 (def default-with-warmup
   {:collector-config default-collector-config
-   :analyse          [:transform-log
-                      [:quantiles {:quantiles [0.9 0.99 0.99]}]
-                      :outliers
-                      [:stats {}]
-                      [:stats {:samples-id :log-samples :id :log-stats}]
-                      :event-stats
-                      :allocation-summary
-                      [:allocation-hotspots {:limit 10}]
-                      :allocation-by-type
-                      :allocation-treemap]
-   :view             [[:stats {:metric-ids [:memory]}]
-                      [:stats {:stats-id :log-stats}]
-                      :event-stats
-                      :outlier-counts
-                      :collect-plan
-                      :allocation-summary
-                      :allocation-hotspots
-                      :allocation-by-type
-                      :allocation-treemap
-                      #_[:final-gc-warnings
-                         {:warn-threshold 0.01}]]
-   :viewer           :print})
+   :analyse [:transform-log
+             [:quantiles {:quantiles [0.9 0.99 0.99]}]
+             :outliers
+             [:stats {}]
+             [:stats {:samples-id :log-samples :id :log-stats}]
+             :event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type
+             :allocation-treemap]
+   :view [[:stats {:metric-ids [:memory]}]
+          [:stats {:stats-id :log-stats}]
+          :event-stats
+          :outlier-counts
+          :collect-plan
+          :allocation-summary
+          :allocation-hotspots
+          :allocation-by-type
+          :allocation-treemap
+          #_[:final-gc-warnings
+             {:warn-threshold 0.01}]]
+   :viewer :print})
 
 (def log-histogram
   {:collector-config default-collector-config
@@ -98,6 +98,42 @@
           :collect-plan
           [:histogram {:stats-id :log-stats}]
           [:kde {:histogram-id :histograms}]
+          :sample-percentiles
+          :samples
+          :allocation-summary
+          :allocation-hotspots
+          :allocation-by-type
+          :allocation-treemap]
+   :viewer :print})
+
+(def kde-modes
+  "Benchmark plan with KDE and mode detection using Silverman's test.
+
+  Includes histogram, KDE, and statistically validated mode analysis.
+  Use when you need to detect and validate multimodality in sample distributions.
+  Mode detection tests from k=1 up to max-modes with Silverman's bootstrap test."
+  {:collector-config default-collector-config
+   :analyse [:transform-log
+             [:quantiles {:quantiles [0.9 0.99 0.99]}]
+             :outliers
+             [:stats {}]
+             [:stats {:samples-id :log-samples :id :log-stats}]
+             :histogram
+             :kde
+             :modes
+             :event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type
+             :allocation-treemap]
+   :view [[:stats {:metric-ids [:memory]}]
+          [:stats {:stats-id :log-stats}]
+          :quantiles
+          :event-stats
+          :outlier-counts
+          :collect-plan
+          [:histogram {:stats-id :log-stats}]
+          [:kde {:histogram-id :histograms :modes-id :modes}]
           :sample-percentiles
           :samples
           :allocation-summary

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -21,27 +21,28 @@
 
 (def default-with-warmup
   {:collector-config default-collector-config
-   :analyse [:transform-log
-             [:quantiles {:quantiles [0.9 0.99 0.99]}]
-             :outliers
-             [:stats {}]
-             [:stats {:samples-id :log-samples :id :log-stats}]
-             :event-stats
-             :allocation-summary
-             [:allocation-hotspots {:limit 10}]
-             :allocation-by-type
-             :allocation-treemap]
-   :view [[:stats {:metric-ids [:memory]}]
-          [:stats {:stats-id :log-stats}]
-          :event-stats
-          :collect-plan
-          :allocation-summary
-          :allocation-hotspots
-          :allocation-by-type
-          :allocation-treemap
-          #_[:final-gc-warnings
-             {:warn-threshold 0.01}]]
-   :viewer :print})
+   :analyse          [:transform-log
+                      [:quantiles {:quantiles [0.9 0.99 0.99]}]
+                      :outliers
+                      [:stats {}]
+                      [:stats {:samples-id :log-samples :id :log-stats}]
+                      :event-stats
+                      :allocation-summary
+                      [:allocation-hotspots {:limit 10}]
+                      :allocation-by-type
+                      :allocation-treemap]
+   :view             [[:stats {:metric-ids [:memory]}]
+                      [:stats {:stats-id :log-stats}]
+                      :event-stats
+                      :outlier-counts
+                      :collect-plan
+                      :allocation-summary
+                      :allocation-hotspots
+                      :allocation-by-type
+                      :allocation-treemap
+                      #_[:final-gc-warnings
+                         {:warn-threshold 0.01}]]
+   :viewer           :print})
 
 (def log-histogram
   {:collector-config default-collector-config

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -70,3 +70,37 @@
           :allocation-by-type
           :allocation-treemap]
    :viewer :print})
+
+(def kde-histogram
+  "Benchmark plan with KDE analysis for density estimation and mode detection.
+
+  Includes histogram and KDE analysis for visualizing sample distributions.
+  Not part of default-with-warmup; use explicitly when density analysis is needed."
+  {:collector-config default-collector-config
+   :analyse [:transform-log
+             [:quantiles {:quantiles [0.9 0.99 0.99]}]
+             :outliers
+             [:stats {}]
+             [:stats {:samples-id :log-samples :id :log-stats}]
+             :histogram
+             :kde
+             :event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type
+             :allocation-treemap]
+   :view [[:stats {:metric-ids [:memory]}]
+          [:stats {:stats-id :log-stats}]
+          :quantiles
+          :event-stats
+          :outlier-counts
+          :collect-plan
+          [:histogram {:stats-id :log-stats}]
+          [:kde {:histogram-id :histograms}]
+          :sample-percentiles
+          :samples
+          :allocation-summary
+          :allocation-hotspots
+          :allocation-by-type
+          :allocation-treemap]
+   :viewer :print})

--- a/bases/criterium/src/criterium/util/helpers.clj
+++ b/bases/criterium/src/criterium/util/helpers.clj
@@ -374,6 +374,11 @@
   Validation handled by malli instrumentation during development."
   [x] x)
 
+(defn ->modes-map
+  "Identity wrapper for modes-map construction.
+  Validation handled by malli instrumentation during development."
+  [x] x)
+
 (defn ->outlier-significance-map
   "Identity wrapper for outlier-significance-map construction.
   Validation handled by malli instrumentation during development."

--- a/bases/criterium/src/criterium/util/helpers.clj
+++ b/bases/criterium/src/criterium/util/helpers.clj
@@ -369,6 +369,11 @@
   Validation handled by malli instrumentation during development."
   [x] x)
 
+(defn ->kde-map
+  "Identity wrapper for kde-map construction.
+  Validation handled by malli instrumentation during development."
+  [x] x)
+
 (defn ->outlier-significance-map
   "Identity wrapper for outlier-significance-map construction.
   Validation handled by malli instrumentation during development."

--- a/bases/criterium/src/criterium/util/kde.clj
+++ b/bases/criterium/src/criterium/util/kde.clj
@@ -309,10 +309,166 @@
                    :ci-upper (stats/quantile alpha-high sorted))
             mode)))))))
 
+;;; Silverman's test for multimodality
+
+(defn count-modes
+  "Count number of modes in KDE with given bandwidth.
+  Creates a grid and counts local maxima in the density estimate."
+  ^long [data ^double bandwidth ^long n-points]
+  (let [data (vec data)
+        x-min (double (reduce min data))
+        x-max (double (reduce max data))
+        margin (/ (- x-max x-min) 10.0)
+        g-min (- x-min margin)
+        g-max (+ x-max margin)
+        g-range (- g-max g-min)
+        grid (double-array n-points)]
+    (dotimes [i n-points]
+      (aset grid i (+ g-min (* g-range (/ (double i) (double (dec n-points)))))))
+    (let [density (gaussian-kde data bandwidth grid)]
+      (count (find-modes grid density)))))
+
+(defn critical-bandwidth
+  "Find smallest bandwidth giving at most k modes via binary search.
+  
+  Returns the critical bandwidth h_k, which is the smallest bandwidth
+  such that the KDE has at most k modes.
+  
+  Parameters:
+  - data: sample values
+  - k: maximum number of modes
+  - opts: optional map with :tol (tolerance, default 1e-6), 
+          :n-points (grid size, default 512)"
+  ^double [data ^long k {:keys [tol n-points]
+                         :or {tol 1e-6
+                              n-points 512}}]
+  (let [data (vec data)
+        n-pts (long n-points)
+        tol (double tol)
+        sigma (Math/sqrt (double (stats/variance data)))
+        ;; Start with range from very small to Silverman bandwidth * 2
+        h-max (* 2.0 (silverman-bandwidth data))
+        h-min (/ sigma 100.0)]
+    ;; Binary search for smallest h with <= k modes
+    (loop [lo h-min
+           hi h-max
+           its 0]
+      (if (or (>= its 100) (< (- hi lo) (* tol (+ hi lo) 0.5)))
+        hi
+        (let [mid (* 0.5 (+ lo hi))
+              n-modes (count-modes data mid n-pts)]
+          (if (<= n-modes k)
+            ;; Can achieve <= k modes, try smaller bandwidth
+            (recur lo mid (inc its))
+            ;; Too many modes, need larger bandwidth
+            (recur mid hi (inc its))))))))
+
+(defn silverman-bootstrap-sample
+  "Generate a smoothed bootstrap sample for Silverman's test.
+  
+  Uses rescaled bootstrap from Silverman (1981):
+  y_i = mean + (X*_i - mean + h * epsilon_i) / sqrt(1 + h²/σ²)
+  
+  This ensures the bootstrap sample has the same variance as the original."
+  [data ^double bandwidth rng]
+  (let [n (count data)
+        sigma-sq (double (stats/variance data))
+        mean-val (double (stats/mean data))
+        scale (Math/sqrt (+ 1.0 (/ (* bandwidth bandwidth) sigma-sq)))
+        ;; Sample with replacement - this consumes n random values
+        resampled (vec (stats/sample data rng))
+        ;; Get 2*n more random values for Box-Muller pairs
+        rng-rest (drop n rng)
+        u-pairs (take (* 2 n) rng-rest)
+        u-vec (vec u-pairs)
+        ;; Generate smoothed sample
+        result (double-array n)]
+    (dotimes [i n]
+      (let [x-star (double (nth resampled i))
+            ;; Box-Muller for normal random
+            u1 (max 1e-10 (double (nth u-vec (* 2 i))))
+            u2 (double (nth u-vec (inc (* 2 i))))
+            epsilon (* (Math/sqrt (* -2.0 (Math/log u1)))
+                       (Math/cos (* 2.0 Math/PI u2)))
+            y (+ mean-val (/ (+ (- x-star mean-val) (* bandwidth epsilon)) scale))]
+        (aset result i y)))
+    (vec result)))
+
+(defn- hall-york-lambda
+  "Hall-York asymptotic correction factor for k=1.
+  
+  Approximation from Hall & York (2001) Table 2.
+  λ_α ≈ a + b*α + c*α² where coefficients fit the asymptotic distribution."
+  ^double [^double alpha]
+  ;; Approximate formula based on Hall-York (2001) 
+  ;; For α = 0.05, λ ≈ 1.06; for α = 0.10, λ ≈ 1.05
+  (let [a 1.07
+        b -0.11
+        c 0.08]
+    (+ a (* b alpha) (* c alpha alpha))))
+
+(defn silverman-test
+  "Silverman's bootstrap test for H0: at most k modes.
+  
+  Tests the null hypothesis that the underlying density has at most k modes.
+  For k=1, applies Hall-York asymptotic correction for better calibration.
+  For k>1, uses standard bootstrap (may be conservative).
+  
+  Parameters:
+  - data: sample values
+  - k: number of modes under H0
+  - opts: optional map with:
+    - :n-bootstrap (default 200)
+    - :n-points (default 512)
+    - :alpha (for Hall-York correction, default 0.05)
+    - :tol (for critical bandwidth search, default 1e-6)
+    - :rng-factory (default: WELL RNG)
+  
+  Returns map with:
+  - :k - number of modes tested
+  - :critical-bandwidth - bandwidth giving exactly k modes  
+  - :p-value - proportion of bootstrap samples with > k modes
+  - :corrected? - whether Hall-York correction was applied"
+  [data ^long k {:keys [n-bootstrap n-points alpha tol rng-factory]
+                 :or {n-bootstrap 200
+                      n-points 512
+                      alpha 0.05
+                      tol 1e-6
+                      rng-factory #(well/well-rng-1024a)}}]
+  (let [data (vec data)
+        n-pts (long n-points)
+        ;; Find critical bandwidth
+        h-crit (double (critical-bandwidth data k {:tol tol :n-points n-pts}))
+        ;; Bootstrap: count how many times we get > k modes
+        exceeds (atom 0)]
+    (dotimes [_ n-bootstrap]
+      (let [rng (rng-factory)
+            ;; Generate smoothed bootstrap sample using the helper function
+            boot-sample (silverman-bootstrap-sample data h-crit rng)
+            ;; Count modes with critical bandwidth
+            boot-modes (count-modes boot-sample h-crit n-pts)]
+        (when (> boot-modes k)
+          (swap! exceeds inc))))
+    ;; Calculate p-value
+    (let [raw-p (/ (double @exceeds) (double n-bootstrap))
+          ;; Apply Hall-York correction for k=1
+          corrected? (= k 1)
+          p-value (if corrected?
+                    (let [lambda (hall-york-lambda alpha)]
+                      ;; Correction adjusts the critical bandwidth
+                      ;; Here we approximate by scaling the p-value
+                      (min 1.0 (* raw-p lambda)))
+                    raw-p)]
+      {:k k
+       :critical-bandwidth h-crit
+       :p-value p-value
+       :raw-p-value raw-p
+       :corrected? corrected?})))
+
 ;;; Main KDE function
 
 (defn kde
-  "Compute complete KDE analysis on sample data.
+  "Compute KDE analysis on sample data.
 
   Parameters:
   - data: vector of sample values
@@ -320,7 +476,6 @@
     - :n-points: grid size (default 512)
     - :bandwidth: override bandwidth (default: ISJ selection)
     - :n-bootstrap: bootstrap samples for confidence bands (default 200)
-    - :n-modes: maximum modes to detect (default 5)
     - :alpha: confidence level (default 0.05)
     - :rng-factory: RNG factory function
 
@@ -331,13 +486,14 @@
   - :density: density values at grid points
   - :lower-band: lower confidence band
   - :upper-band: upper confidence band
-  - :modes: vector of detected modes with CIs
-  - :n: sample size"
+  - :n: sample size
+  
+  Note: Mode detection is now a separate analysis step. Use silverman-test
+  and mode-confidence-intervals for statistical mode analysis."
   ([data] (kde data {}))
-  ([data {:keys [n-points bandwidth n-bootstrap n-modes alpha rng-factory]
+  ([data {:keys [n-points bandwidth n-bootstrap alpha rng-factory]
           :or {n-points 512
                n-bootstrap 200
-               n-modes 5
                alpha 0.05
                rng-factory #(well/well-rng-1024a)}}]
    (when (empty? data)
@@ -365,16 +521,11 @@
            bands (kde-confidence-bands data h grid
                                        {:n-bootstrap n-bootstrap
                                         :alpha alpha
-                                        :rng-factory rng-factory})
-           modes (mode-confidence-intervals data h grid n-modes
-                                            {:n-bootstrap n-bootstrap
-                                             :alpha alpha
-                                             :rng-factory rng-factory})]
+                                        :rng-factory rng-factory})]
        {:type :criterium/kde
         :bandwidth h
         :grid (vec grid)
         :density (vec density)
         :lower-band (vec (:lower bands))
         :upper-band (vec (:upper bands))
-        :modes modes
         :n n}))))

--- a/bases/criterium/src/criterium/util/kde.clj
+++ b/bases/criterium/src/criterium/util/kde.clj
@@ -690,6 +690,61 @@
        :raw-p-value raw-p
        :corrected? corrected?})))
 
+(defn acr-test
+  "ACR test for H0: at most k modes.
+  
+  Combines critical bandwidth and excess mass approaches from
+  Ameijeiras-Alonso, Crujeiras, and Rodríguez-Casal (2019).
+  
+  Unlike Silverman's test which uses mode count as test statistic,
+  ACR uses excess mass which provides better calibration.
+  
+  Parameters:
+  - data: sample values
+  - k: number of modes under H0
+  - opts: optional map with:
+    - :n-bootstrap (default 200)
+    - :n-points (default 512) 
+    - :tol (for critical bandwidth search, default 1e-6)
+    - :rng-factory (default: WELL RNG)
+  
+  Returns map with:
+  - :k - number of modes tested
+  - :excess-mass - observed excess mass statistic
+  - :critical-bandwidth - bandwidth giving exactly k modes
+  - :p-value - proportion of bootstrap excess masses >= observed
+  
+  Reference: Ameijeiras-Alonso et al. (2019) 'Mode testing, critical
+  bandwidth and excess mass' TEST 28, 900-919"
+  [data ^long k {:keys [n-bootstrap n-points tol rng-factory]
+                 :or {n-bootstrap 200
+                      n-points 512
+                      tol 1e-6
+                      rng-factory #(well/well-rng-1024a)}}]
+  (let [data (vec data)
+        n-pts (long n-points)
+        ;; Find critical bandwidth
+        h-crit (double (critical-bandwidth data k {:tol tol :n-points n-pts}))
+        ;; Compute observed excess mass statistic
+        observed-em (:statistic (excess-mass data k {:rng-factory rng-factory}))
+        observed-em (double observed-em)
+        ;; Bootstrap: count how many times bootstrap excess mass >= observed
+        exceeds (atom 0)]
+    (dotimes [_ n-bootstrap]
+      (let [rng (rng-factory)
+            ;; Generate smoothed bootstrap sample at critical bandwidth
+            boot-sample (silverman-bootstrap-sample data h-crit rng)
+            ;; Compute excess mass for bootstrap sample
+            boot-em (:statistic (excess-mass boot-sample k {:rng-factory rng-factory}))]
+        (when (>= (double boot-em) observed-em)
+          (swap! exceeds inc))))
+    ;; Calculate p-value
+    (let [p-value (/ (double @exceeds) (double n-bootstrap))]
+      {:k k
+       :excess-mass observed-em
+       :critical-bandwidth h-crit
+       :p-value p-value})))
+
 ;;; Main KDE function
 
 (defn kde

--- a/bases/criterium/src/criterium/util/kde.clj
+++ b/bases/criterium/src/criterium/util/kde.clj
@@ -7,6 +7,231 @@
    [criterium.util.stats :as stats]
    [criterium.util.well :as well]))
 
+;;; Excess Mass computation (Müller-Sawitzki 1991)
+
+(defn- add-jitter
+  "Add small uniform jitter to handle ties in data.
+  Perturbs each point by ±mindist/2 where mindist is the smallest
+  non-zero distance between points."
+  ^doubles [^doubles sorted-data rng]
+  (let [n (alength sorted-data)]
+    (if (< n 2)
+      sorted-data
+      (let [;; Find minimum non-zero distance
+            min-dist-raw (loop [i (long 1)
+                                md Double/MAX_VALUE]
+                           (if (< i n)
+                             (let [d (- (aget sorted-data i) (aget sorted-data (dec i)))]
+                               (recur (inc i)
+                                      (if (> d 0.0) (Math/min md d) md)))
+                             md))
+            min-dist (double (if (= min-dist-raw Double/MAX_VALUE) 1e-10 min-dist-raw))
+            half-dist (/ min-dist 2.0)
+            result (double-array n)
+            rng-seq (take n rng)]
+        (loop [i (long 0)
+               rs (seq rng-seq)]
+          (when (< i n)
+            (let [r (double (first rs))
+                  jitter (- (* 2.0 r half-dist) half-dist)]
+              (aset result i (+ (aget sorted-data i) jitter))
+              (recur (inc i) (rest rs)))))
+        result))))
+
+(defn- build-distance-matrix
+  "Build upper-triangular distance matrix.
+  A[i,j] = data[j] - data[i] for j > i.
+  Returns a flat array in row-major order for upper triangle."
+  ^doubles [^doubles sorted-data]
+  (let [n (long (alength sorted-data))
+        ;; Number of entries in upper triangle (excluding diagonal)
+        size (long (/ (* n (dec n)) 2))
+        result (double-array size)]
+    (loop [i (long 0)
+           idx (long 0)]
+      (when (< i (dec n))
+        (loop [j (long (inc i))
+               idx2 idx]
+          (when (< j n)
+            (aset result idx2 (- (aget sorted-data j) (aget sorted-data i)))
+            (recur (inc j) (inc idx2))))
+        (recur (inc i) (+ idx (- n 1 i)))))
+    result))
+
+(defn- distance-at
+  "Get distance A[i,j] from flat upper triangular array.
+  Requires i < j."
+  ^double [^doubles dist-arr ^long n ^long i ^long j]
+  (let [;; Index in flattened upper triangular array
+        ;; For row i, entries start at: i*n - i*(i+1)/2
+        row-start (- (* i n) (long (/ (* i (inc i)) 2)))
+        ;; Column offset within row (j - i - 1)
+        col-offset (- j i 1)]
+    (aget dist-arr (+ row-start col-offset))))
+
+(defn- compute-interval-distances
+  "Compute minimum cumulative distances for k disjoint intervals.
+  
+  For each 'span' (total points covered by k intervals), find the
+  minimum total distance (sum of interval widths) achievable.
+  
+  Returns vector where element i is the min distance for span (i+k)."
+  ^doubles [^doubles dist-arr ^long n ^long k]
+  (if (= k 1)
+    ;; For k=1, min distance for span s is simply the min interval of that span
+    (let [result (double-array (- n 1))]
+      (dotimes [span (- n 1)]
+        (let [interval-size (long (inc span))
+              min-d (double
+                     (loop [start (long 0)
+                            md Double/MAX_VALUE]
+                       (if (< (+ start interval-size) n)
+                         (let [end (+ start interval-size)
+                               d (distance-at dist-arr n start end)]
+                           (recur (inc start) (Math/min md d)))
+                         md)))]
+          (aset result (int span) min-d)))
+      result)
+    ;; For k>1, build on k-1 solution
+    (let [^doubles prev-mins (compute-interval-distances dist-arr n (dec k))
+          prev-len (long (alength prev-mins))
+          result-len (- n k)
+          result (double-array result-len)]
+      (dotimes [span result-len]
+        (let [total-span (long (+ span k 1))
+              min-d (double
+                     (loop [new-int-size (long 2)
+                            md Double/MAX_VALUE]
+                       (if (<= new-int-size (- total-span (* 2 (dec k))))
+                         (let [prev-span (long (- total-span new-int-size))
+                               prev-idx (long (- prev-span k))
+                               prev-d (if (and (>= prev-idx 0) (< prev-idx prev-len))
+                                        (aget prev-mins prev-idx)
+                                        Double/MAX_VALUE)
+                               new-d (loop [start (long (- total-span new-int-size))
+                                            nd Double/MAX_VALUE]
+                                       (if (>= start prev-span)
+                                         (if (< (+ start new-int-size) n)
+                                           (let [end (+ start (dec new-int-size))
+                                                 d (distance-at dist-arr n start end)]
+                                             (recur (dec start) (Math/min nd d)))
+                                           (recur (dec start) nd))
+                                         nd))]
+                           (recur (inc new-int-size) (Math/min md (+ prev-d (double new-d)))))
+                         md)))]
+          (aset result (int span) min-d)))
+      result)))
+
+(defn excess-mass
+  "Compute excess mass statistic for testing k modes.
+  
+  The excess mass test statistic is max_λ{E_{n,k+1}(P_n,λ) - E_{n,k}(P_n,λ)}
+  where E_{n,k}(P_n,λ) = sup{∑P_n(C_m) - λ|C_m|} over k disjoint intervals
+  with endpoints at data points.
+  
+  Parameters:
+  - data: sample values (will be sorted internally)
+  - k: number of modes to test (tests H0: at most k modes)
+  - opts: optional map with:
+    - :rng-factory: RNG factory for jitter (default: WELL RNG)
+  
+  Returns map with:
+  - :statistic - the excess mass test statistic
+  - :k - number of modes tested
+  - :n - sample size
+  
+  Reference: Müller, D.W. and Sawitzki, G. (1991) 'Excess Mass Estimates
+  and Tests for Multimodality' JASA 86, 738-746"
+  ([data k] (excess-mass data k {}))
+  ([data k {:keys [rng-factory]
+            :or {rng-factory #(well/well-rng-1024a)}}]
+   (let [data (vec data)
+         n (long (count data))
+         k (long k)]
+     (when (< n 3)
+       (throw (ex-info "Need at least 3 data points for excess mass"
+                       {:error :excess-mass/insufficient-data
+                        :n n})))
+     (when (< k 1)
+       (throw (ex-info "k must be at least 1"
+                       {:error :excess-mass/invalid-k
+                        :k k})))
+     (let [sorted-data (double-array (sort data))
+           ;; Check for ties and add jitter if needed
+           has-ties? (loop [i (long 1)]
+                       (if (< i n)
+                         (if (= (aget sorted-data i) (aget sorted-data (dec i)))
+                           true
+                           (recur (inc i)))
+                         false))
+           sorted-data (if has-ties?
+                         (let [jittered (add-jitter sorted-data (rng-factory))]
+                           (java.util.Arrays/sort jittered)
+                           jittered)
+                         sorted-data)
+           ;; Build distance matrix
+           dist-arr (build-distance-matrix sorted-data)
+           nd (double n)
+           ;; Compute min distances for spans of k and k+1 intervals
+           ^doubles min-dist-k (compute-interval-distances dist-arr n k)
+           ^doubles min-dist-k1 (compute-interval-distances dist-arr n (inc k))
+           len-k (long (alength min-dist-k))
+           len-k1 (long (alength min-dist-k1))
+           ;; Find all possible lambda values where transitions occur
+           lambdas (atom #{})
+           _ (dotimes [i (dec len-k)]
+               (let [i (long i)
+                     p1 (/ (double (+ i k 1)) nd)
+                     p2 (/ (double (+ i k 2)) nd)
+                     d1 (aget min-dist-k i)
+                     d2 (aget min-dist-k (inc i))
+                     dd (double (- d2 d1))]
+                 (when (> (Math/abs dd) 1e-15)
+                   (let [lam (/ (- p2 p1) dd)]
+                     (when (pos? lam)
+                       (swap! lambdas conj lam))))))
+           _ (dotimes [i (dec len-k1)]
+               (let [i (long i)
+                     p1 (/ (double (+ i k 2)) nd)
+                     p2 (/ (double (+ i k 3)) nd)
+                     d1 (aget min-dist-k1 i)
+                     d2 (aget min-dist-k1 (inc i))
+                     dd (double (- d2 d1))]
+                 (when (> (Math/abs dd) 1e-15)
+                   (let [lam (/ (- p2 p1) dd)]
+                     (when (pos? lam)
+                       (swap! lambdas conj lam))))))
+           lambda-vec (vec (sort @lambdas))
+           ;; For each lambda, compute excess mass difference
+           compute-em (fn ^double [^double lam ^long num-k ^doubles min-dists ^long len]
+                        (loop [span (long 0)
+                               max-em Double/NEGATIVE_INFINITY]
+                          (if (< span len)
+                            (let [p (/ (double (+ span num-k 1)) nd)
+                                  d (aget min-dists span)
+                                  em (- p (* lam d))]
+                              (recur (inc span) (Math/max max-em em)))
+                            max-em)))
+           ;; Compute max difference over all lambdas
+           max-diff (double
+                     (if (empty? lambda-vec)
+                       (let [lam 1.0
+                             em-k (double (compute-em lam k min-dist-k len-k))
+                             em-k1 (double (compute-em lam (inc k) min-dist-k1 len-k1))]
+                         (- em-k1 em-k))
+                       (loop [idx (long 0)
+                              max-d Double/NEGATIVE_INFINITY]
+                         (if (< idx (count lambda-vec))
+                           (let [lam (double (nth lambda-vec idx))
+                                 em-k (double (compute-em lam k min-dist-k len-k))
+                                 em-k1 (double (compute-em lam (inc k) min-dist-k1 len-k1))
+                                 d (- em-k1 em-k)]
+                             (recur (inc idx) (Math/max max-d d)))
+                           max-d))))]
+       {:statistic (Math/max 0.0 max-diff)
+        :k k
+        :n n}))))
+
 ;;; DCT-II implementation
 
 (defn dct-ii

--- a/bases/criterium/src/criterium/util/kde.clj
+++ b/bases/criterium/src/criterium/util/kde.clj
@@ -588,6 +588,70 @@
             ;; Too many modes, need larger bandwidth
             (recur mid hi (inc its))))))))
 
+(defn- find-antimodes
+  "Find antimodes (local minima) in a density estimate.
+  Returns vector of maps with :location and :density for each antimode,
+  sorted by location (left to right)."
+  [^doubles grid ^doubles density]
+  (let [n (alength density)]
+    (->> (loop [i 1
+                result []]
+           (if (< i (dec n))
+             (let [d-prev (aget density (dec i))
+                   d-curr (aget density i)
+                   d-next (aget density (inc i))]
+               (if (and (< d-curr d-prev)
+                        (< d-curr d-next))
+                 (recur (inc i)
+                        (conj result {:location (aget grid i)
+                                      :density d-curr}))
+                 (recur (inc i) result)))
+             result))
+         (sort-by :location)
+         vec)))
+
+(defn locate-modes
+  "Find mode and antimode locations using critical bandwidth.
+
+  Given target number of modes k, finds the critical bandwidth h_k
+  (smallest bandwidth with at most k modes) and locates both modes
+  (local maxima) and antimodes (local minima) at that bandwidth.
+
+  Parameters:
+  - data: sample values
+  - k: target number of modes
+  - opts: optional map with :n-points (grid size, default 512),
+          :tol (tolerance, default 1e-6)
+
+  Returns:
+  {:modes [{:location, :density} ...] - sorted by location
+   :antimodes [{:location, :density} ...] - sorted by location
+   :critical-bandwidth h_k}"
+  [data ^long k {:keys [n-points tol]
+                 :or {n-points 512
+                      tol 1e-6}}]
+  (let [data (vec data)
+        n-pts (long n-points)
+        h (critical-bandwidth data k {:n-points n-pts :tol tol})
+        x-min (double (reduce min data))
+        x-max (double (reduce max data))
+        margin (/ (- x-max x-min) 10.0)
+        g-min (- x-min margin)
+        g-max (+ x-max margin)
+        g-range (- g-max g-min)
+        grid (double-array n-pts)]
+    (dotimes [i n-pts]
+      (aset grid i (+ g-min (* g-range (/ (double i) (double (dec n-pts)))))))
+    (let [density (gaussian-kde data h grid)
+          modes (->> (find-modes grid density)
+                     (map #(dissoc % :index))
+                     (sort-by :location)
+                     vec)
+          antimodes (find-antimodes grid density)]
+      {:modes modes
+       :antimodes antimodes
+       :critical-bandwidth h})))
+
 (defn silverman-bootstrap-sample
   "Generate a smoothed bootstrap sample for Silverman's test.
   

--- a/bases/criterium/src/criterium/util/kde.clj
+++ b/bases/criterium/src/criterium/util/kde.clj
@@ -1,60 +1,380 @@
-(ns criterium.util.kde)
+(ns criterium.util.kde
+  "Kernel Density Estimation utilities.
 
-;; Mellin-Meijer-kernel density estimation on R+. Gery Geenens∗ School of
-;; Mathematics and Statistics, UNSW Sydney, Australia July 17, 2017
+  Provides ISJ (Improved Sheather-Jones) bandwidth selection, Gaussian kernel
+  density estimation, bootstrap confidence bands, and mode finding."
+  (:require
+   [criterium.util.stats :as stats]
+   [criterium.util.well :as well]))
 
-(defn gamma-fn
-  "Returns Gamma(z + 1 = number) using Lanczos approximation.
-  Taken from rosettacode."
-  ^double [^double number]
-  (if (< number 0.5)
-    (/ Math/PI (* (Math/sin (* Math/PI number))
-                  (gamma-fn (- 1 number))))
-    (let [n (dec number)
-          c [0.99999999999980993 676.5203681218851 -1259.1392167224028
-             771.32342877765313 -176.61502916214059 12.507343278686905
-             -0.13857109526572012 9.9843695780195716e-6 1.5056327351493116e-7]]
-      (* (Math/sqrt (* 2.0 Math/PI))
-         (Math/pow (+ n 7 0.5) (+ n 0.5))
-         (Math/exp (- (+ n 7 0.5)))
-         (+ (double (first c))
-            (double
-             (reduce
-              +
-              (map-indexed #(/ (double %2) (+ n (long %1) 1)) (next c)))))))))
+;;; DCT-II implementation
 
-(comment
-  (gamma-fn 1)  ; 1
-  (gamma-fn 2)  ; 1
-  (gamma-fn 3)  ; 2
-  (gamma-fn 4)  ; 6
-  (gamma-fn 5)  ; 24
-  )
+(defn dct-ii
+  "Discrete Cosine Transform Type II.
+  Direct O(n²) implementation without FFT dependency.
 
-(defn mellin-transform
-  "Mellin transform.
+  DCT-II formula: X_k = sum_{n=0}^{N-1} x_n * cos(π/N * (n + 0.5) * k)
 
-  Mellin-Meijer-kernel density estimation on R+. Gery Geenens∗ School of
-  Mathematics and Statistics, UNSW Sydney, Australia July 17, 2017
+  Returns vector of N DCT coefficients."
+  ^doubles [^doubles data]
+  (let [n (alength data)
+        result (double-array n)
+        pi-n (/ Math/PI (double n))]
+    (dotimes [k n]
+      (let [kd (double k)
+            sum (double
+                 (loop [i 0
+                        acc 0.0]
+                   (if (< i n)
+                     (recur (inc i)
+                            (+ acc (* (aget data i)
+                                      (Math/cos (* pi-n (+ (double i) 0.5) kd)))))
+                     acc)))]
+        (aset result k sum)))
+    result))
 
-  Eq, 2.19"
-  [nu gamma zeta theta z]
-  (let [^double nu    nu
-        ^double gamma gamma
-        ^double zeta  zeta
-        ^double theta theta
-        ^double z     z
-        tan-theta     (Math/tan theta)
-        cos-theta     (Math/cos theta)
-        ;; sin-theta (Math/sin theta)
-        a1            (/ (* zeta zeta) (* gamma gamma cos-theta cos-theta))
-        a2            (/ (* zeta zeta) (* gamma gamma cos-theta cos-theta))
-        e1            (+ a1 (* zeta (- z 1)))
-        e2            (+ a2 (* zeta (- 1 z)))]
-    (* (Math/pow nu (- z 1))
-       (Math/pow (/ 1 (* tan-theta tan-theta)) (* zeta (- z 1)))
-       (/ (* (gamma-fn e1) (gamma-fn e2))
-          (* (gamma-fn a1) (gamma-fn a2))))))
+;;; Linear binning
 
-;; (mellin-transform 1 1 1 0 1)
-;; (mellin-transform 3 1 2 0 1)
+(defn linear-bin
+  "Bin data onto a regular grid using linear interpolation.
+  Returns vector of bin weights that sum to 1.0.
+
+  Each data point contributes to two adjacent bins proportionally
+  to its distance from bin centers."
+  ^doubles [data ^doubles grid]
+  (let [n (alength grid)
+        weights (double-array n)
+        x-min (aget grid 0)
+        x-max (aget grid (dec n))
+        dx (/ (- x-max x-min) (dec n))
+        n-data (count data)]
+    (doseq [x data]
+      (let [x (double x)
+            ;; Clamp to grid range
+            x (max x-min (min x-max x))
+            ;; Find position in grid
+            pos (/ (- x x-min) dx)
+            i-low (long (Math/floor pos))
+            i-low (min i-low (- n 2))
+            i-high (inc i-low)
+            ;; Linear interpolation weights
+            w-high (- pos i-low)
+            w-low (- 1.0 w-high)]
+        (aset weights i-low (+ (aget weights i-low) w-low))
+        (aset weights i-high (+ (aget weights i-high) w-high))))
+    ;; Normalize to sum to 1
+    (let [total (double n-data)]
+      (dotimes [i n]
+        (aset weights i (/ (aget weights i) total))))
+    weights))
+
+;;; ISJ bandwidth selection
+
+(defn- fixed-point
+  "Fixed-point function for ISJ bandwidth selection.
+  Equation from Botev et al. 'Kernel Density Estimation via Diffusion'."
+  ^double [^double t ^long n ^doubles i-sq ^doubles a2]
+  (let [n-terms (alength i-sq)
+        f (double
+           (loop [i 0
+                  sum 0.0]
+             (if (< i n-terms)
+               (let [i-val (aget i-sq i)
+                     a-val (aget a2 i)
+                     exp-t (* i-val i-val Math/PI Math/PI t)]
+                 (recur (inc i)
+                        (+ sum (* i-val i-val a-val
+                                  (Math/exp (* -2.0 exp-t))))))
+               sum)))]
+    (- (Math/pow
+        (/ (* 2.0 (double n) (Math/sqrt Math/PI) f)
+           1.0)
+        -0.4)
+       t)))
+
+(defn- isj-solve
+  "Solve for optimal ISJ bandwidth using bisection.
+  Returns t* parameter or nil if no solution found."
+  [^long n ^doubles i-sq ^doubles a2]
+  (let [tol 1e-12
+        max-t 1.0]
+    (loop [lo 1e-10
+           hi max-t
+           its 0]
+      (when (< its 100)
+        (let [mid (* 0.5 (+ lo hi))
+              f-mid (fixed-point mid n i-sq a2)]
+          (cond
+            (< (Math/abs f-mid) tol) mid
+            (< (Math/abs (- hi lo)) tol) mid
+            (neg? f-mid) (recur lo mid (inc its))
+            :else (recur mid hi (inc its))))))))
+
+(defn silverman-bandwidth
+  "Silverman's rule of thumb bandwidth selector.
+  h = 0.9 * min(σ, IQR/1.34) * n^(-1/5)
+
+  A simple fallback when ISJ doesn't converge."
+  ^double [data]
+  (let [n (count data)
+        sigma (Math/sqrt (stats/variance data))
+        sorted (sort data)
+        q1 (double (stats/quantile 0.25 sorted))
+        q3 (double (stats/quantile 0.75 sorted))
+        iqr (- q3 q1)
+        spread (min sigma (/ iqr 1.34))]
+    (* 0.9 spread (Math/pow (double n) -0.2))))
+
+(defn isj-bandwidth
+  "Improved Sheather-Jones bandwidth selector.
+
+  Uses DCT-based algorithm from Botev et al. for optimal bandwidth
+  selection that works well for multimodal distributions.
+
+  Falls back to Silverman's rule if ISJ doesn't converge or gives
+  an unreasonable result (bandwidth > half the data range)."
+  ^double [data]
+  (let [data (vec data)
+        n (count data)
+        n-grid 1024
+        x-min (double (reduce min data))
+        x-max (double (reduce max data))
+        r (- x-max x-min)]
+    (if (zero? r)
+      1e-10
+      (let [grid (double-array n-grid)
+            _ (dotimes [i n-grid]
+                (aset grid i (+ x-min (* r (/ (double i) (double (dec n-grid)))))))
+            binned (linear-bin data grid)
+            dct (dct-ii binned)
+            i-sq (double-array (dec n-grid))
+            a2 (double-array (dec n-grid))
+            _ (dotimes [i (dec n-grid)]
+                (let [k (inc i)]
+                  (aset i-sq i (double (* k k)))
+                  (aset a2 i (let [d (aget dct k)] (* d d)))))
+            t-star (isj-solve n i-sq a2)
+            h-isj (when t-star (* (Math/sqrt (double t-star)) r))
+            h-silv (silverman-bandwidth data)]
+        (if (and h-isj (< (double h-isj) (* 0.5 r)))
+          h-isj
+          h-silv)))))
+
+;;; Gaussian kernel density estimation
+
+(defn- gaussian-kernel
+  "Standard Gaussian kernel K(u) = (1/√2π) * exp(-u²/2)."
+  ^double [^double u]
+  (* (/ 1.0 (Math/sqrt (* 2.0 Math/PI)))
+     (Math/exp (* -0.5 u u))))
+
+(defn gaussian-kde
+  "Compute Gaussian kernel density estimate at grid points.
+
+  Parameters:
+  - data: vector of sample values
+  - bandwidth: kernel bandwidth (h)
+  - grid: vector of evaluation points
+
+  Returns vector of density values at each grid point."
+  ^doubles [data ^double bandwidth ^doubles grid]
+  (let [n (long (count data))
+        n-grid (alength grid)
+        density (double-array n-grid)
+        h bandwidth
+        nd (double n)
+        data-a (double-array data)]
+    (dotimes [i n-grid]
+      (let [x (aget grid i)
+            sum (double
+                 (loop [j 0
+                        acc 0.0]
+                   (if (< j n)
+                     (let [xj (aget data-a j)
+                           u (/ (- x xj) h)]
+                       (recur (inc j)
+                              (+ acc (gaussian-kernel u))))
+                     acc)))]
+        (aset density i (/ sum (* nd h)))))
+    density))
+
+;;; Mode finding
+
+(defn find-modes
+  "Find modes (local maxima) in a density estimate.
+
+  Returns vector of maps with :location and :density for each mode,
+  sorted by density (highest first)."
+  [^doubles grid ^doubles density]
+  (let [n (alength density)]
+    (->> (loop [i 1
+                result []]
+           (if (< i (dec n))
+             (let [d-prev (aget density (dec i))
+                   d-curr (aget density i)
+                   d-next (aget density (inc i))]
+               (if (and (> d-curr d-prev)
+                        (> d-curr d-next))
+                 (recur (inc i)
+                        (conj result {:location (aget grid i)
+                                      :density d-curr
+                                      :index i}))
+                 (recur (inc i) result)))
+             result))
+         (sort-by :density >)
+         vec)))
+
+;;; Bootstrap confidence bands
+
+(defn kde-bootstrap-sample
+  "Generate a bootstrap sample of KDE density at fixed grid points.
+  Uses the same bandwidth for all bootstrap iterations.
+  rng is a lazy sequence of random doubles in [0,1)."
+  [data ^double bandwidth ^doubles grid rng]
+  (let [resampled (stats/sample data rng)]
+    (gaussian-kde resampled bandwidth grid)))
+
+(defn kde-confidence-bands
+  "Compute bootstrap confidence bands for KDE.
+
+  Parameters:
+  - data: original sample data
+  - bandwidth: kernel bandwidth
+  - grid: evaluation grid points
+  - n-bootstrap: number of bootstrap samples (default 200)
+  - alpha: confidence level (default 0.05 for 95% CI)
+  - rng-factory: function returning RNG (default: WELL RNG)
+
+  Returns map with :lower and :upper vectors."
+  ([data bandwidth grid]
+   (kde-confidence-bands data bandwidth grid {}))
+  ([data bandwidth ^doubles grid {:keys [n-bootstrap alpha rng-factory]
+                                  :or {n-bootstrap 200
+                                       alpha 0.05
+                                       rng-factory #(well/well-rng-1024a)}}]
+   (let [n-grid (alength grid)
+         samples (vec (for [_ (range n-bootstrap)]
+                        (kde-bootstrap-sample data bandwidth grid (rng-factory))))
+         alpha-low (/ (double alpha) 2.0)
+         alpha-hi (- 1.0 alpha-low)
+         lower (double-array n-grid)
+         upper (double-array n-grid)]
+     (dotimes [i n-grid]
+       (let [point-samples (mapv #(aget ^doubles % i) samples)
+             sorted (sort point-samples)]
+         (aset lower i (double (stats/quantile alpha-low sorted)))
+         (aset upper i (double (stats/quantile alpha-hi sorted)))))
+     {:lower lower
+      :upper upper})))
+
+;;; Mode confidence intervals
+
+(defn mode-confidence-intervals
+  "Compute bootstrap confidence intervals for mode locations.
+
+  Parameters:
+  - data: original sample data
+  - bandwidth: kernel bandwidth
+  - grid: evaluation grid
+  - n-modes: number of modes to track (default 3)
+  - n-bootstrap: number of bootstrap samples (default 200)
+  - alpha: confidence level (default 0.05)
+  - rng-factory: function returning RNG
+
+  Returns vector of mode CIs, each with :location, :ci-lower, :ci-upper."
+  ([data bandwidth grid n-modes]
+   (mode-confidence-intervals data bandwidth grid n-modes {}))
+  ([data bandwidth ^doubles grid n-modes
+    {:keys [n-bootstrap alpha rng-factory]
+     :or {n-bootstrap 200
+          alpha 0.05
+          rng-factory #(well/well-rng-1024a)}}]
+   (let [density (gaussian-kde data bandwidth grid)
+         orig-modes (vec (take n-modes (find-modes grid density)))
+         boot-modes (vec (for [_ (range n-bootstrap)]
+                           (let [boot-density (kde-bootstrap-sample
+                                               data bandwidth grid (rng-factory))]
+                             (vec (take n-modes (find-modes grid boot-density))))))
+         alpha-low (/ (double alpha) 2.0)
+         alpha-high (- 1.0 alpha-low)]
+     (vec
+      (for [[i mode] (map-indexed vector orig-modes)]
+        (let [boot-locs (keep #(when-let [m (get % i)]
+                                 (:location m))
+                              boot-modes)
+              sorted (sort boot-locs)]
+          (if (seq sorted)
+            (assoc mode
+                   :ci-lower (stats/quantile alpha-low sorted)
+                   :ci-upper (stats/quantile alpha-high sorted))
+            mode)))))))
+
+;;; Main KDE function
+
+(defn kde
+  "Compute complete KDE analysis on sample data.
+
+  Parameters:
+  - data: vector of sample values
+  - opts: optional map with:
+    - :n-points: grid size (default 512)
+    - :bandwidth: override bandwidth (default: ISJ selection)
+    - :n-bootstrap: bootstrap samples for confidence bands (default 200)
+    - :n-modes: maximum modes to detect (default 5)
+    - :alpha: confidence level (default 0.05)
+    - :rng-factory: RNG factory function
+
+  Returns map with:
+  - :type :criterium/kde
+  - :bandwidth: selected or provided bandwidth
+  - :grid: evaluation points
+  - :density: density values at grid points
+  - :lower-band: lower confidence band
+  - :upper-band: upper confidence band
+  - :modes: vector of detected modes with CIs
+  - :n: sample size"
+  ([data] (kde data {}))
+  ([data {:keys [n-points bandwidth n-bootstrap n-modes alpha rng-factory]
+          :or {n-points 512
+               n-bootstrap 200
+               n-modes 5
+               alpha 0.05
+               rng-factory #(well/well-rng-1024a)}}]
+   (when (empty? data)
+     (throw (ex-info "Input data cannot be empty"
+                     {:error :kde/no-data})))
+   (let [data (vec data)
+         n (count data)
+         x-min (double (reduce min data))
+         x-max (double (reduce max data))]
+     (when (= x-min x-max)
+       (throw (ex-info "All values are the same - cannot compute KDE"
+                       {:error :kde/constant-data
+                        :value x-min})))
+     (let [margin (/ (- x-max x-min) 10.0)
+           g-min (- x-min margin)
+           g-max (+ x-max margin)
+           g-range (- g-max g-min)
+           n-pts (long n-points)
+           grid (double-array n-pts)
+           _ (dotimes [i n-pts]
+               (aset grid i (+ g-min (* g-range
+                                        (/ (double i) (double (dec n-pts)))))))
+           h (double (or bandwidth (isj-bandwidth data)))
+           density (gaussian-kde data h grid)
+           bands (kde-confidence-bands data h grid
+                                       {:n-bootstrap n-bootstrap
+                                        :alpha alpha
+                                        :rng-factory rng-factory})
+           modes (mode-confidence-intervals data h grid n-modes
+                                            {:n-bootstrap n-bootstrap
+                                             :alpha alpha
+                                             :rng-factory rng-factory})]
+       {:type :criterium/kde
+        :bandwidth h
+        :grid (vec grid)
+        :density (vec density)
+        :lower-band (vec (:lower bands))
+        :upper-band (vec (:upper bands))
+        :modes modes
+        :n n}))))

--- a/bases/criterium/src/criterium/view.clj
+++ b/bases/criterium/src/criterium/view.clj
@@ -24,6 +24,8 @@
 (def-multi-view event-stats)
 (def-multi-view final-gc-warnings)
 (def-multi-view histogram)
+
+(def-multi-view kde)
 (def-multi-view metrics)
 (def-multi-view os)
 (def-multi-view outlier-counts)
@@ -60,6 +62,8 @@
 (defmethod event-stats* :none [_ _ _])
 (defmethod final-gc-warnings* :none [_ _ _])
 (defmethod histogram* :none [_ _ _])
+
+(defmethod kde* :none [_ _ _])
 (defmethod metrics* :none [_ _ _])
 (defmethod os* :none [_ _ _])
 (defmethod outlier-counts* :none [_ _ _])

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -620,6 +620,7 @@
   "Build mode marker layers for KDE visualization.
   Takes modes-data from separate modes analysis (not from kde-data).
   Uses 'kde-density' field to match KDE curve scale.
+  Uses shape (not color) for significance to avoid color scale conflicts.
   Returns a vector of Vega-Lite layer specs (point markers and CI rules)."
   [modes-data metric-config transforms]
   (let [modes (:modes modes-data)
@@ -634,14 +635,16 @@
                    modes)]
     (when (seq data)
       ;; Return a vector of individual layers to avoid nested layer structure
+      ;; Use shape instead of color for significance to avoid color scale conflicts
       [{:data {:values data}
-        :mark {:type "point" :size 100}
+        :mark {:type "point" :size 150 :filled true}
         :encoding {:x {:field field-name :type "quantitative"}
                    :y {:field "kde-density" :type "quantitative"}
-                   :color {:field "significant" :type "nominal"
+                   :shape {:field "significant" :type "nominal"
                            :scale {:domain ["yes" "no"]
-                                   :range ["red" "orange"]}
-                           :legend {:title "Significant"}}
+                                   :range ["circle" "triangle-up"]}
+                           :legend {:title "Significant Mode"}}
+                   :color {:value "red"}
                    :tooltip [{:field field-name :type "quantitative"
                               :title "Mode Location"}
                              {:field "kde-density" :type "quantitative"
@@ -653,13 +656,15 @@
                              {:field "significant" :type "nominal"
                               :title "Significant"}]}}
        {:data {:values data}
-        :mark {:type "rule" :strokeWidth 1 :strokeDash [4 4]}
+        :mark {:type "rule" :strokeWidth 2}
         :encoding {:x {:field "ci-lower" :type "quantitative"}
                    :x2 {:field "ci-upper"}
                    :y {:field "kde-density" :type "quantitative"}
-                   :color {:field "significant" :type "nominal"
-                           :scale {:domain ["yes" "no"]
-                                   :range ["red" "orange"]}}}}])))
+                   :color {:value "red"}
+                   :strokeDash {:field "significant" :type "nominal"
+                                :scale {:domain ["yes" "no"]
+                                        :range [[1 0] [4 4]]}
+                                :legend nil}}}])))
 
 (defn kde-vega-spec
   "Build a complete Vega-Lite spec for KDE visualization.
@@ -694,7 +699,7 @@
     {:data {:values []}
      :resolve {:scale {:x "independent"
                        :y "independent"
-                       :color "shared"}}
+                       :color "independent"}}
      :vconcat
      (mapv
       (fn [metric-config]

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -616,23 +616,28 @@
 
 (defn kde-modes-layer
   "Build mode markers layer for KDE visualization.
+  Takes modes-data from separate modes analysis (not from kde-data).
   Returns a Vega-Lite layer spec."
-  [kde-data metric-config transforms]
-  (let [{:keys [modes]} kde-data
-        {:keys [label]} metric-config
+  [modes-data metric-config transforms]
+  (let [modes (:modes modes-data)
         k (first (:path metric-config))
         field-name (name k)
-        data (mapv (fn [{:keys [location density ci-lower ci-upper]}]
-                     {field-name (util/transform-sample-> location transforms)
-                      :density density
-                      :ci-lower (util/transform-sample-> ci-lower transforms)
-                      :ci-upper (util/transform-sample-> ci-upper transforms)})
+        data (mapv (fn [{:keys [location density ci-lower ci-upper significant?]}]
+                     (cond-> {field-name (util/transform-sample-> location transforms)
+                              :density density
+                              :significant (if significant? "yes" "no")}
+                       ci-lower (assoc :ci-lower (util/transform-sample-> ci-lower transforms))
+                       ci-upper (assoc :ci-upper (util/transform-sample-> ci-upper transforms))))
                    modes)]
     (when (seq data)
       {:data {:values data}
-       :layer [{:mark {:type "point" :size 100 :color "red"}
+       :layer [{:mark {:type "point" :size 100}
                 :encoding {:x {:field field-name :type "quantitative"}
                            :y {:field "density" :type "quantitative"}
+                           :color {:field "significant" :type "nominal"
+                                   :scale {:domain ["yes" "no"]
+                                           :range ["red" "orange"]}
+                                   :legend {:title "Significant"}}
                            :tooltip [{:field field-name :type "quantitative"
                                       :title "Mode Location"}
                                      {:field "density" :type "quantitative"
@@ -640,12 +645,16 @@
                                      {:field "ci-lower" :type "quantitative"
                                       :title "CI Lower"}
                                      {:field "ci-upper" :type "quantitative"
-                                      :title "CI Upper"}]}}
-               {:mark {:type "rule" :color "red" :strokeWidth 1
-                       :strokeDash [4 4]}
+                                      :title "CI Upper"}
+                                     {:field "significant" :type "nominal"
+                                      :title "Significant"}]}}
+               {:mark {:type "rule" :strokeWidth 1 :strokeDash [4 4]}
                 :encoding {:x {:field "ci-lower" :type "quantitative"}
                            :x2 {:field "ci-upper"}
-                           :y {:field "density" :type "quantitative"}}}]})))
+                           :y {:field "density" :type "quantitative"}
+                           :color {:field "significant" :type "nominal"
+                                   :scale {:domain ["yes" "no"]
+                                           :range ["red" "orange"]}}}}]})))
 
 (defn kde-vega-spec
   "Build a complete Vega-Lite spec for KDE visualization.
@@ -656,15 +665,20 @@
   View options:
     :kde-id - Key for KDE data in data-map (default :kde)
     :histogram-id - Optional key for histogram data to overlay
+    :modes-id - Optional key for modes data (default :modes)
 
   Returns the Vega-Lite spec without viewer-specific wrapping."
   [data-map view chart-options]
   (let [kde-id (or (:kde-id view) :kde)
         histogram-id (:histogram-id view)
+        modes-id (or (:modes-id view) :modes)
         kde-map (util/lookup-data data-map kde-id)
         histograms-map (when histogram-id
                          (util/lookup-data data-map histogram-id))
+        ;; Use get for optional modes lookup - don't throw if not present
+        modes-map (get data-map modes-id)
         kdes (:kdes kde-map)
+        all-modes (when modes-map (:modes modes-map))
         metrics-defs (-> (:metrics-defs kde-map)
                          (metric/filter-metrics
                           (metric/type-pred :quantitative)))
@@ -682,7 +696,9 @@
         (let [kde-data (get kdes (:path metric-config))
               histogram (when histograms-map
                           (get (:histograms histograms-map)
-                               (:path metric-config)))]
+                               (:path metric-config)))
+              modes-data (when all-modes
+                           (get all-modes (:path metric-config)))]
           (when kde-data
             (merge
              chart-options
@@ -704,10 +720,10 @@
                 true
                 (conj (kde-density-layer
                        kde-data metric-config kde-transforms))
-                ;; Add mode markers
-                (seq (:modes kde-data))
+                ;; Add mode markers from separate modes analysis
+                (and modes-data (seq (:modes modes-data)))
                 (conj (kde-modes-layer
-                       kde-data metric-config kde-transforms)))}))))
+                       modes-data metric-config kde-transforms)))}))))
       metric-configs)}))
 
 (defn treemap-vega-spec

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -574,23 +574,28 @@
 
 (defn kde-density-layer
   "Build a density curve layer for KDE visualization.
-  Uses 'kde-density' field to avoid Y-scale conflicts with histogram.
+  Applies Jacobian correction to convert log-space density to linear-space.
+  Uses 'density' field to share Y-axis with histogram.
   Returns a Vega-Lite layer spec."
   [kde-data metric-config transforms]
   (let [{:keys [grid density]} kde-data
         {:keys [label]} metric-config
         k (first (:path metric-config))
         field-name (name k)
-        data (mapv (fn [x d]
-                     {field-name (util/transform-sample-> x transforms)
-                      "kde-density" d})
+        ;; Apply Jacobian correction: p_linear(x) = p_log(log(x)) / x
+        ;; Grid is in log-space, so linear value is exp(grid).
+        ;; The Jacobian factor uses the linear value before display scaling.
+        data (mapv (fn [log-x d]
+                     (let [linear-x (Math/exp log-x)]
+                       {field-name (util/transform-sample-> log-x transforms)
+                        "density" (/ d linear-x)}))
                    grid density)]
     {:data {:values data}
      :transform [{:calculate (str "'" "KDE " label "'") :as "layer"}]
      :mark {:type "line" :strokeWidth 2}
      :encoding {:x {:field field-name :type "quantitative"
                     :scale {:zero false}}
-                :y {:field "kde-density" :type "quantitative"}
+                :y {:field "density" :type "quantitative"}
                 :color {:field "layer" :type "nominal"
                         :legend {:orient "top-left" :offset 10}}}}))
 
@@ -715,18 +720,24 @@
                        histogram
                        metric-config
                        0))
-                ;; Add confidence band
+                ;; Wrap KDE layers in a nested group with shared Y-scale
+                ;; This gives them independent Y-scale from histogram
                 true
-                (conj (kde-confidence-band-layer
-                       kde-data metric-config kde-transforms))
-                ;; Add density curve
-                true
-                (conj (kde-density-layer
-                       kde-data metric-config kde-transforms))
-                ;; Add mode markers from separate modes analysis
-                (and modes-data (seq (:modes modes-data)))
-                (conj (kde-modes-layer
-                       modes-data metric-config kde-transforms)))}))))
+                (conj {:resolve {:scale {:y "shared"}}
+                       :layer
+                       (cond-> []
+                         ;; Add confidence band
+                         true
+                         (conj (kde-confidence-band-layer
+                                kde-data metric-config kde-transforms))
+                         ;; Add density curve
+                         true
+                         (conj (kde-density-layer
+                                kde-data metric-config kde-transforms))
+                         ;; Add mode markers from separate modes analysis
+                         (and modes-data (seq (:modes modes-data)))
+                         (conj (kde-modes-layer
+                                modes-data metric-config kde-transforms)))}))}))))
       metric-configs)}))
 
 (defn treemap-vega-spec

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -570,6 +570,146 @@
              (mapcat #(flatten-treemap-node % node-id current-path) children))
        [node-record]))))
 
+;;; KDE charts
+
+(defn kde-density-layer
+  "Build a density curve layer for KDE visualization.
+  Returns a Vega-Lite layer spec."
+  [kde-data metric-config transforms]
+  (let [{:keys [grid density]} kde-data
+        {:keys [label]} metric-config
+        k (first (:path metric-config))
+        field-name (name k)
+        data (mapv (fn [x d]
+                     {field-name (util/transform-sample-> x transforms)
+                      :density d})
+                   grid density)]
+    {:data {:values data}
+     :transform [{:calculate (str "'" "Density " label "'") :as "layer"}]
+     :mark {:type "line" :strokeWidth 2}
+     :encoding {:x {:field field-name :type "quantitative"
+                    :scale {:zero false}}
+                :y {:field "density" :type "quantitative"}
+                :color {:field "layer" :type "nominal"
+                        :legend {:orient "top-left" :offset 10}}}}))
+
+(defn kde-confidence-band-layer
+  "Build a confidence band area layer for KDE visualization.
+  Returns a Vega-Lite layer spec."
+  [kde-data metric-config transforms]
+  (let [{:keys [grid lower-band upper-band]} kde-data
+        {:keys [label]} metric-config
+        k (first (:path metric-config))
+        field-name (name k)
+        data (mapv (fn [x lo hi]
+                     {field-name (util/transform-sample-> x transforms)
+                      :lower lo
+                      :upper hi})
+                   grid lower-band upper-band)]
+    {:data {:values data}
+     :mark {:type "area" :opacity 0.2}
+     :encoding {:x {:field field-name :type "quantitative"
+                    :scale {:zero false}}
+                :y {:field "lower" :type "quantitative"}
+                :y2 {:field "upper"}
+                :color {:value "steelblue"}}}))
+
+(defn kde-modes-layer
+  "Build mode markers layer for KDE visualization.
+  Returns a Vega-Lite layer spec."
+  [kde-data metric-config transforms]
+  (let [{:keys [modes]} kde-data
+        {:keys [label]} metric-config
+        k (first (:path metric-config))
+        field-name (name k)
+        data (mapv (fn [{:keys [location density ci-lower ci-upper]}]
+                     {field-name (util/transform-sample-> location transforms)
+                      :density density
+                      :ci-lower (util/transform-sample-> ci-lower transforms)
+                      :ci-upper (util/transform-sample-> ci-upper transforms)})
+                   modes)]
+    (when (seq data)
+      {:data {:values data}
+       :layer [{:mark {:type "point" :size 100 :color "red"}
+                :encoding {:x {:field field-name :type "quantitative"}
+                           :y {:field "density" :type "quantitative"}
+                           :tooltip [{:field field-name :type "quantitative"
+                                      :title "Mode Location"}
+                                     {:field "density" :type "quantitative"
+                                      :title "Density"}
+                                     {:field "ci-lower" :type "quantitative"
+                                      :title "CI Lower"}
+                                     {:field "ci-upper" :type "quantitative"
+                                      :title "CI Upper"}]}}
+               {:mark {:type "rule" :color "red" :strokeWidth 1
+                       :strokeDash [4 4]}
+                :encoding {:x {:field "ci-lower" :type "quantitative"}
+                           :x2 {:field "ci-upper"}
+                           :y {:field "density" :type "quantitative"}}}]})))
+
+(defn kde-vega-spec
+  "Build a complete Vega-Lite spec for KDE visualization.
+
+  Takes data-map, view options, and chart-options map containing :width and/or
+  :height for chart dimensions.
+
+  View options:
+    :kde-id - Key for KDE data in data-map (default :kde)
+    :histogram-id - Optional key for histogram data to overlay
+
+  Returns the Vega-Lite spec without viewer-specific wrapping."
+  [data-map view chart-options]
+  (let [kde-id (or (:kde-id view) :kde)
+        histogram-id (:histogram-id view)
+        kde-map (util/lookup-data data-map kde-id)
+        histograms-map (when histogram-id
+                         (util/lookup-data data-map histogram-id))
+        kdes (:kdes kde-map)
+        metrics-defs (-> (:metrics-defs kde-map)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        kde-transforms (util/get-transforms data-map kde-id)
+        hist-transforms (when histogram-id
+                          (util/get-transforms data-map histogram-id))]
+    {:data {:values []}
+     :resolve {:scale {:x "independent"
+                       :y "independent"
+                       :color "shared"}}
+     :vconcat
+     (mapv
+      (fn [metric-config]
+        (let [kde-data (get kdes (:path metric-config))
+              histogram (when histograms-map
+                          (get (:histograms histograms-map)
+                               (:path metric-config)))]
+          (when kde-data
+            (merge
+             chart-options
+             {:resolve {:scale {:x "shared" :y "independent"}}
+              :layer
+              (cond-> []
+                ;; Add histogram bars if available
+                histogram
+                (conj (metric-computed-histo-layer
+                       hist-transforms
+                       histogram
+                       metric-config
+                       0))
+                ;; Add confidence band
+                true
+                (conj (kde-confidence-band-layer
+                       kde-data metric-config kde-transforms))
+                ;; Add density curve
+                true
+                (conj (kde-density-layer
+                       kde-data metric-config kde-transforms))
+                ;; Add mode markers
+                (seq (:modes kde-data))
+                (conj (kde-modes-layer
+                       kde-data metric-config kde-transforms)))}))))
+      metric-configs)}))
+
 (defn treemap-vega-spec
   "Build a complete Vega spec for treemap visualization.
 
@@ -590,43 +730,43 @@
     - color by first-level category
     - tooltip on hover showing name, value (formatted bytes), path"
   [treemap-data opts]
-  (let [width        (or (:width opts) 700)
-        height       (or (:height opts) 400)
+  (let [width (or (:width opts) 700)
+        height (or (:height opts) 400)
         color-scheme (or (:color-scheme opts) "tableau10")
-        root         (:root treemap-data)
-        flat-data    (when root (vec (flatten-treemap-node root)))]
+        root (:root treemap-data)
+        flat-data (when root (vec (flatten-treemap-node root)))]
     {:$schema "https://vega.github.io/schema/vega/v5.json"
-     :width   width
-     :height  height
+     :width width
+     :height height
 
-     :data [{:name   "tree"
+     :data [{:name "tree"
              :values (or flat-data [])
              :transform
-             [{:type      "stratify"
-               :key       "id"
+             [{:type "stratify"
+               :key "id"
                :parentKey "parent"}
-              {:type   "treemap"
-               :field  "value"
-               :sort   {:field "value" :order "descending"}
+              {:type "treemap"
+               :field "value"
+               :sort {:field "value" :order "descending"}
                :method "squarify"
-               :ratio  1.6
-               :size   [{:signal "width"} {:signal "height"}]
-               :as     ["x0" "y0" "x1" "y1" "depth" "children"]}]}
-            {:name      "nodes"
-             :source    "tree"
+               :ratio 1.6
+               :size [{:signal "width"} {:signal "height"}]
+               :as ["x0" "y0" "x1" "y1" "depth" "children"]}]}
+            {:name "nodes"
+             :source "tree"
              :transform [{:type "filter"
                           :expr "datum.children"}]}
-            {:name      "leaves"
-             :source    "tree"
+            {:name "leaves"
+             :source "tree"
              :transform [{:type "filter"
                           :expr "!datum.children"}]}]
 
-     :scales [{:name   "color"
-               :type   "ordinal"
-               :domain {:data  "nodes"
+     :scales [{:name "color"
+               :type "ordinal"
+               :domain {:data "nodes"
                         :field "name"
-                        :sort  true}
-               :range  {:scheme color-scheme}}]
+                        :sort true}
+               :range {:scheme color-scheme}}]
 
      :marks [;; Parent category rectangles (colored background)
              {:type "rect"
@@ -635,8 +775,8 @@
               {:enter
                {:fill {:scale "color" :field "name"}}
                :update
-               {:x  {:field "x0"}
-                :y  {:field "y0"}
+               {:x {:field "x0"}
+                :y {:field "y0"}
                 :x2 {:field "x1"}
                 :y2 {:field "y1"}}}}
              ;; Leaf rectangles (white stroke, interactive with tooltip)
@@ -644,13 +784,13 @@
               :from {:data "leaves"}
               :encode
               {:enter
-               {:stroke      {:value "#fff"}
+               {:stroke {:value "#fff"}
                 :strokeWidth {:value 1}}
                :update
-               {:x    {:field "x0"}
-                :y    {:field "y0"}
-                :x2   {:field "x1"}
-                :y2   {:field "y1"}
+               {:x {:field "x0"}
+                :y {:field "y0"}
+                :x2 {:field "x1"}
+                :y2 {:field "y1"}
                 :fill {:value "transparent"}
                 :tooltip
                 {:signal

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -574,6 +574,7 @@
 
 (defn kde-density-layer
   "Build a density curve layer for KDE visualization.
+  Uses 'kde-density' field to avoid Y-scale conflicts with histogram.
   Returns a Vega-Lite layer spec."
   [kde-data metric-config transforms]
   (let [{:keys [grid density]} kde-data
@@ -582,19 +583,20 @@
         field-name (name k)
         data (mapv (fn [x d]
                      {field-name (util/transform-sample-> x transforms)
-                      :density d})
+                      "kde-density" d})
                    grid density)]
     {:data {:values data}
      :transform [{:calculate (str "'" "KDE " label "'") :as "layer"}]
      :mark {:type "line" :strokeWidth 2}
      :encoding {:x {:field field-name :type "quantitative"
                     :scale {:zero false}}
-                :y {:field "density" :type "quantitative"}
+                :y {:field "kde-density" :type "quantitative"}
                 :color {:field "layer" :type "nominal"
                         :legend {:orient "top-left" :offset 10}}}}))
 
 (defn kde-confidence-band-layer
   "Build a confidence band area layer for KDE visualization.
+  Uses 'kde-lower'/'kde-upper' fields to avoid Y-scale conflicts.
   Returns a Vega-Lite layer spec."
   [kde-data metric-config transforms]
   (let [{:keys [grid lower-band upper-band]} kde-data
@@ -603,20 +605,21 @@
         field-name (name k)
         data (mapv (fn [x lo hi]
                      {field-name (util/transform-sample-> x transforms)
-                      :lower lo
-                      :upper hi})
+                      "kde-lower" lo
+                      "kde-upper" hi})
                    grid lower-band upper-band)]
     {:data {:values data}
      :mark {:type "area" :opacity 0.2}
      :encoding {:x {:field field-name :type "quantitative"
                     :scale {:zero false}}
-                :y {:field "lower" :type "quantitative"}
-                :y2 {:field "upper"}
+                :y {:field "kde-lower" :type "quantitative"}
+                :y2 {:field "kde-upper"}
                 :color {:value "#ff7f0e"}}}))
 
 (defn kde-modes-layer
   "Build mode markers layer for KDE visualization.
   Takes modes-data from separate modes analysis (not from kde-data).
+  Uses 'kde-density' field to match KDE curve scale.
   Returns a Vega-Lite layer spec."
   [modes-data metric-config transforms]
   (let [modes (:modes modes-data)
@@ -624,23 +627,23 @@
         field-name (name k)
         data (mapv (fn [{:keys [location density ci-lower ci-upper significant?]}]
                      (cond-> {field-name (util/transform-sample-> location transforms)
-                              :density density
-                              :significant (if significant? "yes" "no")}
-                       ci-lower (assoc :ci-lower (util/transform-sample-> ci-lower transforms))
-                       ci-upper (assoc :ci-upper (util/transform-sample-> ci-upper transforms))))
+                              "kde-density" density
+                              "significant" (if significant? "yes" "no")}
+                       ci-lower (assoc "ci-lower" (util/transform-sample-> ci-lower transforms))
+                       ci-upper (assoc "ci-upper" (util/transform-sample-> ci-upper transforms))))
                    modes)]
     (when (seq data)
       {:data {:values data}
        :layer [{:mark {:type "point" :size 100}
                 :encoding {:x {:field field-name :type "quantitative"}
-                           :y {:field "density" :type "quantitative"}
+                           :y {:field "kde-density" :type "quantitative"}
                            :color {:field "significant" :type "nominal"
                                    :scale {:domain ["yes" "no"]
                                            :range ["red" "orange"]}
                                    :legend {:title "Significant"}}
                            :tooltip [{:field field-name :type "quantitative"
                                       :title "Mode Location"}
-                                     {:field "density" :type "quantitative"
+                                     {:field "kde-density" :type "quantitative"
                                       :title "Density"}
                                      {:field "ci-lower" :type "quantitative"
                                       :title "CI Lower"}
@@ -651,7 +654,7 @@
                {:mark {:type "rule" :strokeWidth 1 :strokeDash [4 4]}
                 :encoding {:x {:field "ci-lower" :type "quantitative"}
                            :x2 {:field "ci-upper"}
-                           :y {:field "density" :type "quantitative"}
+                           :y {:field "kde-density" :type "quantitative"}
                            :color {:field "significant" :type "nominal"
                                    :scale {:domain ["yes" "no"]
                                            :range ["red" "orange"]}}}}]})))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -617,10 +617,10 @@
                 :color {:value "#ff7f0e"}}}))
 
 (defn kde-modes-layer
-  "Build mode markers layer for KDE visualization.
+  "Build mode marker layers for KDE visualization.
   Takes modes-data from separate modes analysis (not from kde-data).
   Uses 'kde-density' field to match KDE curve scale.
-  Returns a Vega-Lite layer spec."
+  Returns a vector of Vega-Lite layer specs (point markers and CI rules)."
   [modes-data metric-config transforms]
   (let [modes (:modes modes-data)
         k (first (:path metric-config))
@@ -633,31 +633,33 @@
                        ci-upper (assoc "ci-upper" (util/transform-sample-> ci-upper transforms))))
                    modes)]
     (when (seq data)
-      {:data {:values data}
-       :layer [{:mark {:type "point" :size 100}
-                :encoding {:x {:field field-name :type "quantitative"}
-                           :y {:field "kde-density" :type "quantitative"}
-                           :color {:field "significant" :type "nominal"
-                                   :scale {:domain ["yes" "no"]
-                                           :range ["red" "orange"]}
-                                   :legend {:title "Significant"}}
-                           :tooltip [{:field field-name :type "quantitative"
-                                      :title "Mode Location"}
-                                     {:field "kde-density" :type "quantitative"
-                                      :title "Density"}
-                                     {:field "ci-lower" :type "quantitative"
-                                      :title "CI Lower"}
-                                     {:field "ci-upper" :type "quantitative"
-                                      :title "CI Upper"}
-                                     {:field "significant" :type "nominal"
-                                      :title "Significant"}]}}
-               {:mark {:type "rule" :strokeWidth 1 :strokeDash [4 4]}
-                :encoding {:x {:field "ci-lower" :type "quantitative"}
-                           :x2 {:field "ci-upper"}
-                           :y {:field "kde-density" :type "quantitative"}
-                           :color {:field "significant" :type "nominal"
-                                   :scale {:domain ["yes" "no"]
-                                           :range ["red" "orange"]}}}}]})))
+      ;; Return a vector of individual layers to avoid nested layer structure
+      [{:data {:values data}
+        :mark {:type "point" :size 100}
+        :encoding {:x {:field field-name :type "quantitative"}
+                   :y {:field "kde-density" :type "quantitative"}
+                   :color {:field "significant" :type "nominal"
+                           :scale {:domain ["yes" "no"]
+                                   :range ["red" "orange"]}
+                           :legend {:title "Significant"}}
+                   :tooltip [{:field field-name :type "quantitative"
+                              :title "Mode Location"}
+                             {:field "kde-density" :type "quantitative"
+                              :title "Density"}
+                             {:field "ci-lower" :type "quantitative"
+                              :title "CI Lower"}
+                             {:field "ci-upper" :type "quantitative"
+                              :title "CI Upper"}
+                             {:field "significant" :type "nominal"
+                              :title "Significant"}]}}
+       {:data {:values data}
+        :mark {:type "rule" :strokeWidth 1 :strokeDash [4 4]}
+        :encoding {:x {:field "ci-lower" :type "quantitative"}
+                   :x2 {:field "ci-upper"}
+                   :y {:field "kde-density" :type "quantitative"}
+                   :color {:field "significant" :type "nominal"
+                           :scale {:domain ["yes" "no"]
+                                   :range ["red" "orange"]}}}}])))
 
 (defn kde-vega-spec
   "Build a complete Vega-Lite spec for KDE visualization.
@@ -731,7 +733,7 @@
                                 kde-data metric-config kde-transforms))
                          ;; Add mode markers from separate modes analysis
                          (and modes-data (seq (:modes modes-data)))
-                         (conj (kde-modes-layer
+                         (into (kde-modes-layer
                                 modes-data metric-config kde-transforms)))}))}))))
       metric-configs)}))
 

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -600,7 +600,7 @@
   Returns a Vega-Lite layer spec."
   [kde-data metric-config transforms]
   (let [{:keys [grid lower-band upper-band]} kde-data
-        {:keys [label]} metric-config
+        {:keys [_label]} metric-config
         k (first (:path metric-config))
         field-name (name k)
         data (mapv (fn [x lo hi]

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -585,7 +585,7 @@
                       :density d})
                    grid density)]
     {:data {:values data}
-     :transform [{:calculate (str "'" "Density " label "'") :as "layer"}]
+     :transform [{:calculate (str "'" "KDE " label "'") :as "layer"}]
      :mark {:type "line" :strokeWidth 2}
      :encoding {:x {:field field-name :type "quantitative"
                     :scale {:zero false}}
@@ -612,7 +612,7 @@
                     :scale {:zero false}}
                 :y {:field "lower" :type "quantitative"}
                 :y2 {:field "upper"}
-                :color {:value "steelblue"}}}))
+                :color {:value "#ff7f0e"}}}))
 
 (defn kde-modes-layer
   "Build mode markers layer for KDE visualization.

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -574,28 +574,23 @@
 
 (defn kde-density-layer
   "Build a density curve layer for KDE visualization.
-  Applies Jacobian correction to convert log-space density to linear-space.
-  Uses 'density' field to share Y-axis with histogram.
+  Uses 'kde-density' field for independent Y-scale from histogram.
   Returns a Vega-Lite layer spec."
   [kde-data metric-config transforms]
   (let [{:keys [grid density]} kde-data
         {:keys [label]} metric-config
         k (first (:path metric-config))
         field-name (name k)
-        ;; Apply Jacobian correction: p_linear(x) = p_log(log(x)) / x
-        ;; Grid is in log-space, so linear value is exp(grid).
-        ;; The Jacobian factor uses the linear value before display scaling.
         data (mapv (fn [log-x d]
-                     (let [linear-x (Math/exp log-x)]
-                       {field-name (util/transform-sample-> log-x transforms)
-                        "density" (/ d linear-x)}))
+                     {field-name (util/transform-sample-> log-x transforms)
+                      "kde-density" d})
                    grid density)]
     {:data {:values data}
      :transform [{:calculate (str "'" "KDE " label "'") :as "layer"}]
      :mark {:type "line" :strokeWidth 2}
      :encoding {:x {:field field-name :type "quantitative"
                     :scale {:zero false}}
-                :y {:field "density" :type "quantitative"}
+                :y {:field "kde-density" :type "quantitative"}
                 :color {:field "layer" :type "nominal"
                         :legend {:orient "top-left" :offset 10}}}}))
 

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -143,6 +143,16 @@
    (charts/histogram-vega-spec data-map view {:width chart-width
                                               :height chart-height})))
 
+(defmethod view/kde* :kindly
+  [_ view data-map]
+  (let [kde-id (or (:kde-id view) :kde)
+        kde-map (get data-map kde-id)]
+    (when kde-map
+      (kindly-heading "Kernel Density Estimation")
+      (kindly-vega-lite
+       (charts/kde-vega-spec data-map view {:width chart-width
+                                            :height chart-height})))))
+
 (defmethod view/sample-percentiles* :kindly
   [_ view data-map]
   (let [quant-samples-id (:samples-id view :samples)

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -162,6 +162,15 @@
   (portal-vega-lite
    (charts/histogram-vega-spec data-map view {:height 800})))
 
+(defmethod view/kde* :portal
+  [_ view data-map]
+  (let [kde-id (or (:kde-id view) :kde)
+        kde-map (get data-map kde-id)]
+    (when kde-map
+      (heading "Kernel Density Estimation")
+      (portal-vega-lite
+       (charts/kde-vega-spec data-map view {:height 400})))))
+
 (defmethod view/sample-percentiles* :portal
   [_ view data-map]
   (let [quant-samples-id (:samples-id view :samples)

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -226,7 +226,7 @@
 (defn- kde-modes-table
   "Prepare modes data for pprint table display."
   [modes metric-config transforms]
-  (let [{:keys [dimension scale]} metric-config]
+  (let [{:keys [_dimension scale]} metric-config]
     (mapv (fn [{:keys [location density ci-lower ci-upper]}]
             {:location (format "%.4g"
                                (* scale
@@ -244,7 +244,7 @@
   "Pretty-print KDE summary for a single metric."
   [metric-config kde-data transforms]
   (let [{:keys [bandwidth modes n]} kde-data
-        {:keys [label dimension scale]} metric-config
+        {:keys [label _dimension scale]} metric-config
         bw (* (double scale) (util/transform-sample-> bandwidth transforms))]
     (println (format "\nKDE of %s (n=%d, bandwidth=%.4g)"
                      label n bw))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -223,6 +223,52 @@
          :density #(format "%-7.3g" %)}))
       (println))))
 
+(defn- kde-modes-table
+  "Prepare modes data for pprint table display."
+  [modes metric-config transforms]
+  (let [{:keys [dimension scale]} metric-config]
+    (mapv (fn [{:keys [location density ci-lower ci-upper]}]
+            {:location (format "%.4g"
+                               (* scale
+                                  (util/transform-sample-> location transforms)))
+             :density (format "%.4g" density)
+             :ci-lower (format "%.4g"
+                               (* scale
+                                  (util/transform-sample-> ci-lower transforms)))
+             :ci-upper (format "%.4g"
+                               (* scale
+                                  (util/transform-sample-> ci-upper transforms)))})
+          modes)))
+
+(defn- pprint-kde-metric
+  "Pretty-print KDE summary for a single metric."
+  [metric-config kde-data transforms]
+  (let [{:keys [bandwidth modes n]} kde-data
+        {:keys [label dimension scale]} metric-config
+        bw (* (double scale) (util/transform-sample-> bandwidth transforms))]
+    (println (format "\nKDE of %s (n=%d, bandwidth=%.4g)"
+                     label n bw))
+    (when (seq modes)
+      (pprint/print-table
+       [:location :density :ci-lower :ci-upper]
+       (kde-modes-table modes metric-config transforms)))
+    (println)))
+
+(defmethod view/kde* :pprint
+  [_ {:keys [kde-id] :as _view} data-map]
+  (let [kde-id (or kde-id :kde)
+        kde-map (get data-map kde-id)]
+    (when kde-map
+      (let [metrics-defs (-> (:metrics-defs kde-map)
+                             (metric/filter-metrics
+                              (metric/type-pred :quantitative)))
+            metric-configs (metric/all-metric-configs metrics-defs)
+            transforms (util/get-transforms data-map kde-id)
+            kdes (:kdes kde-map)]
+        (doseq [metric-config metric-configs]
+          (when-let [kde-data (get kdes (:path metric-config))]
+            (pprint-kde-metric metric-config kde-data transforms)))))))
+
 (defmethod view/sample-percentiles* :pprint
   [_ _view _banch-map]
   ;; TODO

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -226,7 +226,8 @@
 (defn- kde-modes-table
   "Prepare modes data for pprint table display."
   [modes metric-config transforms]
-  (let [{:keys [_dimension scale]} metric-config]
+  (let [{:keys [_dimension scale]} metric-config
+        scale (double scale)]
     (mapv (fn [{:keys [location density ci-lower ci-upper]}]
             {:location (format "%.4g"
                                (* scale

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -354,6 +354,54 @@
        (mapv vector (:centers h) (:counts h) (:density h)))
       (println))))
 
+(defn- format-kde-mode
+  "Format a single mode for display."
+  [mode metric-config transforms]
+  (let [{:keys [location density ci-lower ci-upper]} mode
+        {:keys [dimension scale]} metric-config
+        loc (util/transform-sample-> location transforms)
+        ci-lo (util/transform-sample-> ci-lower transforms)
+        ci-hi (util/transform-sample-> ci-upper transforms)]
+    [(format/format-value dimension (* scale loc))
+     (format "%.4g" density)
+     (format/format-value dimension (* scale ci-lo))
+     (format/format-value dimension (* scale ci-hi))]))
+
+(defn- print-kde-metric
+  "Print KDE summary for a single metric."
+  [metric-config kde-data transforms]
+  (let [{:keys [bandwidth modes n]} kde-data
+        {:keys [label dimension scale]} metric-config
+        bw (util/transform-sample-> bandwidth transforms)]
+    (println (format "%32s: KDE (n=%d)" label n))
+    (println (format "%34s bandwidth: %s"
+                     ""
+                     (format/format-value dimension (* scale bw))))
+    (when (seq modes)
+      (println (format "%34s modes: %d" "" (count modes)))
+      (println (format "%34s %12s %12s %12s %12s"
+                       "" "Location" "Density" "CI Lower" "CI Upper"))
+      (doseq [mode modes]
+        (let [[loc dens ci-lo ci-hi] (format-kde-mode mode metric-config transforms)]
+          (println (format "%34s %12s %12s %12s %12s"
+                           "" loc dens ci-lo ci-hi)))))
+    (println)))
+
+(defmethod view/kde* :print
+  [_ {:keys [kde-id] :as _view} data-map]
+  (let [kde-id (or kde-id :kde)
+        kde-map (get data-map kde-id)]
+    (when kde-map
+      (let [metrics-defs (-> (:metrics-defs kde-map)
+                             (metric/filter-metrics
+                              (metric/type-pred :quantitative)))
+            metric-configs (metric/all-metric-configs metrics-defs)
+            transforms (util/get-transforms data-map kde-id)
+            kdes (:kdes kde-map)]
+        (doseq [metric-config metric-configs]
+          (when-let [kde-data (get kdes (:path metric-config))]
+            (print-kde-metric metric-config kde-data transforms)))))))
+
 (defmethod view/quantiles* :print
   [_ {:keys [quantiles-id]} data-map]
   (let [quantiles-id (or quantiles-id :quantiles)

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -355,52 +355,66 @@
       (println))))
 
 (defn- format-kde-mode
-  "Format a single mode for display."
+  "Format a single mode for display with significance indicator."
   [mode metric-config transforms]
-  (let [{:keys [location density ci-lower ci-upper]} mode
+  (let [{:keys [location density ci-lower ci-upper significant?]} mode
         {:keys [dimension scale]} metric-config
         loc (util/transform-sample-> location transforms)
-        ci-lo (util/transform-sample-> ci-lower transforms)
-        ci-hi (util/transform-sample-> ci-upper transforms)]
-    [(format/format-value dimension (* scale loc))
+        ci-lo (when ci-lower (util/transform-sample-> ci-lower transforms))
+        ci-hi (when ci-upper (util/transform-sample-> ci-upper transforms))
+        sig-marker (if significant? "*" "")]
+    [(str (format/format-value dimension (* scale loc)) sig-marker)
      (format "%.4g" density)
-     (format/format-value dimension (* scale ci-lo))
-     (format/format-value dimension (* scale ci-hi))]))
+     (if ci-lo (format/format-value dimension (* scale ci-lo)) "-")
+     (if ci-hi (format/format-value dimension (* scale ci-hi)) "-")]))
 
 (defn- print-kde-metric
-  "Print KDE summary for a single metric."
-  [metric-config kde-data transforms]
-  (let [{:keys [bandwidth modes n]} kde-data
+  "Print KDE summary for a single metric with optional modes from separate analysis."
+  [metric-config kde-data modes-data transforms]
+  (let [{:keys [bandwidth n]} kde-data
         {:keys [label dimension scale]} metric-config
-        bw (util/transform-sample-> bandwidth transforms)]
+        bw (util/transform-sample-> bandwidth transforms)
+        modes (when modes-data (:modes modes-data))
+        n-modes (when modes-data (:n-modes modes-data))
+        silverman (when modes-data (:silverman modes-data))]
     (println (format "%32s: KDE (n=%d)" label n))
     (println (format "%34s bandwidth: %s"
                      ""
                      (format/format-value dimension (* scale bw))))
     (when (seq modes)
-      (println (format "%34s modes: %d" "" (count modes)))
+      (println (format "%34s modes: %d (validated: %s)"
+                       "" (count modes) (or n-modes "?")))
       (println (format "%34s %12s %12s %12s %12s"
                        "" "Location" "Density" "CI Lower" "CI Upper"))
       (doseq [mode modes]
         (let [[loc dens ci-lo ci-hi] (format-kde-mode mode metric-config transforms)]
           (println (format "%34s %12s %12s %12s %12s"
-                           "" loc dens ci-lo ci-hi)))))
+                           "" loc dens ci-lo ci-hi))))
+      (when silverman
+        (let [p-values (:p-values silverman)]
+          (println (format "%34s Silverman test p-values:" ""))
+          (doseq [k (sort (keys p-values))]
+            (println (format "%36s k=%d: p=%.4f" "" k (get p-values k)))))))
     (println)))
 
 (defmethod view/kde* :print
-  [_ {:keys [kde-id] :as _view} data-map]
+  [_ {:keys [kde-id modes-id] :as _view} data-map]
   (let [kde-id (or kde-id :kde)
-        kde-map (get data-map kde-id)]
+        modes-id (or modes-id :modes)
+        kde-map (get data-map kde-id)
+        modes-map (get data-map modes-id)]
     (when kde-map
       (let [metrics-defs (-> (:metrics-defs kde-map)
                              (metric/filter-metrics
                               (metric/type-pred :quantitative)))
             metric-configs (metric/all-metric-configs metrics-defs)
             transforms (util/get-transforms data-map kde-id)
-            kdes (:kdes kde-map)]
+            kdes (:kdes kde-map)
+            all-modes (when modes-map (:modes modes-map))]
         (doseq [metric-config metric-configs]
           (when-let [kde-data (get kdes (:path metric-config))]
-            (print-kde-metric metric-config kde-data transforms)))))))
+            (let [modes-data (when all-modes (get all-modes (:path metric-config)))]
+              (print-kde-metric metric-config kde-data modes-data transforms))))))))
 
 (defmethod view/quantiles* :print
   [_ {:keys [quantiles-id]} data-map]

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -430,3 +430,61 @@
         (is (< grid-max 200) "grid should not extend to outlier value")
         (is (= :outliers (:outliers-id kde-data))
             "should record outliers-id in output")))))
+
+(deftest modes-test
+  ;; Tests analyse/modes function for multimodality testing.
+  ;; Verifies ACR (default) and Silverman methods work correctly
+  ;; and produce expected output structure.
+  (testing "modes"
+    (testing "uses ACR test by default"
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+            samples (metrics-samples {[:elapsed-time] raw-data} 1)
+            data-map {:samples samples}
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+            result ((analyse/modes {:n-bootstrap 10}) with-kde)]
+        (is (contains? result :modes))
+        (let [modes-data (:modes result)
+              elapsed-modes (get-in modes-data [:modes [:elapsed-time]])]
+          (is (= :acr (get-in elapsed-modes [:test-results :method]))
+              "should use ACR method by default")
+          (is (contains? (:test-results elapsed-modes) :excess-mass)
+              "ACR results should include excess-mass"))))
+
+    (testing "supports Silverman method via :method option"
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+            samples (metrics-samples {[:elapsed-time] raw-data} 1)
+            data-map {:samples samples}
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+            result ((analyse/modes {:n-bootstrap 10 :method :silverman}) with-kde)]
+        (is (contains? result :modes))
+        (let [modes-data (:modes result)
+              elapsed-modes (get-in modes-data [:modes [:elapsed-time]])]
+          (is (= :silverman (get-in elapsed-modes [:test-results :method]))
+              "should use Silverman method when specified")
+          (is (nil? (get-in elapsed-modes [:test-results :excess-mass]))
+              "Silverman results should not include excess-mass"))))
+
+    (testing "returns correct output structure"
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+            samples (metrics-samples {[:elapsed-time] raw-data} 1)
+            data-map {:samples samples}
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+            result ((analyse/modes {:n-bootstrap 10}) with-kde)
+            modes-data (:modes result)
+            elapsed-modes (get-in modes-data [:modes [:elapsed-time]])]
+        (is (= :criterium/modes (:type modes-data)))
+        (is (vector? (:modes elapsed-modes)))
+        (is (number? (:n-modes elapsed-modes)))
+        (is (map? (:test-results elapsed-modes)))
+        (is (contains? (:test-results elapsed-modes) :k-tested))
+        (is (contains? (:test-results elapsed-modes) :p-values))
+        (is (contains? (:test-results elapsed-modes) :critical-bandwidths))))))

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -344,13 +344,11 @@
 
 (deftest kde-test
   ;; Tests the analyse/kde function for correct structure,
-  ;; multimodal detection, outlier filtering, and graceful handling of missing data.
+  ;; outlier filtering, and graceful handling of missing data.
+  ;; Note: Mode detection is now a separate analysis step via analyse/modes.
   (testing "kde"
-    (testing "returns correct structure with multimodal data"
-      (let [;; Bimodal: cluster around 100 and cluster around 200
-            cluster1 (repeat 30 100)
-            cluster2 (repeat 30 200)
-            ;; Add some variation to avoid constant-data error
+    (testing "returns correct structure"
+      (let [;; Bimodal: clusters around 100 and 200
             raw-data (concat
                       (mapv #(+ 98 (* 4 %)) (range 30))
                       (mapv #(+ 198 (* 4 %)) (range 30)))
@@ -372,7 +370,9 @@
             (is (number? (:bandwidth elapsed-kde)))
             (is (vector? (:grid elapsed-kde)))
             (is (vector? (:density elapsed-kde)))
-            (is (vector? (:modes elapsed-kde)))))))
+            ;; Modes are now computed separately via analyse/modes
+            (is (nil? (:modes elapsed-kde))
+                "modes should not be in KDE output (now separate)")))))
 
     (testing "uses custom samples-id"
       (let [raw-data (mapv #(+ 10.0 (* 0.5 %)) (range 50))

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -22,23 +22,23 @@
 (defn metrics-samples
   [data ^long batch-size]
   (let [n (count (first (vals data)))]
-    {:type           :criterium/metrics-samples
+    {:type :criterium/metrics-samples
      :metric->values data
-     :transform      (if (= batch-size 1)
-                       collect-plan/identity-transforms
-                       (#'collect-plan/batch-transforms batch-size))
-     :num-samples    n
-     :batch-size     batch-size
-     :eval-count     (* n batch-size)
-     :metrics-defs   (select-keys
-                      (metrics/metrics)
-                      (mapv first (keys data)))
-     :source-id      nil
-     :expr-value     (ffirst (vals data))}))
+     :transform (if (= batch-size 1)
+                  collect-plan/identity-transforms
+                  (#'collect-plan/batch-transforms batch-size))
+     :num-samples n
+     :batch-size batch-size
+     :eval-count (* n batch-size)
+     :metrics-defs (select-keys
+                    (metrics/metrics)
+                    (mapv first (keys data)))
+     :source-id nil
+     :expr-value (ffirst (vals data))}))
 
 (defn transformed-metric-values
   [data-map id p]
-  (let [m          (-> data-map id)
+  (let [m (-> data-map id)
         transforms (util/get-transforms data-map id)]
     (mapv
      #(util/transform-sample-> % transforms)
@@ -55,12 +55,12 @@
 (deftest transform-log-test
   (testing "transform-log"
     (let [raw-data [(Math/exp 1) (Math/exp 2) (Math/exp 3)]
-          samples  (metrics-samples
-                    {[:elapsed-time]         raw-data
-                     [:compilation :time-ms] [0 0 0]}
-                    10)
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   10)
           data-map {:samples samples}
-          result   ((analyse/transform-log) data-map)]
+          result ((analyse/transform-log) data-map)]
       (testing "puts the log transformed metrics into the result-path"
         (is (= [1.0 2.0 3.0]
                (-> result
@@ -79,13 +79,13 @@
 (deftest quantiles-test
   (testing "quantiles"
     (let [raw-data [10 20 30]
-          samples  (metrics-samples
-                    {[:elapsed-time]         raw-data
-                     [:compilation :time-ms] [0 0 0]}
-                    10)
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   10)
           data-map {:samples samples}
-          result   ((analyse/quantiles {:quantiles [0.025 0.975]})
-                    data-map)]
+          result ((analyse/quantiles {:quantiles [0.025 0.975]})
+                  data-map)]
       (testing "puts the quantiles into the result-path"
         (let [qs [0.25 0.5 0.75 0.025 0.975]
               vs (-> result :quantiles util/quantiles :elapsed-time)]
@@ -105,14 +105,14 @@
 (deftest outliers-test
   ;; http://www.ellipticgroup.com/misc/article_supplement.pdf, p22
   (testing "Outliers"
-    (let [raw-data  [9 10 9 10 9 10 10000]
-          samples   (metrics-samples
-                     {[:elapsed-time]         raw-data
-                      [:compilation :time-ms] [0 0 0]}
-                     10)
-          data-map  {:samples samples}
+    (let [raw-data [9 10 9 10 9 10 10000]
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   10)
+          data-map {:samples samples}
           quantiles (analyse/quantiles {:quantiles []})
-          outliers  (analyse/outliers)]
+          outliers (analyse/outliers)]
       (is (= {:low-severe 0, :low-mild 0, :high-mild 0, :high-severe 1}
              (-> data-map
                  quantiles
@@ -127,14 +127,14 @@
   (testing "Outlier counts"
     (let [data-map
           {:samples
-           {:type           :criterium/collected-metrics-samples
+           {:type :criterium/collected-metrics-samples
             :metric->values {[:elapsed-time] [1 1 1 1000]}
-            :transform      collect-plan/identity-transforms
-            :batch-size     1
-            :eval-count     4
-            :metrics-defs   (select-keys
-                             (metrics/metrics)
-                             [:elapsed-time])}}
+            :transform collect-plan/identity-transforms
+            :batch-size 1
+            :eval-count 4
+            :metrics-defs (select-keys
+                           (metrics/metrics)
+                           [:elapsed-time])}}
           analyse (benchmark/->analyse
                    [[:quantiles {:quantiles [0.025 0.975]}]
                     :outliers])]
@@ -148,20 +148,20 @@
 (deftest stats-test
   (testing "stats"
     (let [raw-data [1 2 3]
-          samples  (metrics-samples
-                    {[:elapsed-time]         raw-data
-                     [:compilation :time-ms] [0 0 0]}
-                    10)
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   10)
           data-map {:samples samples}
-          result   ((analyse/stats) data-map)]
+          result ((analyse/stats) data-map)]
       (testing "puts the stats into the result-path"
-        (is (= {:min-val           1.0,
-                :max-val           3.0,
-                :mean              2.0,
-                :mean-plus-3sigma  5.0,
-                :variance          1.0,
+        (is (= {:min-val 1.0,
+                :max-val 3.0,
+                :mean 2.0,
+                :mean-plus-3sigma 5.0,
+                :variance 1.0,
                 :mean-minus-3sigma -1.0
-                :n                 3}
+                :n 3}
                (->> result :stats util/stats :elapsed-time))))
       (testing "doesn't transform event-metrics "
         (is (every?
@@ -171,21 +171,21 @@
                (->> result :stats util/stats keys))))))
   (testing "stats variance"
     (let [raw-data [1 1 1 5 5 5 9 9 9]
-          samples  (metrics-samples
-                    {[:elapsed-time]         raw-data
-                     [:compilation :time-ms] [0 0 0]}
-                    1)
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   1)
           data-map {:samples samples}
-          result   ((analyse/stats) data-map)]
+          result ((analyse/stats) data-map)]
       (testing "calculates sample variance"
         (is (= 12.0 (:variance (->> result :stats util/stats :elapsed-time))))))
     (let [raw-data [1 1 1 5 5 5 9 9 9]
-          samples  (metrics-samples
-                    {[:elapsed-time]         raw-data
-                     [:compilation :time-ms] [0 0 0]}
-                    10)
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   10)
           data-map {:samples samples}
-          result   ((analyse/stats) data-map)]
+          result ((analyse/stats) data-map)]
       (testing "scales with batch size"
         (let [v (:variance (->> result :stats util/stats :elapsed-time))]
           (is (= 12.0 v))
@@ -193,23 +193,23 @@
                        v
                        (util/get-transforms result :stats))))))))
   (testing "excludes outliers"
-    (let [raw-data  [9 10 9 10 9 10 10000]
-          samples   (metrics-samples
-                     {[:elapsed-time]         raw-data
-                      [:compilation :time-ms] [0 0 0]}
-                     1)
-          data-map  {:samples samples}
+    (let [raw-data [9 10 9 10 9 10 10000]
+          samples (metrics-samples
+                   {[:elapsed-time] raw-data
+                    [:compilation :time-ms] [0 0 0]}
+                   1)
+          data-map {:samples samples}
           quantiles (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
-          outliers  (analyse/outliers)
-          stats     (analyse/stats)
-          result    (-> data-map
-                        quantiles
-                        outliers
-                        stats)
-          smap      (->> result :stats util/stats :elapsed-time)
-          smap'     (util/transform-vals->
-                     (->> result :stats util/stats :elapsed-time)
-                     (util/get-transforms result :stats))]
+          outliers (analyse/outliers)
+          stats (analyse/stats)
+          result (-> data-map
+                     quantiles
+                     outliers
+                     stats)
+          smap (->> result :stats util/stats :elapsed-time)
+          smap' (util/transform-vals->
+                 (->> result :stats util/stats :elapsed-time)
+                 (util/get-transforms result :stats))]
       (testing "calculates sample variance"
         (is (approx= 9.5 (:mean smap)))
         (is (approx= 0.3 (:variance smap)))
@@ -227,20 +227,20 @@
         (is (approx= 7.8568323274845016 (:mean-minus-3sigma smap')))))
 
     (testing "scales with batch size"
-      (let [raw-data  [9 10 9 10 9 10 10000]
-            samples   (metrics-samples
-                       {[:elapsed-time]         raw-data
-                        [:compilation :time-ms] [0 0 0]}
-                       2)
+      (let [raw-data [9 10 9 10 9 10 10000]
+            samples (metrics-samples
+                     {[:elapsed-time] raw-data
+                      [:compilation :time-ms] [0 0 0]}
+                     2)
             quantiles (analyse/quantiles {:quantiles [0.9 0.99 0.99]})
-            data-map  {:samples samples}
-            outliers  (analyse/outliers)
-            stats     (analyse/stats)
-            result    (-> data-map quantiles outliers stats)
-            smap      (-> result :stats util/stats :elapsed-time)
-            smap'     (util/transform-vals->
-                       (-> result :stats util/stats :elapsed-time)
-                       (util/get-transforms result :stats))]
+            data-map {:samples samples}
+            outliers (analyse/outliers)
+            stats (analyse/stats)
+            result (-> data-map quantiles outliers stats)
+            smap (-> result :stats util/stats :elapsed-time)
+            smap' (util/transform-vals->
+                   (-> result :stats util/stats :elapsed-time)
+                   (util/get-transforms result :stats))]
         (is (approx= 9.5 (:mean smap)))
         (is (approx= 0.3 (:variance smap)))
         (is (approx= 9 (:min-val smap)))
@@ -259,7 +259,7 @@
   (testing "event-stats"
     (let [data-map
           {:samples
-           {:type           :criterium/metrics-samples
+           {:type :criterium/metrics-samples
             :metrics-defs
             (-> (select-keys
                  (metrics/metrics)
@@ -274,40 +274,40 @@
                     (str "%32s: ran %s times"
                          " for a total of %s in %s samples")
                     :values
-                    [{:path      [:garbage-collector :total :count]
-                      :scale     1
+                    [{:path [:garbage-collector :total :count]
+                      :scale 1
                       :dimension :count
-                      :label     "GC total count"
-                      :type      :event}
-                     {:path      [:garbage-collector :total :time-ms]
-                      :scale     1e-3
+                      :label "GC total count"
+                      :type :event}
+                     {:path [:garbage-collector :total :time-ms]
+                      :scale 1e-3
                       :dimension :time
-                      :label     "GC total time"
-                      :type      :event}]
+                      :label "GC total time"
+                      :type :event}]
                     :label "Garbage Collector"}}}))
-            :metric->values {[:elapsed-time]                      [1 2 3]
-                             [:compilation :time-ms]              [3 5 0]
+            :metric->values {[:elapsed-time] [1 2 3]
+                             [:compilation :time-ms] [3 5 0]
                              [:garbage-collector :total :time-ms] [1 1 1]
-                             [:garbage-collector :total :count]   [2 1 1]
-                             [:class-loader :loaded-count]        [2 2 0]
-                             [:class-loader :unloaded-count]      [0 0 0]}
-            :batch-size     1
-            :eval-count     3}}
+                             [:garbage-collector :total :count] [2 1 1]
+                             [:class-loader :loaded-count] [2 2 0]
+                             [:class-loader :unloaded-count] [0 0 0]}
+            :batch-size 1
+            :eval-count 3}}
           result ((analyse/event-stats) data-map)]
       (testing "puts the event-stats into the output-path"
-        (is (= {[:class-loader :loaded-count]             4,
-                [:class-loader :unloaded-count]           0,
-                [:class-loader :sample-count]             2,
-                [:compilation :time-ms]                   8,
-                [:compilation :sample-count]              2,
-                [:garbage-collector :total :count]        4,
-                [:garbage-collector :total :time-ms]      3,
+        (is (= {[:class-loader :loaded-count] 4,
+                [:class-loader :unloaded-count] 0,
+                [:class-loader :sample-count] 2,
+                [:compilation :time-ms] 8,
+                [:compilation :sample-count] 2,
+                [:garbage-collector :total :count] 4,
+                [:garbage-collector :total :time-ms] 3,
                 [:garbage-collector :total :sample-count] 3}
-               #_{:compilation       {:time-ms 8 :sample-count 2}
+               #_{:compilation {:time-ms 8 :sample-count 2}
                   :garbage-collector {:total
                                       {:time-ms 3 :count 4 :sample-count 3}}
-                  :class-loader      {:sample-count 2
-                                      :loaded-count 4 :unloaded-count 0}}
+                  :class-loader {:sample-count 2
+                                 :loaded-count 4 :unloaded-count 0}}
                (->> result :event-stats util/event-stats)))))))
 
 (deftest outlier-effect-test
@@ -321,14 +321,14 @@
   (testing "Outlier counts"
     (let [data-map
           {:samples
-           {:type           :criterium/collected-metrics-samples
+           {:type :criterium/collected-metrics-samples
             :metric->values {[:elapsed-time] [1 1 1 1000]}
-            :transform      collect-plan/identity-transforms
-            :batch-size     1
-            :eval-count     4
-            :metrics-defs   (select-keys
-                             (metrics/metrics)
-                             [:elapsed-time])}}
+            :transform collect-plan/identity-transforms
+            :batch-size 1
+            :eval-count 4
+            :metrics-defs (select-keys
+                           (metrics/metrics)
+                           [:elapsed-time])}}
           analyse (benchmark/->analyse
                    [[:quantiles {:quantiles [0.025 0.975]}]
                     :outliers
@@ -336,8 +336,71 @@
                     :outlier-significance])]
 
       (is (= {:significance 0
-              :effect       :unaffected}
+              :effect :unaffected}
              (-> (analyse data-map)
                  :outlier-significance
                  util/outlier-significance
                  :elapsed-time))))))
+
+(deftest kde-test
+  ;; Tests the analyse/kde function for correct structure,
+  ;; multimodal detection, and graceful handling of missing data.
+  (testing "kde"
+    (testing "returns correct structure with multimodal data"
+      (let [;; Bimodal: cluster around 100 and cluster around 200
+            cluster1 (repeat 30 100)
+            cluster2 (repeat 30 200)
+            ;; Add some variation to avoid constant-data error
+            raw-data (concat
+                      (mapv #(+ 98 (* 4 %)) (range 30))
+                      (mapv #(+ 198 (* 4 %)) (range 30)))
+            samples (metrics-samples
+                     {[:elapsed-time] (vec raw-data)}
+                     1)
+            data-map {:samples samples}
+            ;; Need to add log-samples since that's the default source
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            result ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)]
+        (is (contains? result :kde) "result should have :kde key")
+        (let [kde-data (:kde result)]
+          (is (= :criterium/kde (:type kde-data)))
+          (is (map? (:kdes kde-data)))
+          (is (contains? (:kdes kde-data) [:elapsed-time]))
+          (let [elapsed-kde (get-in kde-data [:kdes [:elapsed-time]])]
+            (is (number? (:bandwidth elapsed-kde)))
+            (is (vector? (:grid elapsed-kde)))
+            (is (vector? (:density elapsed-kde)))
+            (is (vector? (:modes elapsed-kde)))))))
+
+    (testing "uses custom samples-id"
+      (let [raw-data (mapv #(+ 10.0 (* 0.5 %)) (range 50))
+            samples (metrics-samples
+                     {[:elapsed-time] raw-data}
+                     1)
+            data-map {:my-samples samples}
+            result ((analyse/kde {:samples-id :my-samples
+                                  :n-bootstrap 10
+                                  :n-points 32})
+                    data-map)]
+        (is (contains? result :kde))))
+
+    (testing "returns data-map unchanged when samples unavailable"
+      (let [data-map {:other-data 123}
+            result ((analyse/kde) data-map)]
+        (is (= data-map result))
+        (is (not (contains? result :kde)))))
+
+    (testing "uses custom output id"
+      (let [raw-data (mapv #(+ 10.0 (* 0.5 %)) (range 50))
+            samples (metrics-samples
+                     {[:elapsed-time] raw-data}
+                     1)
+            data-map {:log-samples samples}
+            result ((analyse/kde {:id :my-kde
+                                  :n-bootstrap 10
+                                  :n-points 32})
+                    data-map)]
+        (is (contains? result :my-kde))
+        (is (not (contains? result :kde)))))))

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -487,4 +487,63 @@
         (is (map? (:test-results elapsed-modes)))
         (is (contains? (:test-results elapsed-modes) :k-tested))
         (is (contains? (:test-results elapsed-modes) :p-values))
-        (is (contains? (:test-results elapsed-modes) :critical-bandwidths))))))
+        (is (contains? (:test-results elapsed-modes) :critical-bandwidths))))
+
+    (testing "with :mode-method :critical"
+      (testing "includes antimodes and mode-bandwidth"
+        (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+              samples (metrics-samples {[:elapsed-time] raw-data} 1)
+              data-map {:samples samples}
+              with-log ((analyse/transform-log {:id :log-samples
+                                                :samples-id :samples})
+                        data-map)
+              with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+              result ((analyse/modes {:n-bootstrap 10 :mode-method :critical})
+                      with-kde)
+              modes-data (:modes result)
+              elapsed-modes (get-in modes-data [:modes [:elapsed-time]])]
+          (is (= :critical (:mode-method elapsed-modes))
+              "should record mode-method in output")
+          (is (number? (:mode-bandwidth elapsed-modes))
+              "should include mode-bandwidth")
+          (is (vector? (:antimodes elapsed-modes))
+              "should include antimodes vector")))
+
+      (testing "for multimodal data produces antimodes"
+        (let [;; Create well-separated bimodal data (log-transform will be applied)
+              ;; Use exponential values so log-transform creates clearly separated modes
+              raw-data (concat
+                        (mapv #(* (Math/exp 1.0) (+ 1.0 (* 0.01 %))) (range 30))
+                        (mapv #(* (Math/exp 5.0) (+ 1.0 (* 0.01 %))) (range 30)))
+              samples (metrics-samples {[:elapsed-time] (vec raw-data)} 1)
+              data-map {:samples samples}
+              with-log ((analyse/transform-log {:id :log-samples
+                                                :samples-id :samples})
+                        data-map)
+              with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+              result ((analyse/modes {:n-bootstrap 10 :mode-method :critical})
+                      with-kde)
+              elapsed-modes (get-in result [:modes :modes [:elapsed-time]])]
+          ;; Antimodes vector should exist for :critical method
+          (is (vector? (:antimodes elapsed-modes))
+              "antimodes should be a vector")
+          ;; When we have multiple modes, there should be antimodes between them
+          (when (> (:n-modes elapsed-modes) 1)
+            (is (pos? (count (:antimodes elapsed-modes)))
+                "multiple modes should have at least one antimode"))))
+
+      (testing "with :isj (default) does not include antimodes"
+        (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+              samples (metrics-samples {[:elapsed-time] raw-data} 1)
+              data-map {:samples samples}
+              with-log ((analyse/transform-log {:id :log-samples
+                                                :samples-id :samples})
+                        data-map)
+              with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+              result ((analyse/modes {:n-bootstrap 10 :mode-method :isj})
+                      with-kde)
+              elapsed-modes (get-in result [:modes :modes [:elapsed-time]])]
+          (is (nil? (:mode-method elapsed-modes))
+              "should not include mode-method for :isj")
+          (is (nil? (:antimodes elapsed-modes))
+              "should not include antimodes for :isj"))))))

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -344,7 +344,7 @@
 
 (deftest kde-test
   ;; Tests the analyse/kde function for correct structure,
-  ;; multimodal detection, and graceful handling of missing data.
+  ;; multimodal detection, outlier filtering, and graceful handling of missing data.
   (testing "kde"
     (testing "returns correct structure with multimodal data"
       (let [;; Bimodal: cluster around 100 and cluster around 200
@@ -403,4 +403,30 @@
                                   :n-points 32})
                     data-map)]
         (is (contains? result :my-kde))
-        (is (not (contains? result :kde)))))))
+        (is (not (contains? result :kde)))))
+
+    (testing "excludes outliers from KDE computation"
+      (let [;; Normal samples around 100, with one extreme outlier at end
+            raw-data (conj (vec (mapv #(+ 100.0 (* 0.5 %)) (range 49)))
+                           10000.0)
+            samples (metrics-samples
+                     {[:elapsed-time] raw-data}
+                     1)
+            data-map {:samples samples}
+            ;; Use the analysis functions to generate proper outliers
+            with-quantiles ((analyse/quantiles {:quantiles []}) data-map)
+            with-outliers ((analyse/outliers) with-quantiles)
+            ;; KDE uses log-samples by default, but we test with raw samples
+            result ((analyse/kde {:samples-id :samples
+                                  :n-bootstrap 10
+                                  :n-points 32})
+                    with-outliers)
+            kde-data (:kde result)
+            elapsed-kde (get-in kde-data [:kdes [:elapsed-time]])
+            grid (:grid elapsed-kde)
+            grid-max (apply max grid)]
+        ;; If outlier was included, grid would extend to ~10000
+        ;; With outlier excluded, grid max should be near 124 (100 + 0.5*48)
+        (is (< grid-max 200) "grid should not extend to outlier value")
+        (is (= :outliers (:outliers-id kde-data))
+            "should record outliers-id in output")))))

--- a/bases/criterium/test/criterium/test_utils.clj
+++ b/bases/criterium/test/criterium/test_utils.clj
@@ -3,7 +3,9 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [clojure.test.check.generators :as gen]
-   [criterium.util.stats :as stats]))
+   [criterium.util.stats :as stats]
+   [criterium.util.well :as well]
+   [criterium.util.ziggurat :as ziggurat]))
 
 (defn abs-error
   ^double [^double expected ^double actual]
@@ -133,6 +135,18 @@
   (->> s
        str/split-lines
        (mapv str/trim)))
+
+(defn gaussian-samples
+  "Generate n samples from a Gaussian distribution.
+  Uses WELL RNG and Ziggurat algorithm for high-quality random numbers.
+  Returns a vector of doubles."
+  ([n] (gaussian-samples n 0.0 1.0))
+  ([n mean std-dev] (gaussian-samples n mean std-dev 42))
+  ([n mean std-dev seed]
+   (let [rng (well/well-rng-1024a seed)
+         normals (ziggurat/random-normal-zig rng)]
+     (mapv (fn [^double x] (+ (double mean) (* (double std-dev) x)))
+           (take n normals)))))
 
 (defn plus-frac ^double [^double x ^double f]
   (+ x (* x f)))

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -6,6 +6,11 @@
    [clojure.test :refer [deftest is testing]]
    [criterium.util.kde :as kde]))
 
+(defn rand-double
+  "Returns a random double between 0 and 1."
+  ^double []
+  (clojure.core/rand))
+
 (deftest silverman-bandwidth-test
   ;; Tests Silverman's rule of thumb bandwidth selector against
   ;; expected values for known distributions.
@@ -44,20 +49,20 @@
   ;; estimation properties.
   (testing "gaussian-kde"
     (testing "density integrates to approximately 1"
-      (let [data [1.0 2.0 3.0 4.0 5.0]
-            h 1.0
-            grid (double-array (range 0.0 6.0 0.1))
+      (let [data    [1.0 2.0 3.0 4.0 5.0]
+            h       1.0
+            grid    (double-array (range 0.0 6.0 0.1))
             density (kde/gaussian-kde data h grid)
-            dx 0.1
-            total (* dx (reduce + density))]
+            dx      0.1
+            total   (* dx (double (reduce + density)))]
         (is (< (Math/abs (- total 1.0)) 0.1)
             "density should integrate to approximately 1")))
 
     (testing "density is highest near data concentration"
-      (let [data (double-array (repeat 10 5.0))
-            h 1.0
-            grid (double-array [0.0 2.5 5.0 7.5 10.0])
-            density (kde/gaussian-kde (vec data) h grid)]
+      (let [data             (double-array (repeat 10 5.0))
+            h                1.0
+            grid             (double-array [0.0 2.5 5.0 7.5 10.0])
+            ^doubles density (kde/gaussian-kde (vec data) h grid)]
         (is (> (aget density 2) (aget density 0))
             "density at mode should be higher than at edges")
         (is (> (aget density 2) (aget density 4))
@@ -165,16 +170,16 @@
   ;; Tests linear binning for correct distribution of weights.
   (testing "linear-bin"
     (testing "weights sum to 1"
-      (let [data [1.0 2.0 3.0 4.0 5.0]
-            grid (double-array [0.0 2.0 4.0 6.0])
-            weights (kde/linear-bin data grid)
-            total (reduce + weights)]
+      (let [data          [1.0 2.0 3.0 4.0 5.0]
+            grid          (double-array [0.0 2.0 4.0 6.0])
+            weights       (kde/linear-bin data grid)
+            ^double total (reduce + weights)]
         (is (< (Math/abs (- total 1.0)) 0.0001)
             "weights should sum to 1")))
 
     (testing "data at grid point goes to that bin"
-      (let [data [2.0]
-            grid (double-array [0.0 2.0 4.0 6.0])
+      (let [data    [2.0]
+            grid    (double-array [0.0 2.0 4.0 6.0])
             weights (kde/linear-bin data grid)]
         (is (> (aget weights 1) 0.9)
             "weight should be concentrated at matching grid point")))))
@@ -240,8 +245,8 @@
             normals (loop [i 0 result []]
                       (if (>= i n)
                         result
-                        (let [u1 (max 1e-10 (rand))
-                              u2 (rand)
+                        (let [u1 (max 1e-10 (rand-double))
+                              u2 (rand-double)
                               z (* (Math/sqrt (* -2.0 (Math/log u1)))
                                    (Math/cos (* 2.0 Math/PI u2)))
                               ;; N(50, 10^2)
@@ -271,8 +276,8 @@
             normals (loop [i 0 result []]
                       (if (>= i n)
                         result
-                        (let [u1 (max 1e-10 (rand))
-                              u2 (rand)
+                        (let [u1 (max 1e-10 (rand-double))
+                              u2 (rand-double)
                               z (* (Math/sqrt (* -2.0 (Math/log u1)))
                                    (Math/cos (* 2.0 Math/PI u2)))
                               x (+ 50.0 (* 10.0 z))]
@@ -283,16 +288,16 @@
 
     (testing "bimodal data should reject k=1"
       ;; Well-separated bimodal data
-      (let [cluster1 (repeatedly 100 #(+ -2.0 (* 0.5 (- (rand) 0.5))))
-            cluster2 (repeatedly 100 #(+ 2.0 (* 0.5 (- (rand) 0.5))))
+      (let [cluster1 (repeatedly 100 #(+ -2.0 (* 0.5 (- (rand-double) 0.5))))
+            cluster2 (repeatedly 100 #(+ 2.0 (* 0.5 (- (rand-double) 0.5))))
             data (concat cluster1 cluster2)
             result (kde/acr-test data 1 {:n-bootstrap 50})]
         (is (<= (:p-value result) 0.1)
             "Bimodal data should reject single mode hypothesis")))
 
     (testing "bimodal data should not reject k=2"
-      (let [cluster1 (repeatedly 100 #(+ -2.0 (* 0.5 (- (rand) 0.5))))
-            cluster2 (repeatedly 100 #(+ 2.0 (* 0.5 (- (rand) 0.5))))
+      (let [cluster1 (repeatedly 100 #(+ -2.0 (* 0.5 (- (rand-double) 0.5))))
+            cluster2 (repeatedly 100 #(+ 2.0 (* 0.5 (- (rand-double) 0.5))))
             data (concat cluster1 cluster2)
             result (kde/acr-test data 2 {:n-bootstrap 50})]
         (is (>= (:p-value result) 0.01)
@@ -332,7 +337,7 @@
     (testing "bimodal data has larger excess mass for k=1"
       ;; Two well-separated random clusters
       (let [cluster1 (repeatedly 50 rand) ;; [0, 1)
-            cluster2 (repeatedly 50 #(+ 5.0 (rand))) ;; [5, 6)
+            cluster2 (repeatedly 50 #(+ 5.0 (rand-double))) ;; [5, 6)
             data (concat cluster1 cluster2)
             em-k1 (:statistic (kde/excess-mass data 1))
             em-k2 (:statistic (kde/excess-mass data 2))]
@@ -352,7 +357,7 @@
       ;; Compare unimodal vs bimodal random data for k=1
       (let [unimodal (repeatedly 100 rand)
             bimodal (concat (repeatedly 50 rand)
-                            (repeatedly 50 #(+ 5.0 (rand))))
+                            (repeatedly 50 #(+ 5.0 (rand-double))))
             em-unimodal (:statistic (kde/excess-mass unimodal 1))
             em-bimodal (:statistic (kde/excess-mass bimodal 1))]
         (is (< em-unimodal em-bimodal)

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -1,0 +1,189 @@
+(ns criterium.util.kde-test
+  ;; Tests for the KDE (Kernel Density Estimation) module.
+  ;; Verifies ISJ bandwidth selection, Gaussian KDE evaluation,
+  ;; mode detection, and bootstrap confidence intervals.
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.util.kde :as kde]
+   [criterium.util.well :as well]))
+
+(deftest silverman-bandwidth-test
+  ;; Tests Silverman's rule of thumb bandwidth selector against
+  ;; expected values for known distributions.
+  (testing "silverman-bandwidth"
+    (testing "returns reasonable bandwidth for uniform data"
+      (let [data (range 0 100)
+            h (kde/silverman-bandwidth data)]
+        (is (pos? h) "bandwidth should be positive")
+        (is (< h 50) "bandwidth should be less than half the range")))
+
+    (testing "returns smaller bandwidth for tighter distributions"
+      (let [wide-data (range 0 100)
+            narrow-data (range 45 55)
+            h-wide (kde/silverman-bandwidth wide-data)
+            h-narrow (kde/silverman-bandwidth narrow-data)]
+        (is (< h-narrow h-wide)
+            "narrow distribution should have smaller bandwidth")))))
+
+(deftest isj-bandwidth-test
+  ;; Tests the ISJ bandwidth selector, which should produce reasonable
+  ;; bandwidths and fall back to Silverman when ISJ gives unreasonable results.
+  (testing "isj-bandwidth"
+    (testing "returns positive bandwidth"
+      (let [data (range 0 100)
+            h (kde/isj-bandwidth data)]
+        (is (pos? h) "bandwidth should be positive")))
+
+    (testing "falls back to Silverman for problematic data"
+      ;; Bimodal data where ISJ might give too large a bandwidth
+      (let [bimodal (concat (range 0 10) (range 90 100))
+            h (kde/isj-bandwidth bimodal)]
+        (is (< h 45) "should not return bandwidth larger than half the range")))))
+
+(deftest gaussian-kde-test
+  ;; Tests the Gaussian KDE evaluation function for correct density
+  ;; estimation properties.
+  (testing "gaussian-kde"
+    (testing "density integrates to approximately 1"
+      (let [data [1.0 2.0 3.0 4.0 5.0]
+            h 1.0
+            grid (double-array (range 0.0 6.0 0.1))
+            density (kde/gaussian-kde data h grid)
+            dx 0.1
+            total (* dx (reduce + density))]
+        (is (< (Math/abs (- total 1.0)) 0.1)
+            "density should integrate to approximately 1")))
+
+    (testing "density is highest near data concentration"
+      (let [data (double-array (repeat 10 5.0))
+            h 1.0
+            grid (double-array [0.0 2.5 5.0 7.5 10.0])
+            density (kde/gaussian-kde (vec data) h grid)]
+        (is (> (aget density 2) (aget density 0))
+            "density at mode should be higher than at edges")
+        (is (> (aget density 2) (aget density 4))
+            "density at mode should be higher than at edges")))))
+
+(deftest find-modes-test
+  ;; Tests mode detection for unimodal and multimodal distributions.
+  (testing "find-modes"
+    (testing "finds single mode in unimodal density"
+      (let [grid (double-array [0 1 2 3 4 5 6])
+            ;; Peak at position 3
+            density (double-array [0.1 0.2 0.3 0.5 0.3 0.2 0.1])
+            modes (kde/find-modes grid density)]
+        (is (= 1 (count modes)) "should find exactly one mode")
+        (is (= 3.0 (:location (first modes))) "mode should be at position 3")))
+
+    (testing "finds multiple modes in bimodal density"
+      (let [grid (double-array [0 1 2 3 4 5 6 7 8])
+            ;; Peaks at positions 2 and 6
+            density (double-array [0.1 0.2 0.4 0.2 0.1 0.2 0.4 0.2 0.1])
+            modes (kde/find-modes grid density)]
+        (is (= 2 (count modes)) "should find two modes")
+        (is (= #{2.0 6.0} (set (map :location modes)))
+            "modes should be at positions 2 and 6")))
+
+    (testing "returns modes sorted by density"
+      (let [grid (double-array [0 1 2 3 4 5 6 7 8])
+            ;; Higher peak at 2, lower peak at 6
+            density (double-array [0.1 0.2 0.5 0.2 0.1 0.2 0.3 0.2 0.1])
+            modes (kde/find-modes grid density)]
+        (is (= 2.0 (:location (first modes)))
+            "first mode should be the highest peak")))))
+
+(deftest kde-confidence-bands-test
+  ;; Tests bootstrap confidence bands for KDE density estimates.
+  (testing "kde-confidence-bands"
+    (testing "returns lower and upper bands of correct size"
+      (let [data (range 0 50)
+            h 2.0
+            grid (double-array (range 0.0 50.0 1.0))
+            bands (kde/kde-confidence-bands data h grid {:n-bootstrap 20})
+            n-grid (alength grid)]
+        (is (= n-grid (alength ^doubles (:lower bands))))
+        (is (= n-grid (alength ^doubles (:upper bands))))))
+
+    (testing "lower band <= upper band at all points"
+      (let [data (range 0 50)
+            h 2.0
+            grid (double-array (range 0.0 50.0 2.0))
+            bands (kde/kde-confidence-bands data h grid {:n-bootstrap 20})
+            lower ^doubles (:lower bands)
+            upper ^doubles (:upper bands)
+            n (alength lower)]
+        (is (every? true?
+                    (for [i (range n)]
+                      (<= (aget lower i) (aget upper i))))
+            "lower band should be <= upper band everywhere")))))
+
+(deftest kde-test
+  ;; Tests the main kde function for correct output structure
+  ;; and reasonable values.
+  (testing "kde"
+    (testing "returns correct structure"
+      (let [data (range 0 100)
+            result (kde/kde data {:n-bootstrap 10 :n-points 32})]
+        (is (= :criterium/kde (:type result)))
+        (is (number? (:bandwidth result)))
+        (is (vector? (:grid result)))
+        (is (vector? (:density result)))
+        (is (vector? (:lower-band result)))
+        (is (vector? (:upper-band result)))
+        (is (vector? (:modes result)))
+        (is (= 100 (:n result)))))
+
+    (testing "throws on empty data"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"empty"
+                            (kde/kde []))))
+
+    (testing "throws on constant data"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"same"
+                            (kde/kde (repeat 10 5.0)))))
+
+    (testing "respects custom bandwidth"
+      (let [data (range 0 100)
+            h 5.0
+            result (kde/kde data {:bandwidth h :n-bootstrap 10})]
+        (is (= h (:bandwidth result)))))
+
+    (testing "finds mode near data center for unimodal data"
+      (let [;; Data concentrated around 50
+            data (concat (range 40 60) (range 45 55))
+            result (kde/kde data {:n-bootstrap 10 :n-points 64})]
+        (when (seq (:modes result))
+          (let [mode-loc (:location (first (:modes result)))]
+            (is (< 40 mode-loc 60)
+                "mode should be near the data concentration")))))))
+
+(deftest dct-ii-test
+  ;; Tests DCT-II implementation for basic properties.
+  (testing "dct-ii"
+    (testing "first coefficient equals sum of inputs"
+      (let [data (double-array [1.0 2.0 3.0 4.0])
+            result (kde/dct-ii data)]
+        (is (< (Math/abs (- (aget result 0) 10.0)) 0.001)
+            "DC component should equal sum of inputs")))
+
+    (testing "returns array of same size"
+      (let [data (double-array [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0])
+            result (kde/dct-ii data)]
+        (is (= 8 (alength result)))))))
+
+(deftest linear-bin-test
+  ;; Tests linear binning for correct distribution of weights.
+  (testing "linear-bin"
+    (testing "weights sum to 1"
+      (let [data [1.0 2.0 3.0 4.0 5.0]
+            grid (double-array [0.0 2.0 4.0 6.0])
+            weights (kde/linear-bin data grid)
+            total (reduce + weights)]
+        (is (< (Math/abs (- total 1.0)) 0.0001)
+            "weights should sum to 1")))
+
+    (testing "data at grid point goes to that bin"
+      (let [data [2.0]
+            grid (double-array [0.0 2.0 4.0 6.0])
+            weights (kde/linear-bin data grid)]
+        (is (> (aget weights 1) 0.9)
+            "weight should be concentrated at matching grid point")))))

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -252,6 +252,66 @@
         (is (>= (:p-value result) 0.01)
             "Gaussian unimodal data should not strongly reject single mode")))))
 
+(deftest excess-mass-test
+  ;; Tests the excess mass statistic (Müller-Sawitzki 1991) for multimodality.
+  ;; Verifies the algorithm correctly distinguishes unimodal from multimodal data.
+  (testing "excess-mass"
+    (testing "returns correct structure"
+      (let [data (range 10 110)
+            result (kde/excess-mass data 1)]
+        (is (= 1 (:k result)))
+        (is (= 100 (:n result)))
+        (is (number? (:statistic result)))
+        (is (>= (:statistic result) 0) "statistic should be non-negative")))
+
+    (testing "handles small data"
+      (let [result (kde/excess-mass [1 2 3 4 5] 1)]
+        (is (number? (:statistic result)))))
+
+    (testing "rejects insufficient data"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"at least 3"
+                            (kde/excess-mass [1 2] 1))))
+
+    (testing "rejects invalid k"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"at least 1"
+                            (kde/excess-mass [1 2 3 4 5] 0))))
+
+    (testing "unimodal data has small excess mass for k=1"
+      ;; Uniform data is clearly unimodal
+      (let [data (range 0 100)
+            result (kde/excess-mass data 1)]
+        (is (< (:statistic result) 0.2)
+            "Uniform data should have small excess mass for k=1")))
+
+    (testing "bimodal data has larger excess mass for k=1"
+      ;; Two well-separated random clusters
+      (let [cluster1 (repeatedly 50 rand) ;; [0, 1)
+            cluster2 (repeatedly 50 #(+ 5.0 (rand))) ;; [5, 6)
+            data (concat cluster1 cluster2)
+            em-k1 (:statistic (kde/excess-mass data 1))
+            em-k2 (:statistic (kde/excess-mass data 2))]
+        (is (> em-k1 0.2)
+            (str "Bimodal data should have larger excess mass for k=1, got: " em-k1))
+        (is (< em-k2 em-k1)
+            "Bimodal data should have smaller excess mass for k=2 than k=1")))
+
+    (testing "handles ties in data via jitter"
+      ;; Data with many repeated values
+      (let [data (concat (repeat 30 1.0) (repeat 30 5.0) (repeat 30 10.0))
+            result (kde/excess-mass data 1)]
+        (is (number? (:statistic result))
+            "Should handle ties without error")))
+
+    (testing "statistic increases with more modes"
+      ;; Compare unimodal vs bimodal random data for k=1
+      (let [unimodal (repeatedly 100 rand)
+            bimodal (concat (repeatedly 50 rand)
+                            (repeatedly 50 #(+ 5.0 (rand))))
+            em-unimodal (:statistic (kde/excess-mass unimodal 1))
+            em-bimodal (:statistic (kde/excess-mass bimodal 1))]
+        (is (< em-unimodal em-bimodal)
+            "Bimodal data should have larger excess mass than unimodal")))))
+
 (deftest mode-confidence-intervals-test
   ;; Tests mode confidence interval computation.
   (testing "mode-confidence-intervals"

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -119,7 +119,8 @@
 
 (deftest kde-test
   ;; Tests the main kde function for correct output structure
-  ;; and reasonable values.
+  ;; and reasonable values. Note: modes are now computed separately
+  ;; via the modes analysis step.
   (testing "kde"
     (testing "returns correct structure"
       (let [data (range 0 100)
@@ -130,7 +131,7 @@
         (is (vector? (:density result)))
         (is (vector? (:lower-band result)))
         (is (vector? (:upper-band result)))
-        (is (vector? (:modes result)))
+        (is (nil? (:modes result)) "modes are computed separately")
         (is (= 100 (:n result)))))
 
     (testing "throws on empty data"
@@ -145,16 +146,7 @@
       (let [data (range 0 100)
             h 5.0
             result (kde/kde data {:bandwidth h :n-bootstrap 10})]
-        (is (= h (:bandwidth result)))))
-
-    (testing "finds mode near data center for unimodal data"
-      (let [;; Data concentrated around 50
-            data (concat (range 40 60) (range 45 55))
-            result (kde/kde data {:n-bootstrap 10 :n-points 64})]
-        (when (seq (:modes result))
-          (let [mode-loc (:location (first (:modes result)))]
-            (is (< 40 mode-loc 60)
-                "mode should be near the data concentration")))))))
+        (is (= h (:bandwidth result)))))))
 
 (deftest dct-ii-test
   ;; Tests DCT-II implementation for basic properties.
@@ -187,3 +179,104 @@
             weights (kde/linear-bin data grid)]
         (is (> (aget weights 1) 0.9)
             "weight should be concentrated at matching grid point")))))
+
+(deftest count-modes-test
+  ;; Tests the count-modes function for mode counting at different bandwidths.
+  (testing "count-modes"
+    (testing "finds single mode for unimodal data with appropriate bandwidth"
+      (let [data (range 0 100)]
+        (is (= 1 (kde/count-modes data 20.0 128))
+            "large bandwidth should give single mode")))
+
+    (testing "finds multiple modes for bimodal data with small bandwidth"
+      (let [bimodal (concat (repeat 50 10.0) (repeat 50 90.0))]
+        (is (>= (kde/count-modes bimodal 5.0 128) 2)
+            "small bandwidth on bimodal data should find multiple modes")))))
+
+(deftest critical-bandwidth-test
+  ;; Tests critical bandwidth computation for mode testing.
+  (testing "critical-bandwidth"
+    (testing "returns positive bandwidth"
+      (let [data (range 0 100)
+            h (kde/critical-bandwidth data 1 {})]
+        (is (pos? h) "critical bandwidth should be positive")))
+
+    (testing "larger k allows smaller bandwidth"
+      (let [data (range 0 100)
+            h1 (kde/critical-bandwidth data 1 {})
+            h2 (kde/critical-bandwidth data 2 {})]
+        (is (<= h2 h1) "more modes allowed means smaller bandwidth OK")))
+
+    (testing "finds appropriate bandwidth for bimodal data"
+      (let [bimodal (concat (repeat 50 10.0) (repeat 50 90.0))
+            h1 (kde/critical-bandwidth bimodal 1 {})
+            h2 (kde/critical-bandwidth bimodal 2 {})]
+        (is (> h1 h2) "bandwidth for 1 mode should be larger than for 2")))))
+
+(deftest silverman-test-test
+  ;; Tests Silverman's bootstrap test for multimodality.
+  (testing "silverman-test"
+    (testing "returns correct structure"
+      (let [data (range 0 100)
+            result (kde/silverman-test data 1 {:n-bootstrap 20})]
+        (is (= 1 (:k result)))
+        (is (number? (:critical-bandwidth result)))
+        (is (number? (:p-value result)))
+        (is (<= 0 (:p-value result) 1) "p-value should be between 0 and 1")
+        (is (boolean? (:corrected? result)))))
+
+    (testing "applies Hall-York correction for k=1"
+      (let [data (range 0 100)
+            result (kde/silverman-test data 1 {:n-bootstrap 20})]
+        (is (:corrected? result) "k=1 should have correction applied")))
+
+    (testing "does not apply correction for k>1"
+      (let [data (range 0 100)
+            result (kde/silverman-test data 2 {:n-bootstrap 20})]
+        (is (not (:corrected? result)) "k>1 should not have correction")))
+
+    (testing "unimodal Gaussian data should not reject k=1"
+      ;; Generate proper Gaussian data using Box-Muller transform
+      (let [n 200
+            normals (loop [i 0 result []]
+                      (if (>= i n)
+                        result
+                        (let [u1 (max 1e-10 (rand))
+                              u2 (rand)
+                              z (* (Math/sqrt (* -2.0 (Math/log u1)))
+                                   (Math/cos (* 2.0 Math/PI u2)))
+                              ;; N(50, 10^2)
+                              x (+ 50.0 (* 10.0 z))]
+                          (recur (inc i) (conj result x)))))
+            result (kde/silverman-test normals 1 {:n-bootstrap 100})]
+        ;; p-value should be relatively high (fail to reject H0: <= 1 mode)
+        (is (>= (:p-value result) 0.01)
+            "Gaussian unimodal data should not strongly reject single mode")))))
+
+(deftest mode-confidence-intervals-test
+  ;; Tests mode confidence interval computation.
+  (testing "mode-confidence-intervals"
+    (testing "returns correct structure"
+      (let [data (range 0 100)
+            h (kde/isj-bandwidth data)
+            grid (double-array (range 0.0 100.0 1.0))
+            modes (kde/mode-confidence-intervals data h grid 3
+                                                 {:n-bootstrap 20})]
+        (is (vector? modes))
+        (doseq [mode modes]
+          (is (number? (:location mode)))
+          (is (number? (:density mode)))
+          (is (number? (:ci-lower mode)))
+          (is (number? (:ci-upper mode))))))
+
+    (testing "CI lower <= location <= CI upper"
+      (let [data (concat (range 40 60) (range 45 55))
+            h (kde/isj-bandwidth data)
+            grid (double-array (range 0.0 100.0 1.0))
+            modes (kde/mode-confidence-intervals data h grid 1
+                                                 {:n-bootstrap 30})]
+        (doseq [mode modes]
+          (is (<= (:ci-lower mode) (:location mode))
+              "CI lower should be <= location")
+          (is (<= (:location mode) (:ci-upper mode))
+              "location should be <= CI upper"))))))

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -4,6 +4,7 @@
   ;; mode detection, and bootstrap confidence intervals.
   (:require
    [clojure.test :refer [deftest is testing]]
+   [criterium.test-utils :as tu]
    [criterium.util.kde :as kde]))
 
 (defn rand-double
@@ -397,31 +398,30 @@
   ;; unimodal and bimodal distributions.
   (testing "locate-modes"
     (testing "with unimodal data"
-      (testing "returns exactly one mode with k=1"
-        (let [unimodal (range 0 100)
-              result (kde/locate-modes unimodal 1 {})]
-          (is (= 1 (count (:modes result))))
-          (is (pos? (:critical-bandwidth result)))))
+      (let [unimodal (tu/gaussian-samples 100 50.0 10.0)]
+        (testing "returns exactly one mode with k=1"
+          (let [result (kde/locate-modes unimodal 1 {})]
+            (is (= 1 (count (:modes result))))
+            (is (pos? (:critical-bandwidth result)))))
 
-      (testing "returns no antimodes for single mode"
-        (let [unimodal (range 0 100)
-              result (kde/locate-modes unimodal 1 {})]
-          (is (empty? (:antimodes result))))))
+        (testing "returns no antimodes for single mode"
+          (let [result (kde/locate-modes unimodal 1 {})]
+            (is (empty? (:antimodes result)))))))
 
     (testing "with bimodal data"
-      (testing "returns two modes with k=2"
-        (let [bimodal (concat (range 0 50) (range 100 150))
-              result (kde/locate-modes bimodal 2 {})]
-          (is (= 2 (count (:modes result))))))
+      (let [bimodal (concat (tu/gaussian-samples 50 0.0 1.0 1)
+                            (tu/gaussian-samples 50 10.0 1.0 2))]
+        (testing "returns two modes with k=2"
+          (let [result (kde/locate-modes bimodal 2 {})]
+            (is (= 2 (count (:modes result))))))
 
-      (testing "modes are sorted by location"
-        (let [bimodal (concat (range 0 50) (range 100 150))
-              result (kde/locate-modes bimodal 2 {})
-              locs (map :location (:modes result))]
-          (is (apply < locs) "modes should be in ascending order"))))
+        (testing "modes are sorted by location"
+          (let [result (kde/locate-modes bimodal 2 {})
+                locs (map :location (:modes result))]
+            (is (apply < locs) "modes should be in ascending order")))))
 
     (testing "returns correct structure"
-      (let [data (range 0 100)
+      (let [data (tu/gaussian-samples 100 50.0 10.0)
             result (kde/locate-modes data 1 {})]
         (is (contains? result :modes))
         (is (contains? result :antimodes))
@@ -431,7 +431,7 @@
         (is (number? (:critical-bandwidth result)))))
 
     (testing "mode maps have required keys"
-      (let [data (range 0 100)
+      (let [data (tu/gaussian-samples 100 50.0 10.0)
             result (kde/locate-modes data 1 {})
             mode (first (:modes result))]
         (is (contains? mode :location))

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -385,3 +385,51 @@
               "CI lower should be <= location")
           (is (<= (:location mode) (:ci-upper mode))
               "location should be <= CI upper"))))))
+
+(deftest locate-modes-test
+  ;; Tests locate-modes using critical bandwidth for mode/antimode finding.
+  ;; Verifies that modes and antimodes are correctly identified for
+  ;; unimodal and bimodal distributions.
+  (testing "locate-modes"
+    (testing "with unimodal data"
+      (testing "returns exactly one mode with k=1"
+        (let [unimodal (range 0 100)
+              result (kde/locate-modes unimodal 1 {})]
+          (is (= 1 (count (:modes result))))
+          (is (pos? (:critical-bandwidth result)))))
+
+      (testing "returns no antimodes for single mode"
+        (let [unimodal (range 0 100)
+              result (kde/locate-modes unimodal 1 {})]
+          (is (empty? (:antimodes result))))))
+
+    (testing "with bimodal data"
+      (testing "returns two modes with k=2"
+        (let [bimodal (concat (range 0 50) (range 100 150))
+              result (kde/locate-modes bimodal 2 {})]
+          (is (= 2 (count (:modes result))))))
+
+      (testing "modes are sorted by location"
+        (let [bimodal (concat (range 0 50) (range 100 150))
+              result (kde/locate-modes bimodal 2 {})
+              locs (map :location (:modes result))]
+          (is (apply < locs) "modes should be in ascending order"))))
+
+    (testing "returns correct structure"
+      (let [data (range 0 100)
+            result (kde/locate-modes data 1 {})]
+        (is (contains? result :modes))
+        (is (contains? result :antimodes))
+        (is (contains? result :critical-bandwidth))
+        (is (vector? (:modes result)))
+        (is (vector? (:antimodes result)))
+        (is (number? (:critical-bandwidth result)))))
+
+    (testing "mode maps have required keys"
+      (let [data (range 0 100)
+            result (kde/locate-modes data 1 {})
+            mode (first (:modes result))]
+        (is (contains? mode :location))
+        (is (contains? mode :density))
+        (is (number? (:location mode)))
+        (is (number? (:density mode)))))))

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -252,6 +252,52 @@
         (is (>= (:p-value result) 0.01)
             "Gaussian unimodal data should not strongly reject single mode")))))
 
+(deftest acr-test-test
+  ;; Tests ACR test (Ameijeiras-Alonso et al. 2019) for multimodality.
+  ;; Combines critical bandwidth and excess mass for better calibration.
+  (testing "acr-test"
+    (testing "returns correct structure"
+      (let [data (range 0 100)
+            result (kde/acr-test data 1 {:n-bootstrap 20})]
+        (is (= 1 (:k result)))
+        (is (number? (:critical-bandwidth result)))
+        (is (number? (:excess-mass result)))
+        (is (>= (:excess-mass result) 0) "excess mass should be non-negative")
+        (is (number? (:p-value result)))
+        (is (<= 0 (:p-value result) 1) "p-value should be between 0 and 1")))
+
+    (testing "unimodal Gaussian data should not reject k=1"
+      (let [n 200
+            normals (loop [i 0 result []]
+                      (if (>= i n)
+                        result
+                        (let [u1 (max 1e-10 (rand))
+                              u2 (rand)
+                              z (* (Math/sqrt (* -2.0 (Math/log u1)))
+                                   (Math/cos (* 2.0 Math/PI u2)))
+                              x (+ 50.0 (* 10.0 z))]
+                          (recur (inc i) (conj result x)))))
+            result (kde/acr-test normals 1 {:n-bootstrap 100})]
+        (is (>= (:p-value result) 0.01)
+            "Gaussian unimodal data should not strongly reject single mode")))
+
+    (testing "bimodal data should reject k=1"
+      ;; Well-separated bimodal data
+      (let [cluster1 (repeatedly 100 #(+ -2.0 (* 0.5 (- (rand) 0.5))))
+            cluster2 (repeatedly 100 #(+ 2.0 (* 0.5 (- (rand) 0.5))))
+            data (concat cluster1 cluster2)
+            result (kde/acr-test data 1 {:n-bootstrap 50})]
+        (is (<= (:p-value result) 0.1)
+            "Bimodal data should reject single mode hypothesis")))
+
+    (testing "bimodal data should not reject k=2"
+      (let [cluster1 (repeatedly 100 #(+ -2.0 (* 0.5 (- (rand) 0.5))))
+            cluster2 (repeatedly 100 #(+ 2.0 (* 0.5 (- (rand) 0.5))))
+            data (concat cluster1 cluster2)
+            result (kde/acr-test data 2 {:n-bootstrap 50})]
+        (is (>= (:p-value result) 0.01)
+            "Bimodal data should not reject k=2 hypothesis")))))
+
 (deftest excess-mass-test
   ;; Tests the excess mass statistic (Müller-Sawitzki 1991) for multimodality.
   ;; Verifies the algorithm correctly distinguishes unimodal from multimodal data.

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -4,8 +4,7 @@
   ;; mode detection, and bootstrap confidence intervals.
   (:require
    [clojure.test :refer [deftest is testing]]
-   [criterium.util.kde :as kde]
-   [criterium.util.well :as well]))
+   [criterium.util.kde :as kde]))
 
 (deftest silverman-bandwidth-test
   ;; Tests Silverman's rule of thumb bandwidth selector against

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -1200,10 +1200,14 @@
             (is (= :kind/vega-lite (:kindly/kind (meta chart))))
             (is (string? (:$schema chart)) "Expected Vega-Lite schema")
             (is (contains? chart :vconcat))
-            (let [first-chart (first (:vconcat chart))]
+            (let [first-chart (first (:vconcat chart))
+                  layers (:layer first-chart)
+                  ;; KDE layers are nested in a group for independent Y-scale
+                  kde-group (first layers)
+                  kde-layers (:layer kde-group)]
               (is (contains? first-chart :layer))
-              (is (>= (count (:layer first-chart)) 2)
-                  "Expected at least confidence band and density layers"))))))
+              (is (>= (count kde-layers) 2)
+                  "Expected at least confidence band and density layers in nested group"))))))
 
     (testing "uses custom kde-id"
       (reset! kindly/accumulated [])

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -6,6 +6,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
+   [criterium.collector.metrics :as metrics]
    [criterium.test-data :as test-data]
    [criterium.view :as view]
    [criterium.viewer.kindly :as kindly]))
@@ -1164,4 +1165,67 @@
       (view/allocation-treemap* :kindly {}
                                 {:allocation-treemap
                                  {:type :criterium/allocation-treemap}})
+      (is (nil? (kindly/flush))))))
+
+(deftest kde-view-test
+  ;; Tests the view/kde* multimethod for :kindly viewer.
+  ;; Verifies that KDE data is rendered as a heading and Vega-Lite chart
+  ;; with density curve, confidence bands, and optional mode markers.
+  (testing "view/kde* :kindly"
+    (testing "renders KDE as heading and Vega-Lite chart"
+      (reset! kindly/accumulated [])
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :modes [{:location 2.0
+                                       :density 0.3
+                                       :ci-lower 1.8
+                                       :ci-upper 2.2}]
+                              :n 100}}}]
+        (view/kde* :kindly {} {:kde kde-data})
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 2 (count result)) "Expected heading and chart")
+          (let [[heading chart] result]
+            (is (= :kind/md (:kindly/kind (meta heading))))
+            (is (= ["**Kernel Density Estimation**"] heading))
+            (is (= :kind/vega-lite (:kindly/kind (meta chart))))
+            (is (string? (:$schema chart)) "Expected Vega-Lite schema")
+            (is (contains? chart :vconcat))
+            (let [first-chart (first (:vconcat chart))]
+              (is (contains? first-chart :layer))
+              (is (>= (count (:layer first-chart)) 2)
+                  "Expected at least confidence band and density layers"))))))
+
+    (testing "uses custom kde-id"
+      (reset! kindly/accumulated [])
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.3
+                              :grid [1.0]
+                              :density [0.5]
+                              :lower-band [0.4]
+                              :upper-band [0.6]
+                              :modes []
+                              :n 25}}}]
+        (view/kde* :kindly {:kde-id :my-kde} {:my-kde kde-data})
+        (let [result (kindly/flush)
+              [heading _chart] result]
+          (is (= ["**Kernel Density Estimation**"] heading)))))
+
+    (testing "handles missing kde data gracefully"
+      (reset! kindly/accumulated [])
+      (view/kde* :kindly {} {})
       (is (nil? (kindly/flush))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -761,3 +761,65 @@
           (is (empty? @v))
           (finally
             (remove-tap f)))))))
+
+(deftest portal-kde-test
+  ;; Tests the portal viewer output for KDE analysis results.
+  ;; Verifies Vega-Lite spec generation with density curve and optional histogram overlay.
+  (testing "kde*"
+    (testing "produces vega-lite output with kde spec"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :modes [{:location 2.0
+                                       :density 0.3
+                                       :ci-lower 1.8
+                                       :ci-upper 2.2}]
+                              :n 100}}}
+            [title vega-spec] (with-tap-out
+                                (view/kde* :portal {} {:kde kde-data}))
+            viewer-meta (meta vega-spec)]
+        (is (= [:b "Kernel Density Estimation"] title))
+        (is (= :portal.viewer/vega-lite (:portal.viewer/default viewer-meta)))
+        (is (str/includes? (:$schema vega-spec) "vega-lite"))
+        (is (contains? vega-spec :vconcat))
+        (is (vector? (:vconcat vega-spec)))
+        (let [first-chart (first (:vconcat vega-spec))]
+          (is (contains? first-chart :layer))
+          (is (>= (count (:layer first-chart)) 2)))))
+
+    (testing "handles missing kde data gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/kde* :portal {} {})
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))
+
+    (testing "uses custom kde-id"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.3
+                              :grid [1.0]
+                              :density [0.5]
+                              :lower-band [0.4]
+                              :upper-band [0.6]
+                              :modes []
+                              :n 25}}}
+            [title _spec] (with-tap-out
+                            (view/kde* :portal {:kde-id :my-kde} {:my-kde kde-data}))]
+        (is (= [:b "Kernel Density Estimation"] title))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
+   [criterium.collector.metrics]
    [criterium.test-data :as test-data]
    [criterium.view :as view]
    [criterium.viewer.portal :as portal])

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -791,9 +791,14 @@
         (is (str/includes? (:$schema vega-spec) "vega-lite"))
         (is (contains? vega-spec :vconcat))
         (is (vector? (:vconcat vega-spec)))
-        (let [first-chart (first (:vconcat vega-spec))]
+        (let [first-chart (first (:vconcat vega-spec))
+              layers (:layer first-chart)
+              ;; KDE layers are nested in a group for independent Y-scale
+              kde-group (first layers)
+              kde-layers (:layer kde-group)]
           (is (contains? first-chart :layer))
-          (is (>= (count (:layer first-chart)) 2)))))
+          (is (>= (count kde-layers) 2)
+              "Expected at least confidence band and density layers in nested group"))))
 
     (testing "handles missing kde data gracefully"
       (let [v (volatile! [])

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -413,3 +413,37 @@
         (is (str/includes? output "type→class→line"))
         (is (str/includes? output "count"))
         (is (str/includes? output "Object"))))))
+
+(deftest kde-pprint-test
+  ;; Tests the pprint viewer output for KDE analysis results.
+  ;; Verifies tabular mode display format with bandwidth and modes table.
+  (testing "kde*"
+    (testing "prints KDE summary with modes table"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :modes [{:location 2.0
+                                       :density 0.3
+                                       :ci-lower 1.8
+                                       :ci-upper 2.2}]
+                              :n 100}}}
+            output (with-out-str
+                     (view/kde* :pprint {} {:kde kde-data}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "KDE of Elapsed Time") lines))
+        (is (some #(str/includes? % "n=100") lines))
+        (is (some #(str/includes? % ":location") lines))
+        (is (some #(str/includes? % ":density") lines))))
+
+    (testing "handles missing KDE data"
+      (let [output (with-out-str
+                     (view/kde* :pprint {} {}))]
+        (is (str/blank? output))))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
+   [criterium.collector.metrics]
    [criterium.test-data :as test-data]
    [criterium.test-utils :refer [trimmed-lines]]
    [criterium.view :as view]

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -951,7 +951,7 @@
   ;; Tests the print viewer output for KDE analysis results.
   ;; Verifies bandwidth display, mode count, and mode table formatting.
   (testing "kde*"
-    (testing "prints KDE summary with bandwidth and modes"
+    (testing "prints KDE summary with bandwidth and modes from separate modes data"
       (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
             kde-data {:type :criterium/kde
                       :metrics-defs metrics-defs
@@ -963,13 +963,17 @@
                               :density [0.1 0.3 0.1]
                               :lower-band [0.08 0.25 0.08]
                               :upper-band [0.12 0.35 0.12]
-                              :modes [{:location 2.0
-                                       :density 0.3
-                                       :ci-lower 1.8
-                                       :ci-upper 2.2}]
                               :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform collect-plan/identity-transforms
+                        :modes {[:elapsed-time]
+                                {:modes [{:location 2.0
+                                          :density 0.3
+                                          :ci-lower 1.8
+                                          :ci-upper 2.2}]
+                                 :n-modes 1}}}
             output (with-out-str
-                     (view/kde* :print {} {:kde kde-data}))
+                     (view/kde* :print {} {:kde kde-data :modes modes-data}))
             lines (trimmed-lines output)]
         (is (some #(str/includes? % "Elapsed Time") lines))
         (is (some #(str/includes? % "KDE") lines))
@@ -981,7 +985,7 @@
         (is (some #(str/includes? % "CI Lower") lines))
         (is (some #(str/includes? % "CI Upper") lines))))
 
-    (testing "handles KDE with no modes"
+    (testing "handles KDE without modes data"
       (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
             kde-data {:type :criterium/kde
                       :metrics-defs metrics-defs
@@ -993,7 +997,6 @@
                               :density [0.1 0.2 0.1]
                               :lower-band [0.08 0.18 0.08]
                               :upper-band [0.12 0.22 0.12]
-                              :modes []
                               :n 50}}}
             output (with-out-str
                      (view/kde* :print {} {:kde kde-data}))
@@ -1006,7 +1009,7 @@
                      (view/kde* :print {} {}))]
         (is (str/blank? output))))
 
-    (testing "uses custom kde-id"
+    (testing "uses custom kde-id and modes-id"
       (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
             kde-data {:type :criterium/kde
                       :metrics-defs metrics-defs
@@ -1018,8 +1021,17 @@
                               :density [0.5]
                               :lower-band [0.4]
                               :upper-band [0.6]
-                              :modes []
                               :n 25}}}
+            modes-data {:type :criterium/modes
+                        :transform collect-plan/identity-transforms
+                        :modes {[:elapsed-time]
+                                {:modes [{:location 1.0
+                                          :density 0.5
+                                          :ci-lower 0.9
+                                          :ci-upper 1.1}]
+                                 :n-modes 1}}}
             output (with-out-str
-                     (view/kde* :print {:kde-id :my-kde} {:my-kde kde-data}))]
-        (is (str/includes? output "n=25"))))))
+                     (view/kde* :print {:kde-id :my-kde :modes-id :my-modes}
+                                {:my-kde kde-data :my-modes modes-data}))]
+        (is (str/includes? output "n=25"))
+        (is (str/includes? output "modes: 1"))))))

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -946,3 +946,80 @@
         (is (str/includes? output "type→class→line"))
         (is (str/includes? output "count"))
         (is (str/includes? output "Object"))))))
+
+(deftest kde-print-test
+  ;; Tests the print viewer output for KDE analysis results.
+  ;; Verifies bandwidth display, mode count, and mode table formatting.
+  (testing "kde*"
+    (testing "prints KDE summary with bandwidth and modes"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform collect-plan/identity-transforms
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :modes [{:location 2.0
+                                       :density 0.3
+                                       :ci-lower 1.8
+                                       :ci-upper 2.2}]
+                              :n 100}}}
+            output (with-out-str
+                     (view/kde* :print {} {:kde kde-data}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Elapsed Time") lines))
+        (is (some #(str/includes? % "KDE") lines))
+        (is (some #(str/includes? % "n=100") lines))
+        (is (some #(str/includes? % "bandwidth") lines))
+        (is (some #(str/includes? % "modes: 1") lines))
+        (is (some #(str/includes? % "Location") lines))
+        (is (some #(str/includes? % "Density") lines))
+        (is (some #(str/includes? % "CI Lower") lines))
+        (is (some #(str/includes? % "CI Upper") lines))))
+
+    (testing "handles KDE with no modes"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform collect-plan/identity-transforms
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.2 0.1]
+                              :lower-band [0.08 0.18 0.08]
+                              :upper-band [0.12 0.22 0.12]
+                              :modes []
+                              :n 50}}}
+            output (with-out-str
+                     (view/kde* :print {} {:kde kde-data}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "n=50") lines))
+        (is (not (some #(str/includes? % "modes:") lines)))))
+
+    (testing "handles missing KDE data"
+      (let [output (with-out-str
+                     (view/kde* :print {} {}))]
+        (is (str/blank? output))))
+
+    (testing "uses custom kde-id"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform collect-plan/identity-transforms
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.3
+                              :grid [1.0]
+                              :density [0.5]
+                              :lower-band [0.4]
+                              :upper-band [0.6]
+                              :modes []
+                              :n 25}}}
+            output (with-out-str
+                     (view/kde* :print {:kde-id :my-kde} {:my-kde kde-data}))]
+        (is (str/includes? output "n=25"))))))

--- a/bases/notebooks/src/criterium/index.clj
+++ b/bases/notebooks/src/criterium/index.clj
@@ -25,3 +25,4 @@
 ;; - [Domain Bench](./criterium.domain_bench_notebook.html) - Simplified domain benchmarking with domain/bench
 ;; - [Domain Analysis](./criterium.analyse_domain_notebook.html) - Manual domain construction and analysis
 ;; - [Domain Builder](./criterium.domain_builder_notebook.html) - Automated domain construction and workflows
+;; - [KDE Analysis](./criterium.kde_analysis_notebook.html) - Kernel density estimation for sample distributions

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -36,7 +36,7 @@
 ;; ## Using the kde-modes Bench Plan
 ;;
 ;; For statistically validated mode detection, use the `kde-modes` bench plan.
-;; This includes Silverman's bootstrap test for multimodality.
+;; This includes multimodality testing to validate the number of distribution modes.
 
 ^:kindly/hide-code
 (bench-display
@@ -45,7 +45,7 @@
 
 ;; The kde-modes plan adds:
 ;; - Mode detection with confidence intervals
-;; - Silverman's test p-values for each k (number of modes)
+;; - ACR test p-values for each k (number of modes)
 ;; - Validated mode count based on statistical significance
 
 ;; ## Understanding KDE Output
@@ -75,13 +75,30 @@
 ;; Mode analysis (from the `kde-modes` plan) provides statistically validated
 ;; peaks in the density curve:
 
-;; ### Silverman's Test
+;; ### Multimodality Testing Methods
 ;;
-;; Silverman's bootstrap test determines if the data supports k modes. The test
-;; is run for k=1, 2, 3, ... up to max-modes. A low p-value indicates evidence
-;; for more than k modes.
+;; Criterium supports two methods for testing multimodality:
 ;;
-;; For k=1, the Hall-York correction is applied for better calibration.
+;; **ACR Test (Default)**
+;;
+;; The ACR test (Ameijeiras-Alonso, Crujeiras, Rodríguez-Casal 2019) uses
+;; excess mass as the test statistic. This provides better calibration than
+;; mode counting, especially for detecting genuine multimodality vs noise.
+;;
+;; **Silverman's Test**
+;;
+;; Silverman's bootstrap test determines if the data supports k modes by
+;; counting modes in bootstrap samples. For k=1, the Hall-York correction
+;; is applied. However, mode counting can be sensitive to noise and may
+;; be overly conservative.
+;;
+;; **Why ACR is Recommended**
+;;
+;; - Excess mass is more robust to small fluctuations in the density
+;; - Better calibrated p-values across different sample sizes
+;; - Less sensitive to bandwidth choice than mode counting
+;;
+;; Use `:method :silverman` if you specifically need backward compatibility.
 
 ;; ### Validated Mode Count
 ;;
@@ -92,7 +109,28 @@
 ;; ### Mode Significance
 ;;
 ;; Each detected mode is marked with `significant?` indicating whether
-;; Silverman's test supports its existence.
+;; the test supports its existence.
+
+;; ### Understanding ACR Test Results
+;;
+;; The ACR test output includes:
+;;
+;; - `:method` - The test method used (`:acr` or `:silverman`)
+;; - `:k-tested` - Vector of k values tested (e.g., [1 2 3])
+;; - `:p-values` - Map of k to p-value (e.g., {1 0.02, 2 0.45})
+;; - `:critical-bandwidths` - Map of k to h_k (smallest bandwidth giving ≤ k modes)
+;; - `:excess-mass` - Map of k to excess mass statistic (ACR only)
+;;
+;; **Interpreting excess mass:**
+;; - Larger values suggest stronger evidence for more than k modes
+;; - The p-value is computed by comparing observed excess mass to bootstrap
+;;   samples under the null hypothesis
+;;
+;; **Example interpretation:**
+;; If `:p-values {1 0.02, 2 0.35}`:
+;; - p=0.02 for k=1: Reject H0 (unimodal), evidence for >1 mode
+;; - p=0.35 for k=2: Fail to reject H0 (≤2 modes)
+;; - Conclusion: n-modes = 2 (bimodal distribution)
 
 ;; ## Accessing KDE and Modes Results Programmatically
 ;;
@@ -107,7 +145,7 @@
         modes-result (:modes data)]
     {:bandwidth (get-in kde-result [:kdes [:elapsed-time] :bandwidth])
      :n-modes (get-in modes-result [:modes [:elapsed-time] :n-modes])
-     :silverman-p-values (get-in modes-result [:modes [:elapsed-time] :silverman :p-values])
+     :test-results (get-in modes-result [:modes [:elapsed-time] :test-results])
      :modes (get-in modes-result [:modes [:elapsed-time] :modes])}))
 
 ;; ## Customizing KDE Options
@@ -134,8 +172,27 @@
 
 ;; ### max-modes
 ;;
-;; Maximum number of modes to test. Default is 5. Silverman's test is run
+;; Maximum number of modes to test. Default is 5. The test is run
 ;; for k=1 through max-modes.
+
+;; ### method
+;;
+;; The multimodality test method. Options:
+;; - `:acr` (default) - Uses excess mass statistic for better calibration
+;; - `:silverman` - Uses bootstrap mode count (legacy method)
+
+;; ### mode-method
+;;
+;; How mode locations are determined. Options:
+;; - `:isj` (default) - Find modes from KDE density at ISJ bandwidth
+;; - `:critical` - Find modes at critical bandwidth for validated k modes
+;;
+;; When using `:critical`, the output includes additional fields:
+;; - `:antimodes` - Local minima between modes (useful for segmentation)
+;; - `:mode-bandwidth` - The critical bandwidth used for mode finding
+;;
+;; The critical bandwidth approach finds the smallest bandwidth that gives
+;; exactly k modes, which can provide more stable mode locations.
 
 ;; ### Custom Bench Plan Example
 ;;
@@ -151,13 +208,34 @@
               [:stats {:samples-id :log-samples :id :log-stats}]
               :histogram
               [:kde {:n-points 256 :n-bootstrap 100}]
-              [:modes {:max-modes 3 :n-bootstrap 100}]
+              [:modes {:max-modes 3 :n-bootstrap 100 :method :acr}]
               :event-stats])))
 
 ^:kindly/hide-code
 (bench-display
  (bench/bench (reduce + (range 1000))
               :bench-plan custom-kde-modes-plan))
+
+;; ### Using Critical Bandwidth for Mode Finding
+;;
+;; The critical bandwidth approach can provide more stable mode locations:
+
+(def critical-modes-plan
+  (-> bench-plans/kde-modes
+      (assoc :analyse
+             [:transform-log
+              [:quantiles {:quantiles [0.25 0.5 0.75]}]
+              :outliers
+              [:stats {}]
+              :histogram
+              [:kde {:n-points 512}]
+              [:modes {:max-modes 3 :mode-method :critical}]
+              :event-stats])))
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (reduce + (range 1000))
+              :bench-plan critical-modes-plan))
 
 ;; ## Visualization with Portal and Kindly
 ;;
@@ -199,8 +277,10 @@
 ;; - CPU frequency scaling
 ;; - Cache effects
 ;;
-;; Silverman's test provides statistical validation for multimodality. A low
-;; p-value for k=1 suggests the distribution is not unimodal.
+;; The ACR test provides statistical validation for multimodality. A low
+;; p-value for k=1 suggests the distribution is not unimodal. The ACR test
+;; uses the excess mass statistic, which measures how much the empirical
+;; distribution exceeds what would be expected under k modes.
 
 ;; ### Example: Synthetic Multimodal Distribution
 ;;
@@ -208,14 +288,49 @@
 
 (defn variable-work
   "Simulate variable-time work with occasional slow paths."
-  [^long n]
-  (if (zero? (long (mod (rand-int 100) 5)))
-    (reduce + (range (* n 10))) ; 20% slow path
-    (reduce + (range n)))) ; 90% fast path
+  [^long n slow?]
+  (if slow?
+    (reduce + (range (* n 3))) ; slow path
+    (reduce + (range n)))) ; fast path
 
-(bench/bench (variable-work 100)
-             :bench-plan bench-plans/kde-modes
-             :viewer :kindly)
+(bench/bench
+ (variable-work 100 (zero? (long (mod (rand-int 100) 3))))
+ :bench-plan bench-plans/kde-modes
+ :viewer :kindly)
+
+;; ### Comparing ACR and Silverman Results
+;;
+;; You can compare results from both test methods:
+
+(defn compare-test-methods
+  "Run both ACR and Silverman tests and compare results."
+  [expr-fn]
+  (let [acr-plan bench-plans/kde-modes
+        silverman-plan (assoc-in bench-plans/kde-modes
+                                 [:analyse 7 1 :method] :silverman)]
+    ;; Run with ACR
+    (bench/bench-measured {:args-fn (fn [] [])
+                           :f expr-fn}
+                          {:bench-plan acr-plan
+                           :viewer :none})
+    (let [acr-result (get-in (:data (bench/last-bench))
+                             [:modes :modes [:elapsed-time]])]
+      ;; Run with Silverman
+      (bench/bench-measured {:args-fn (fn [] [])
+                             :f expr-fn}
+                            {:bench-plan silverman-plan
+                             :viewer :none})
+      (let [silv-result (get-in (:data (bench/last-bench))
+                                [:modes :modes [:elapsed-time]])]
+        {:acr {:n-modes (:n-modes acr-result)
+               :p-values (get-in acr-result [:test-results :p-values])
+               :excess-mass (get-in acr-result [:test-results :excess-mass])}
+         :silverman {:n-modes (:n-modes silv-result)
+                     :p-values (get-in silv-result [:test-results :p-values])}}))))
+
+;; Compare results on the multimodal example:
+(kind/code
+ "(compare-test-methods #(variable-work 100 (zero? (mod (rand-int 100) 3))))")
 
 ;; ## Comparing KDE to Histograms
 ;;
@@ -237,14 +352,20 @@
 ;;    to see the distribution shape without statistical mode validation.
 ;;
 ;; 2. **Use kde-modes for mode detection** - When you need statistically
-;;    validated mode counts with Silverman's test.
+;;    validated mode counts with the ACR test.
 ;;
-;; 3. **Check Silverman's p-values** - Low p-values for k=1 indicate
-;;    evidence against unimodality.
+;; 3. **Check test p-values** - Low p-values for k=1 indicate evidence
+;;    against unimodality. The `test-results` map contains p-values for each k.
 ;;
-;; 4. **Consider computation cost** - Mode analysis with Silverman's test
-;;    involves multiple rounds of bootstrap resampling. Use `kde-histogram`
-;;    when you only need the density curve.
+;; 4. **Use ACR over Silverman** - ACR provides better calibrated p-values
+;;    and is less sensitive to noise in the density estimate.
+;;
+;; 5. **Consider :mode-method :critical** - When you need stable mode
+;;    locations and want to identify antimodes (valleys between peaks).
+;;
+;; 6. **Consider computation cost** - Mode analysis involves multiple rounds
+;;    of bootstrap resampling. Use `kde-histogram` when you only need the
+;;    density curve.
 
 ;; ## Running Examples
 ;;
@@ -255,7 +376,7 @@
   (bench/bench (reduce + (range 1000))
                :bench-plan bench-plans/kde-histogram)
 
-  ;; KDE with mode detection and Silverman's test
+  ;; KDE with mode detection and ACR test (default)
   (bench/bench (reduce + (range 1000))
                :bench-plan bench-plans/kde-modes)
 
@@ -263,7 +384,18 @@
   (let [data (:data (bench/last-bench))]
     {:kde-bandwidth (get-in data [:kde :kdes [:elapsed-time] :bandwidth])
      :n-modes (get-in data [:modes :modes [:elapsed-time] :n-modes])
-     :p-values (get-in data [:modes :modes [:elapsed-time] :silverman :p-values])})
+     :test-results (get-in data [:modes :modes [:elapsed-time] :test-results])
+     :excess-mass (get-in data [:modes :modes [:elapsed-time] :test-results :excess-mass])})
+
+  ;; Use Silverman test instead of ACR
+  (bench/bench (reduce + (range 1000))
+               :bench-plan (assoc-in bench-plans/kde-modes
+                                     [:analyse 7 1 :method] :silverman))
+
+  ;; Use critical bandwidth for mode finding
+  (bench/bench (reduce + (range 1000))
+               :bench-plan (assoc-in bench-plans/kde-modes
+                                     [:analyse 7 1 :mode-method] :critical))
 
   ;; Custom options
   (bench/bench (reduce + (range 1000))

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -169,8 +169,8 @@
 
 (defn variable-work
   "Simulate variable-time work with occasional slow paths."
-  [n]
-  (if (zero? (mod (rand-int 100) 10))
+  [^long n]
+  (if (zero? (long (mod (rand-int 100) 10)))
     (reduce + (range (* n 10))) ; 10% slow path
     (reduce + (range n)))) ; 90% fast path
 

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -1,0 +1,231 @@
+(ns criterium.kde-analysis-notebook
+  "Kernel Density Estimation analysis for benchmark samples."
+  (:require
+   [criterium.bench :as bench]
+   [criterium.bench-plans :as bench-plans]
+   [criterium.notebook.helpers :refer [bench-display]]
+   [scicloj.kindly.v4.kind :as kind]))
+
+;; # KDE Analysis for Benchmark Samples
+;;
+;; Kernel Density Estimation (KDE) provides a smooth, continuous estimate of
+;; the probability density function underlying benchmark samples. This is useful
+;; for:
+;;
+;; - Visualizing sample distributions beyond histograms
+;; - Detecting multimodality (multiple peaks indicating distinct performance modes)
+;; - Identifying modes with confidence intervals
+;; - Understanding the shape of timing distributions
+
+;; ## Using the kde-histogram Bench Plan
+;;
+;; The `kde-histogram` bench plan includes both histogram and KDE analysis.
+;; This is not part of the default plan; use it explicitly when density
+;; analysis is needed.
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (reduce + (range 1000))
+              :bench-plan bench-plans/kde-histogram))
+
+;; The output includes:
+;; - Standard statistics (mean, standard deviation)
+;; - Histogram visualization
+;; - KDE density curve overlaid on the histogram
+;; - Detected modes with confidence intervals
+
+;; ## Understanding KDE Output
+;;
+;; KDE analysis produces several key outputs:
+
+;; ### Bandwidth
+;;
+;; The bandwidth controls the smoothness of the density estimate. Criterium uses
+;; ISJ (Improved Sheather-Jones) bandwidth selection, which automatically chooses
+;; an optimal bandwidth based on the data. A smaller bandwidth captures more
+;; detail but may be noisy; a larger bandwidth produces a smoother curve.
+
+;; ### Density Curve
+;;
+;; The density curve shows the estimated probability density at each point.
+;; Unlike histograms, KDE produces a smooth, continuous curve that doesn't
+;; depend on bin boundaries.
+
+;; ### Confidence Bands
+;;
+;; Bootstrap confidence bands show the uncertainty in the density estimate.
+;; The shaded area represents the range where the true density likely falls.
+
+;; ### Modes
+;;
+;; Modes are the peaks of the density curve, representing the most likely
+;; execution times. Each mode includes:
+;; - Location: the x-value of the peak
+;; - Density: the height of the peak
+;; - Confidence interval: the range within which the mode location is estimated
+
+;; ## Accessing KDE Results Programmatically
+;;
+;; Use `last-bench` to access the full KDE results:
+
+(do
+  (bench/bench (reduce + (range 1000))
+               :bench-plan bench-plans/kde-histogram
+               :viewer :none)
+  (let [data (:data (bench/last-bench))
+        kde-result (:kde data)]
+    {:bandwidth (get-in kde-result [:kdes [:elapsed-time] :bandwidth])
+     :n-modes (count (get-in kde-result [:kdes [:elapsed-time] :modes]))
+     :modes (get-in kde-result [:kdes [:elapsed-time] :modes])}))
+
+;; ## Customizing KDE Options
+;;
+;; The `kde` analysis step accepts several options via the bench plan:
+
+;; ### n-points
+;;
+;; Grid size for density evaluation. Default is 512. Higher values give
+;; smoother curves but take longer to compute.
+
+;; ### n-bootstrap
+;;
+;; Number of bootstrap samples for confidence bands. Default is 200.
+;; More samples give more accurate confidence intervals but take longer.
+
+;; ### n-modes
+;;
+;; Maximum number of modes to detect. Default is 5. Set higher if you
+;; expect more distinct performance modes.
+
+;; ### alpha
+;;
+;; Confidence level for intervals. Default is 0.05 (95% confidence).
+
+;; ### Custom Bench Plan Example
+;;
+;; Create a custom bench plan with modified KDE options:
+
+(def custom-kde-plan
+  (-> bench-plans/kde-histogram
+      (assoc :analyse
+             [:transform-log
+              [:quantiles {:quantiles [0.9 0.99 0.99]}]
+              :outliers
+              [:stats {}]
+              [:stats {:samples-id :log-samples :id :log-stats}]
+              :histogram
+              [:kde {:n-points 256 :n-bootstrap 100 :n-modes 3}]
+              :event-stats])))
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (reduce + (range 1000))
+              :bench-plan custom-kde-plan))
+
+;; ## Visualization with Portal and Kindly
+;;
+;; The `:portal` and `:kindly` viewers render the KDE as a Vega-Lite chart:
+;; - Density curve overlaid on histogram bars
+;; - Shaded confidence bands
+;; - Mode markers with horizontal confidence interval lines
+
+;; ### Portal Viewer
+;;
+;; To use with Portal, ensure Portal is connected:
+
+(kind/code
+ "(require '[portal.api :as p])
+(def portal (p/open))
+(add-tap #'p/submit)
+
+(bench/bench (reduce + (range 1000))
+             :bench-plan bench-plans/kde-histogram
+             :viewer :portal)")
+
+;; ### Kindly Viewer
+;;
+;; For Clay notebooks, use `:viewer :kindly` to get embedded charts:
+
+(bench/bench (reduce + (range 1000))
+             :bench-plan bench-plans/kde-histogram
+             :viewer :kindly)
+
+;; ## Detecting Multimodality
+;;
+;; Multimodal distributions indicate that benchmark execution times fall into
+;; distinct groups. This can happen due to:
+;;
+;; - JIT compilation tiers
+;; - GC pauses affecting some samples
+;; - CPU frequency scaling
+;; - Cache effects
+;;
+;; When KDE detects multiple modes, investigate the cause to understand
+;; your benchmark's behavior.
+
+;; ### Example: Synthetic Multimodal Distribution
+;;
+;; This artificial example shows how multimodality appears:
+
+(defn variable-work
+  "Simulate variable-time work with occasional slow paths."
+  [n]
+  (if (zero? (mod (rand-int 100) 10))
+    (reduce + (range (* n 10))) ; 10% slow path
+    (reduce + (range n)))) ; 90% fast path
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (variable-work 100)
+              :bench-plan bench-plans/kde-histogram))
+
+;; ## Comparing KDE to Histograms
+;;
+;; Both histogram and KDE visualize distributions, but they differ:
+;;
+;; | Aspect | Histogram | KDE |
+;; |--------|-----------|-----|
+;; | Output | Discrete bins | Continuous curve |
+;; | Bin sensitivity | Depends on bin width | Depends on bandwidth |
+;; | Mode detection | Visual inspection | Automatic with CIs |
+;; | Interpretation | Counts per bin | Probability density |
+;;
+;; Use histograms for quick visual inspection; use KDE when you need
+;; precise mode locations or smooth density estimates.
+
+;; ## Best Practices
+;;
+;; 1. **Use KDE when you need mode detection** - The automatic mode finding
+;;    with confidence intervals is valuable for identifying performance modes.
+;;
+;; 2. **Combine with histograms** - The `kde-histogram` plan overlays KDE
+;;    on histograms, giving you both discrete bin counts and smooth density.
+;;
+;; 3. **Check for multimodality** - Multiple modes may indicate that your
+;;    benchmark is measuring different code paths or JIT states.
+;;
+;; 4. **Consider computation cost** - KDE with bootstrap confidence bands
+;;    takes longer than basic statistics. Use the default plan for quick
+;;    benchmarks; use `kde-histogram` when you need density analysis.
+
+;; ## Running Examples
+;;
+;; Execute benchmarks with KDE analysis:
+
+(comment
+  ;; Basic KDE analysis
+  (bench/bench (reduce + (range 1000))
+               :bench-plan bench-plans/kde-histogram)
+
+  ;; Access KDE results programmatically
+  (let [data (:data (bench/last-bench))]
+    (get-in data [:kde :kdes [:elapsed-time] :modes]))
+
+  ;; Custom KDE options
+  (bench/bench (reduce + (range 1000))
+               :bench-plan custom-kde-plan)
+
+  ;; With Portal visualization
+  (bench/bench (reduce + (range 1000))
+               :bench-plan bench-plans/kde-histogram
+               :viewer :portal))

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -3,6 +3,7 @@
   (:require
    [criterium.bench :as bench]
    [criterium.bench-plans :as bench-plans]
+   [criterium.measured :as measured]
    [criterium.notebook.helpers :refer [bench-display]]
    [scicloj.kindly.v4.kind :as kind]))
 
@@ -227,6 +228,7 @@
               [:quantiles {:quantiles [0.25 0.5 0.75]}]
               :outliers
               [:stats {}]
+              [:stats {:samples-id :log-samples :id :log-stats}]
               :histogram
               [:kde {:n-points 512}]
               [:modes {:max-modes 3 :mode-method :critical}]
@@ -303,34 +305,32 @@
 ;; You can compare results from both test methods:
 
 (defn compare-test-methods
-  "Run both ACR and Silverman tests and compare results."
-  [expr-fn]
-  (let [acr-plan bench-plans/kde-modes
-        silverman-plan (assoc-in bench-plans/kde-modes
-                                 [:analyse 7 1 :method] :silverman)]
-    ;; Run with ACR
-    (bench/bench-measured {:args-fn (fn [] [])
-                           :f expr-fn}
-                          {:bench-plan acr-plan
-                           :viewer :none})
+  "Run both ACR and Silverman tests and compare results.
+  Takes a measured (created with measured/callable or measured/expr)."
+  [m]
+  (let [silverman-plan (assoc-in bench-plans/kde-modes
+                                 [:analyse 7] [:modes {:method :silverman}])]
+    ;; Run with ACR (default method)
+    (bench/bench-measured
+     (bench/options->bench-plan :bench-plan bench-plans/kde-modes :viewer :none)
+     m)
     (let [acr-result (get-in (:data (bench/last-bench))
                              [:modes :modes [:elapsed-time]])]
       ;; Run with Silverman
-      (bench/bench-measured {:args-fn (fn [] [])
-                             :f expr-fn}
-                            {:bench-plan silverman-plan
-                             :viewer :none})
+      (bench/bench-measured
+       (bench/options->bench-plan :bench-plan silverman-plan :viewer :none)
+       m)
       (let [silv-result (get-in (:data (bench/last-bench))
                                 [:modes :modes [:elapsed-time]])]
-        {:acr {:n-modes (:n-modes acr-result)
-               :p-values (get-in acr-result [:test-results :p-values])
-               :excess-mass (get-in acr-result [:test-results :excess-mass])}
-         :silverman {:n-modes (:n-modes silv-result)
+        {:acr       {:n-modes     (:n-modes acr-result)
+                     :p-values    (get-in acr-result [:test-results :p-values])
+                     :excess-mass (get-in acr-result [:test-results :excess-mass])}
+         :silverman {:n-modes  (:n-modes silv-result)
                      :p-values (get-in silv-result [:test-results :p-values])}}))))
 
 ;; Compare results on the multimodal example:
-(kind/code
- "(compare-test-methods #(variable-work 100 (zero? (mod (rand-int 100) 3))))")
+(compare-test-methods
+ (measured/callable #(variable-work 100 (zero? (mod (rand-int 100) 3)))))
 
 ;; ## Comparing KDE to Histograms
 ;;
@@ -383,19 +383,19 @@
   ;; Access modes results programmatically
   (let [data (:data (bench/last-bench))]
     {:kde-bandwidth (get-in data [:kde :kdes [:elapsed-time] :bandwidth])
-     :n-modes (get-in data [:modes :modes [:elapsed-time] :n-modes])
-     :test-results (get-in data [:modes :modes [:elapsed-time] :test-results])
-     :excess-mass (get-in data [:modes :modes [:elapsed-time] :test-results :excess-mass])})
+     :n-modes       (get-in data [:modes :modes [:elapsed-time] :n-modes])
+     :test-results  (get-in data [:modes :modes [:elapsed-time] :test-results])
+     :excess-mass   (get-in data [:modes :modes [:elapsed-time] :test-results :excess-mass])})
 
   ;; Use Silverman test instead of ACR
   (bench/bench (reduce + (range 1000))
                :bench-plan (assoc-in bench-plans/kde-modes
-                                     [:analyse 7 1 :method] :silverman))
+                                     [:analyse 7] [:modes {:method :silverman}]))
 
   ;; Use critical bandwidth for mode finding
   (bench/bench (reduce + (range 1000))
                :bench-plan (assoc-in bench-plans/kde-modes
-                                     [:analyse 7 1 :mode-method] :critical))
+                                     [:analyse 7] [:modes {:mode-method :critical}]))
 
   ;; Custom options
   (bench/bench (reduce + (range 1000))

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -19,7 +19,7 @@
 
 ;; ## Using the kde-histogram Bench Plan
 ;;
-;; The `kde-histogram` bench plan includes both histogram and KDE analysis.
+;; The `kde-histogram` bench plan includes histogram and KDE analysis.
 ;; This is not part of the default plan; use it explicitly when density
 ;; analysis is needed.
 
@@ -32,7 +32,21 @@
 ;; - Standard statistics (mean, standard deviation)
 ;; - Histogram visualization
 ;; - KDE density curve overlaid on the histogram
-;; - Detected modes with confidence intervals
+
+;; ## Using the kde-modes Bench Plan
+;;
+;; For statistically validated mode detection, use the `kde-modes` bench plan.
+;; This includes Silverman's bootstrap test for multimodality.
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (reduce + (range 1000))
+              :bench-plan bench-plans/kde-modes))
+
+;; The kde-modes plan adds:
+;; - Mode detection with confidence intervals
+;; - Silverman's test p-values for each k (number of modes)
+;; - Validated mode count based on statistical significance
 
 ;; ## Understanding KDE Output
 ;;
@@ -56,27 +70,45 @@
 ;; Bootstrap confidence bands show the uncertainty in the density estimate.
 ;; The shaded area represents the range where the true density likely falls.
 
-;; ### Modes
+;; ## Understanding Modes Output
 ;;
-;; Modes are the peaks of the density curve, representing the most likely
-;; execution times. Each mode includes:
-;; - Location: the x-value of the peak
-;; - Density: the height of the peak
-;; - Confidence interval: the range within which the mode location is estimated
+;; Mode analysis (from the `kde-modes` plan) provides statistically validated
+;; peaks in the density curve:
 
-;; ## Accessing KDE Results Programmatically
+;; ### Silverman's Test
 ;;
-;; Use `last-bench` to access the full KDE results:
+;; Silverman's bootstrap test determines if the data supports k modes. The test
+;; is run for k=1, 2, 3, ... up to max-modes. A low p-value indicates evidence
+;; for more than k modes.
+;;
+;; For k=1, the Hall-York correction is applied for better calibration.
+
+;; ### Validated Mode Count
+;;
+;; The `n-modes` value in the output is the smallest k where we fail to reject
+;; the null hypothesis (H0: at most k modes). This gives a statistically
+;; supported mode count.
+
+;; ### Mode Significance
+;;
+;; Each detected mode is marked with `significant?` indicating whether
+;; Silverman's test supports its existence.
+
+;; ## Accessing KDE and Modes Results Programmatically
+;;
+;; Use `last-bench` to access the full results:
 
 (do
   (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-histogram
+               :bench-plan bench-plans/kde-modes
                :viewer :none)
   (let [data (:data (bench/last-bench))
-        kde-result (:kde data)]
+        kde-result (:kde data)
+        modes-result (:modes data)]
     {:bandwidth (get-in kde-result [:kdes [:elapsed-time] :bandwidth])
-     :n-modes (count (get-in kde-result [:kdes [:elapsed-time] :modes]))
-     :modes (get-in kde-result [:kdes [:elapsed-time] :modes])}))
+     :n-modes (get-in modes-result [:modes [:elapsed-time] :n-modes])
+     :silverman-p-values (get-in modes-result [:modes [:elapsed-time] :silverman :p-values])
+     :modes (get-in modes-result [:modes [:elapsed-time] :modes])}))
 
 ;; ## Customizing KDE Options
 ;;
@@ -92,21 +124,25 @@
 ;; Number of bootstrap samples for confidence bands. Default is 200.
 ;; More samples give more accurate confidence intervals but take longer.
 
-;; ### n-modes
-;;
-;; Maximum number of modes to detect. Default is 5. Set higher if you
-;; expect more distinct performance modes.
-
 ;; ### alpha
 ;;
 ;; Confidence level for intervals. Default is 0.05 (95% confidence).
 
+;; ## Customizing Modes Options
+;;
+;; The `modes` analysis step has additional options:
+
+;; ### max-modes
+;;
+;; Maximum number of modes to test. Default is 5. Silverman's test is run
+;; for k=1 through max-modes.
+
 ;; ### Custom Bench Plan Example
 ;;
-;; Create a custom bench plan with modified KDE options:
+;; Create a custom bench plan with modified options:
 
-(def custom-kde-plan
-  (-> bench-plans/kde-histogram
+(def custom-kde-modes-plan
+  (-> bench-plans/kde-modes
       (assoc :analyse
              [:transform-log
               [:quantiles {:quantiles [0.9 0.99 0.99]}]
@@ -114,20 +150,22 @@
               [:stats {}]
               [:stats {:samples-id :log-samples :id :log-stats}]
               :histogram
-              [:kde {:n-points 256 :n-bootstrap 100 :n-modes 3}]
+              [:kde {:n-points 256 :n-bootstrap 100}]
+              [:modes {:max-modes 3 :n-bootstrap 100}]
               :event-stats])))
 
 ^:kindly/hide-code
 (bench-display
  (bench/bench (reduce + (range 1000))
-              :bench-plan custom-kde-plan))
+              :bench-plan custom-kde-modes-plan))
 
 ;; ## Visualization with Portal and Kindly
 ;;
 ;; The `:portal` and `:kindly` viewers render the KDE as a Vega-Lite chart:
 ;; - Density curve overlaid on histogram bars
 ;; - Shaded confidence bands
-;; - Mode markers with horizontal confidence interval lines
+;; - Mode markers with horizontal confidence interval lines (when modes data present)
+;; - Color coding for significant vs non-significant modes
 
 ;; ### Portal Viewer
 ;;
@@ -139,16 +177,17 @@
 (add-tap #'p/submit)
 
 (bench/bench (reduce + (range 1000))
-             :bench-plan bench-plans/kde-histogram
+             :bench-plan bench-plans/kde-modes
              :viewer :portal)")
 
 ;; ### Kindly Viewer
 ;;
 ;; For Clay notebooks, use `:viewer :kindly` to get embedded charts:
 
-(bench/bench (reduce + (range 1000))
-             :bench-plan bench-plans/kde-histogram
-             :viewer :kindly)
+(bench/bench
+ (reduce + (range 1000))
+ :bench-plan bench-plans/kde-modes
+ :viewer :kindly)
 
 ;; ## Detecting Multimodality
 ;;
@@ -160,8 +199,8 @@
 ;; - CPU frequency scaling
 ;; - Cache effects
 ;;
-;; When KDE detects multiple modes, investigate the cause to understand
-;; your benchmark's behavior.
+;; Silverman's test provides statistical validation for multimodality. A low
+;; p-value for k=1 suggests the distribution is not unimodal.
 
 ;; ### Example: Synthetic Multimodal Distribution
 ;;
@@ -170,14 +209,13 @@
 (defn variable-work
   "Simulate variable-time work with occasional slow paths."
   [^long n]
-  (if (zero? (long (mod (rand-int 100) 10)))
-    (reduce + (range (* n 10))) ; 10% slow path
+  (if (zero? (long (mod (rand-int 100) 5)))
+    (reduce + (range (* n 10))) ; 20% slow path
     (reduce + (range n)))) ; 90% fast path
 
-^:kindly/hide-code
-(bench-display
- (bench/bench (variable-work 100)
-              :bench-plan bench-plans/kde-histogram))
+(bench/bench (variable-work 100)
+             :bench-plan bench-plans/kde-modes
+             :viewer :kindly)
 
 ;; ## Comparing KDE to Histograms
 ;;
@@ -195,37 +233,43 @@
 
 ;; ## Best Practices
 ;;
-;; 1. **Use KDE when you need mode detection** - The automatic mode finding
-;;    with confidence intervals is valuable for identifying performance modes.
+;; 1. **Use kde-histogram for density visualization** - When you just need
+;;    to see the distribution shape without statistical mode validation.
 ;;
-;; 2. **Combine with histograms** - The `kde-histogram` plan overlays KDE
-;;    on histograms, giving you both discrete bin counts and smooth density.
+;; 2. **Use kde-modes for mode detection** - When you need statistically
+;;    validated mode counts with Silverman's test.
 ;;
-;; 3. **Check for multimodality** - Multiple modes may indicate that your
-;;    benchmark is measuring different code paths or JIT states.
+;; 3. **Check Silverman's p-values** - Low p-values for k=1 indicate
+;;    evidence against unimodality.
 ;;
-;; 4. **Consider computation cost** - KDE with bootstrap confidence bands
-;;    takes longer than basic statistics. Use the default plan for quick
-;;    benchmarks; use `kde-histogram` when you need density analysis.
+;; 4. **Consider computation cost** - Mode analysis with Silverman's test
+;;    involves multiple rounds of bootstrap resampling. Use `kde-histogram`
+;;    when you only need the density curve.
 
 ;; ## Running Examples
 ;;
-;; Execute benchmarks with KDE analysis:
+;; Execute benchmarks with KDE and mode analysis:
 
 (comment
-  ;; Basic KDE analysis
+  ;; Basic KDE analysis (no mode testing)
   (bench/bench (reduce + (range 1000))
                :bench-plan bench-plans/kde-histogram)
 
-  ;; Access KDE results programmatically
-  (let [data (:data (bench/last-bench))]
-    (get-in data [:kde :kdes [:elapsed-time] :modes]))
-
-  ;; Custom KDE options
+  ;; KDE with mode detection and Silverman's test
   (bench/bench (reduce + (range 1000))
-               :bench-plan custom-kde-plan)
+               :bench-plan bench-plans/kde-modes)
+
+  ;; Access modes results programmatically
+  (let [data (:data (bench/last-bench))]
+    {:kde-bandwidth (get-in data [:kde :kdes [:elapsed-time] :bandwidth])
+     :n-modes (get-in data [:modes :modes [:elapsed-time] :n-modes])
+     :p-values (get-in data [:modes :modes [:elapsed-time] :silverman :p-values])})
+
+  ;; Custom options
+  (bench/bench (reduce + (range 1000))
+               :bench-plan custom-kde-modes-plan)
 
   ;; With Portal visualization
   (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-histogram
+               :bench-plan bench-plans/kde-modes
                :viewer :portal))


### PR DESCRIPTION
## Summary

Implements Kernel Density Estimation (KDE) analysis for benchmark sample data, providing density estimation, mode detection with significance testing, and visualization support.

### Features

- **Core KDE utilities** (`criterium.util.kde`): ISJ bandwidth selector with Silverman fallback, Gaussian KDE, bootstrap confidence bands, mode finding
- **Analysis functions**: `analyse/kde` for density estimation, `analyse/modes` for mode detection with Silverman's multimodality test
- **Viewer support**: Print/pprint show bandwidth and mode summaries; Portal/Kindly render density overlays on histograms with mode markers
- **Bench plan**: `kde-histogram` plan variant for on-demand KDE analysis

### Implementation Details

- Uses log-transformed samples to avoid negative value issues
- Outliers filtered before KDE computation
- Mode significance indicated via Silverman's test
- DCT-II for ISJ bandwidth is O(n²) direct implementation

### Changes

- `criterium.util.kde`: Core KDE implementation
- `criterium.analyse`: kde and modes analysis functions
- `criterium.analyse.methods`: Multimethods for kde and modes
- `criterium.view`, `criterium.viewer.*`: Viewer integration
- `criterium.bench-plans`: kde-histogram plan
- `criterium.kde_analysis_notebook`: Documentation notebook

## Test Plan

- [ ] Unit tests pass for KDE bandwidth selection
- [ ] Unit tests pass for mode detection accuracy
- [ ] Integration tests pass with synthetic multimodal data
- [ ] Viewer output tests pass
- [ ] Notebook renders correctly