### PR TITLE
feat: KDE analysis follow-up improvements

### DIFF
--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -107,11 +107,12 @@
    :viewer :print})
 
 (def kde-modes
-  "Benchmark plan with KDE and mode detection using Silverman's test.
+  "Benchmark plan with KDE and mode detection using ACR test.
 
   Includes histogram, KDE, and statistically validated mode analysis.
   Use when you need to detect and validate multimodality in sample distributions.
-  Mode detection tests from k=1 up to max-modes with Silverman's bootstrap test."
+  Mode detection tests from k=1 up to max-modes. Supports ACR (default) and
+  Silverman test methods via :modes analysis options."
   {:collector-config default-collector-config
    :analyse [:transform-log
              [:quantiles {:quantiles [0.9 0.99 0.99]}]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -376,7 +376,7 @@
         bw (util/transform-sample-> bandwidth transforms)
         modes (when modes-data (:modes modes-data))
         n-modes (when modes-data (:n-modes modes-data))
-        silverman (when modes-data (:silverman modes-data))]
+        test-results (when modes-data (:test-results modes-data))]
     (println (format "%32s: KDE (n=%d)" label n))
     (println (format "%34s bandwidth: %s"
                      ""
@@ -390,9 +390,13 @@
         (let [[loc dens ci-lo ci-hi] (format-kde-mode mode metric-config transforms)]
           (println (format "%34s %12s %12s %12s %12s"
                            "" loc dens ci-lo ci-hi))))
-      (when silverman
-        (let [p-values (:p-values silverman)]
-          (println (format "%34s Silverman test p-values:" ""))
+      (when test-results
+        (let [{:keys [method p-values]} test-results
+              method-name (case method
+                            :acr "ACR"
+                            :silverman "Silverman"
+                            (name method))]
+          (println (format "%34s %s test p-values:" "" method-name))
           (doseq [k (sort (keys p-values))]
             (println (format "%36s k=%d: p=%.4f" "" k (get p-values k)))))))
     (println)))

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -350,8 +350,8 @@
     (testing "returns correct structure"
       (let [;; Bimodal: clusters around 100 and 200
             raw-data (concat
-                      (mapv #(+ 98 (* 4 %)) (range 30))
-                      (mapv #(+ 198 (* 4 %)) (range 30)))
+                      (mapv #(+ 98.0 (* 4.0 (double %))) (range 30))
+                      (mapv #(+ 198.0 (* 4.0 (double %))) (range 30)))
             samples (metrics-samples
                      {[:elapsed-time] (vec raw-data)}
                      1)
@@ -375,7 +375,7 @@
                 "modes should not be in KDE output (now separate)")))))
 
     (testing "uses custom samples-id"
-      (let [raw-data (mapv #(+ 10.0 (* 0.5 %)) (range 50))
+      (let [raw-data (mapv #(+ 10.0 (* 0.5 (double %))) (range 50))
             samples (metrics-samples
                      {[:elapsed-time] raw-data}
                      1)
@@ -393,7 +393,7 @@
         (is (not (contains? result :kde)))))
 
     (testing "uses custom output id"
-      (let [raw-data (mapv #(+ 10.0 (* 0.5 %)) (range 50))
+      (let [raw-data (mapv #(+ 10.0 (* 0.5 (double %))) (range 50))
             samples (metrics-samples
                      {[:elapsed-time] raw-data}
                      1)
@@ -407,7 +407,7 @@
 
     (testing "excludes outliers from KDE computation"
       (let [;; Normal samples around 100, with one extreme outlier at end
-            raw-data (conj (vec (mapv #(+ 100.0 (* 0.5 %)) (range 49)))
+            raw-data (conj (vec (mapv #(+ 100.0 (* 0.5 (double %))) (range 49)))
                            10000.0)
             samples (metrics-samples
                      {[:elapsed-time] raw-data}
@@ -437,7 +437,7 @@
   ;; and produce expected output structure.
   (testing "modes"
     (testing "uses ACR test by default"
-      (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
             samples (metrics-samples {[:elapsed-time] raw-data} 1)
             data-map {:samples samples}
             with-log ((analyse/transform-log {:id :log-samples
@@ -454,7 +454,7 @@
               "ACR results should include excess-mass"))))
 
     (testing "supports Silverman method via :method option"
-      (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
             samples (metrics-samples {[:elapsed-time] raw-data} 1)
             data-map {:samples samples}
             with-log ((analyse/transform-log {:id :log-samples
@@ -471,7 +471,7 @@
               "Silverman results should not include excess-mass"))))
 
     (testing "returns correct output structure"
-      (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
             samples (metrics-samples {[:elapsed-time] raw-data} 1)
             data-map {:samples samples}
             with-log ((analyse/transform-log {:id :log-samples
@@ -491,7 +491,7 @@
 
     (testing "with :mode-method :critical"
       (testing "includes antimodes and mode-bandwidth"
-        (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+        (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
               samples (metrics-samples {[:elapsed-time] raw-data} 1)
               data-map {:samples samples}
               with-log ((analyse/transform-log {:id :log-samples
@@ -513,8 +513,8 @@
         (let [;; Create well-separated bimodal data (log-transform will be applied)
               ;; Use exponential values so log-transform creates clearly separated modes
               raw-data (concat
-                        (mapv #(* (Math/exp 1.0) (+ 1.0 (* 0.01 %))) (range 30))
-                        (mapv #(* (Math/exp 5.0) (+ 1.0 (* 0.01 %))) (range 30)))
+                        (mapv #(* (Math/exp 1.0) (+ 1.0 (* 0.01 (double %)))) (range 30))
+                        (mapv #(* (Math/exp 5.0) (+ 1.0 (* 0.01 (double %)))) (range 30)))
               samples (metrics-samples {[:elapsed-time] (vec raw-data)} 1)
               data-map {:samples samples}
               with-log ((analyse/transform-log {:id :log-samples
@@ -528,12 +528,12 @@
           (is (vector? (:antimodes elapsed-modes))
               "antimodes should be a vector")
           ;; When we have multiple modes, there should be antimodes between them
-          (when (> (:n-modes elapsed-modes) 1)
+          (when (> (long (:n-modes elapsed-modes)) 1)
             (is (pos? (count (:antimodes elapsed-modes)))
                 "multiple modes should have at least one antimode"))))
 
       (testing "with :isj (default) does not include antimodes"
-        (let [raw-data (mapv #(+ 100.0 (* 0.5 %)) (range 50))
+        (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
               samples (metrics-samples {[:elapsed-time] raw-data} 1)
               data-map {:samples samples}
               with-log ((analyse/transform-log {:id :log-samples

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -731,7 +731,7 @@
                                               :data [[{:n 100} 100.0]
                                                      [{:n 200} 200.0]
                                                      [{:n 300} 300.0]]}}}
-            models {:cubic {:transform (fn [n] (* n n n))
+            models {:cubic {:transform (fn [n] (let [n (double n)] (* n n n)))
                             :label "O(n³)"}}
             result (analysis/fit-complexity extract :n models)
             regression (get-in result [:regressions :elapsed-time])]

--- a/bases/criterium/test/criterium/domain/builder_test.clj
+++ b/bases/criterium/test/criterium/domain/builder_test.clj
@@ -80,13 +80,13 @@
         (is (apply < result))))
     (testing "produces evenly spaced values in n*log(n) domain"
       (let [result (builder/n-log-n-range 10 10000 7)
-            f (fn [x] (* x (Math/log x)))
+            f (fn [x] (let [x (double x)] (* x (Math/log x))))
             y-values (map f result)
             diffs (map - (rest y-values) y-values)
-            mean-diff (/ (reduce + diffs) (count diffs))
+            mean-diff (/ (double (reduce + diffs)) (count diffs))
             ;; Allow 1% tolerance for rounding errors
-            tolerance (* 0.01 mean-diff)]
-        (is (every? #(< (Math/abs (- % mean-diff)) tolerance) diffs))))
+            tolerance (* 0.01 (double mean-diff))]
+        (is (every? #(< (Math/abs (- (double %) (double mean-diff))) tolerance) diffs))))
     (testing "handles 2-point range"
       (is (= [10 1000] (builder/n-log-n-range 10 1000 2))))
     (testing "handles single point"
@@ -179,6 +179,6 @@
         (is (= m1 ((:impl-a result) {})))
         (is (= m2 ((:impl-b result) {})))))
     (testing "passes through function values unchanged"
-      (let [impl-fn (fn [{:keys [n]}] (measured/expr (+ n 1)))
+      (let [impl-fn (fn [{n :n}] (let [n (long n)] (measured/expr (+ n 1))))
             result (#'builder/normalize-implementations {:impl-a impl-fn})]
         (is (= impl-fn (:impl-a result)))))))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -47,7 +47,7 @@
     (testing "replaces args-fn while preserving measurement function"
       (let [original-m  (measured/measured
                          (fn [] [1])
-                         (fn [[x] _n] [0 (* x 10)])
+                         (fn [[x] _n] [0 (* (long x) 10)])
                          (fn [] ::original))
             new-args-fn (fn [] [5])
             modified-m  (measured/with-args-fn original-m new-args-fn)]

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -1233,3 +1233,162 @@
       (reset! kindly/accumulated [])
       (view/kde* :kindly {} {})
       (is (nil? (kindly/flush))))))
+
+(deftest kde-modes-rendering-test
+  ;; Tests mode markers, significance indicators, and CI lines in KDE visualization.
+  ;; Verifies that when modes data is provided via separate :modes key,
+  ;; the chart includes point markers and rule lines for confidence intervals.
+  (testing "view/kde* :kindly modes rendering"
+    (testing "includes mode markers and CI lines when modes data present"
+      (reset! kindly/accumulated [])
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform {:sample-> identity :->sample identity}
+                        :modes {[:elapsed-time]
+                                {:modes [{:location 2.0
+                                          :density 0.3
+                                          :ci-lower 1.8
+                                          :ci-upper 2.2
+                                          :significant? true}]
+                                 :n-modes 1}}}]
+        (view/kde* :kindly {} {:kde kde-data :modes modes-data})
+        (let [result (kindly/flush)
+              [_heading chart] result
+              first-chart (first (:vconcat chart))
+              layers (:layer first-chart)
+              kde-group (first layers)
+              kde-layers (:layer kde-group)
+              point-layer (first (filter #(= "point" (get-in % [:mark :type]))
+                                         kde-layers))
+              rule-layer (first (filter #(= "rule" (get-in % [:mark :type]))
+                                        kde-layers))]
+          (is (some? point-layer) "Expected point layer for mode markers")
+          (is (some? rule-layer) "Expected rule layer for CI lines")
+          ;; Verify point layer has shape encoding for significance
+          (is (= "significant" (get-in point-layer [:encoding :shape :field]))
+              "Expected shape encoding by significance field")
+          (is (= ["yes" "no"]
+                 (get-in point-layer [:encoding :shape :scale :domain]))
+              "Expected significance domain")
+          (is (= ["circle" "triangle-up"]
+                 (get-in point-layer [:encoding :shape :scale :range]))
+              "Expected significance shape range")
+          ;; Verify rule layer encodes CI bounds
+          (is (= "ci-lower" (get-in rule-layer [:encoding :x :field]))
+              "Expected x encoding from ci-lower")
+          (is (= "ci-upper" (get-in rule-layer [:encoding :x2 :field]))
+              "Expected x2 encoding from ci-upper")
+          ;; Verify stroke dash encoding for significance
+          (is (= "significant" (get-in rule-layer [:encoding :strokeDash :field]))
+              "Expected strokeDash encoding by significance"))))
+
+    (testing "distinguishes significant vs non-significant modes via shape"
+      (reset! kindly/accumulated [])
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0 4.0]
+                              :density [0.1 0.3 0.2 0.15]
+                              :lower-band [0.08 0.25 0.15 0.10]
+                              :upper-band [0.12 0.35 0.25 0.20]
+                              :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform {:sample-> identity :->sample identity}
+                        :modes {[:elapsed-time]
+                                {:modes [{:location 2.0
+                                          :density 0.3
+                                          :ci-lower 1.8
+                                          :ci-upper 2.2
+                                          :significant? true}
+                                         {:location 3.5
+                                          :density 0.18
+                                          :ci-lower 3.2
+                                          :ci-upper 3.8
+                                          :significant? false}]
+                                 :n-modes 2}}}]
+        (view/kde* :kindly {} {:kde kde-data :modes modes-data})
+        (let [result (kindly/flush)
+              [_heading chart] result
+              first-chart (first (:vconcat chart))
+              kde-group (first (:layer first-chart))
+              kde-layers (:layer kde-group)
+              point-layer (first (filter #(= "point" (get-in % [:mark :type]))
+                                         kde-layers))
+              point-data (get-in point-layer [:data :values])]
+          (is (= 2 (count point-data)) "Expected 2 mode markers")
+          (is (= #{"yes" "no"} (set (map #(get % "significant") point-data)))
+              "Expected both significant and non-significant modes"))))
+
+    (testing "omits mode layers when modes data not present"
+      (reset! kindly/accumulated [])
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :n 100}}}]
+        (view/kde* :kindly {} {:kde kde-data})
+        (let [result (kindly/flush)
+              [_heading chart] result
+              first-chart (first (:vconcat chart))
+              kde-group (first (:layer first-chart))
+              kde-layers (:layer kde-group)
+              point-layers (filter #(= "point" (get-in % [:mark :type]))
+                                   kde-layers)
+              rule-layers (filter #(= "rule" (get-in % [:mark :type]))
+                                  kde-layers)]
+          (is (empty? point-layers)
+              "Expected no point layers without modes data")
+          (is (empty? rule-layers)
+              "Expected no rule layers without modes data"))))
+
+    (testing "omits mode layers when modes list is empty"
+      (reset! kindly/accumulated [])
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform {:sample-> identity :->sample identity}
+                        :modes {[:elapsed-time]
+                                {:modes []
+                                 :n-modes 0}}}]
+        (view/kde* :kindly {} {:kde kde-data :modes modes-data})
+        (let [result (kindly/flush)
+              [_heading chart] result
+              first-chart (first (:vconcat chart))
+              kde-group (first (:layer first-chart))
+              kde-layers (:layer kde-group)
+              point-layers (filter #(= "point" (get-in % [:mark :type]))
+                                   kde-layers)]
+          (is (empty? point-layers)
+              "Expected no point layers when modes list empty"))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -829,3 +829,160 @@
             [title _spec] (with-tap-out
                             (view/kde* :portal {:kde-id :my-kde} {:my-kde kde-data}))]
         (is (= [:b "Kernel Density Estimation"] title))))))
+
+(deftest portal-kde-modes-rendering-test
+  ;; Tests mode markers, significance indicators, and CI lines in portal KDE visualization.
+  ;; Verifies that when modes data is provided via separate :modes key,
+  ;; the chart includes point markers and rule lines for confidence intervals.
+  (testing "kde* modes rendering"
+    (testing "includes mode markers and CI lines when modes data present"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform {:sample-> identity :->sample identity}
+                        :modes {[:elapsed-time]
+                                {:modes [{:location 2.0
+                                          :density 0.3
+                                          :ci-lower 1.8
+                                          :ci-upper 2.2
+                                          :significant? true}]
+                                 :n-modes 1}}}
+            [_title vega-spec] (with-tap-out
+                                 (view/kde* :portal {}
+                                            {:kde kde-data :modes modes-data}))
+            first-chart (first (:vconcat vega-spec))
+            kde-group (first (:layer first-chart))
+            kde-layers (:layer kde-group)
+            point-layer (first (filter #(= "point" (get-in % [:mark :type]))
+                                       kde-layers))
+            rule-layer (first (filter #(= "rule" (get-in % [:mark :type]))
+                                      kde-layers))]
+        (is (some? point-layer) "Expected point layer for mode markers")
+        (is (some? rule-layer) "Expected rule layer for CI lines")
+        ;; Verify point layer has shape encoding for significance
+        (is (= "significant" (get-in point-layer [:encoding :shape :field]))
+            "Expected shape encoding by significance field")
+        (is (= ["yes" "no"]
+               (get-in point-layer [:encoding :shape :scale :domain]))
+            "Expected significance domain")
+        (is (= ["circle" "triangle-up"]
+               (get-in point-layer [:encoding :shape :scale :range]))
+            "Expected significance shape range")
+        ;; Verify rule layer encodes CI bounds
+        (is (= "ci-lower" (get-in rule-layer [:encoding :x :field]))
+            "Expected x encoding from ci-lower")
+        (is (= "ci-upper" (get-in rule-layer [:encoding :x2 :field]))
+            "Expected x2 encoding from ci-upper")
+        ;; Verify stroke dash encoding for significance
+        (is (= "significant" (get-in rule-layer [:encoding :strokeDash :field]))
+            "Expected strokeDash encoding by significance")))
+
+    (testing "distinguishes significant vs non-significant modes via shape"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0 4.0]
+                              :density [0.1 0.3 0.2 0.15]
+                              :lower-band [0.08 0.25 0.15 0.10]
+                              :upper-band [0.12 0.35 0.25 0.20]
+                              :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform {:sample-> identity :->sample identity}
+                        :modes {[:elapsed-time]
+                                {:modes [{:location 2.0
+                                          :density 0.3
+                                          :ci-lower 1.8
+                                          :ci-upper 2.2
+                                          :significant? true}
+                                         {:location 3.5
+                                          :density 0.18
+                                          :ci-lower 3.2
+                                          :ci-upper 3.8
+                                          :significant? false}]
+                                 :n-modes 2}}}
+            [_title vega-spec] (with-tap-out
+                                 (view/kde* :portal {}
+                                            {:kde kde-data :modes modes-data}))
+            first-chart (first (:vconcat vega-spec))
+            kde-group (first (:layer first-chart))
+            kde-layers (:layer kde-group)
+            point-layer (first (filter #(= "point" (get-in % [:mark :type]))
+                                       kde-layers))
+            point-data (get-in point-layer [:data :values])]
+        (is (= 2 (count point-data)) "Expected 2 mode markers")
+        (is (= #{"yes" "no"} (set (map #(get % "significant") point-data)))
+            "Expected both significant and non-significant modes")))
+
+    (testing "omits mode layers when modes data not present"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :n 100}}}
+            [_title vega-spec] (with-tap-out
+                                 (view/kde* :portal {} {:kde kde-data}))
+            first-chart (first (:vconcat vega-spec))
+            kde-group (first (:layer first-chart))
+            kde-layers (:layer kde-group)
+            point-layers (filter #(= "point" (get-in % [:mark :type]))
+                                 kde-layers)
+            rule-layers (filter #(= "rule" (get-in % [:mark :type]))
+                                kde-layers)]
+        (is (empty? point-layers)
+            "Expected no point layers without modes data")
+        (is (empty? rule-layers)
+            "Expected no rule layers without modes data")))
+
+    (testing "omits mode layers when modes list is empty"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            kde-data {:type :criterium/kde
+                      :metrics-defs metrics-defs
+                      :transform {:sample-> identity :->sample identity}
+                      :kdes {[:elapsed-time]
+                             {:type :criterium/kde
+                              :bandwidth 0.5
+                              :grid [1.0 2.0 3.0]
+                              :density [0.1 0.3 0.1]
+                              :lower-band [0.08 0.25 0.08]
+                              :upper-band [0.12 0.35 0.12]
+                              :n 100}}}
+            modes-data {:type :criterium/modes
+                        :transform {:sample-> identity :->sample identity}
+                        :modes {[:elapsed-time]
+                                {:modes []
+                                 :n-modes 0}}}
+            [_title vega-spec] (with-tap-out
+                                 (view/kde* :portal {}
+                                            {:kde kde-data :modes modes-data}))
+            first-chart (first (:vconcat vega-spec))
+            kde-group (first (:layer first-chart))
+            kde-layers (:layer kde-group)
+            point-layers (filter #(= "point" (get-in % [:mark :type]))
+                                 kde-layers)]
+        (is (empty? point-layers)
+            "Expected no point layers when modes list empty")))))


### PR DESCRIPTION
## Summary

Follow-up improvements and fixes identified during KDE implementation code review.

## Changes

- Fix print viewer to use `:test-results` key instead of `:silverman` and display method name dynamically (ACR or Silverman)
- Update `kde-modes` docstring to document ACR as the default method
- Add type casts to eliminate boxed math warnings in tests
- Add comprehensive tests for KDE modes rendering in kindly and portal viewers

## Commits

- `b7bc16b` test(view): add modes rendering tests for KDE visualization
- `d797bf1` fix(test): add type casts to eliminate boxed math warnings
- `3b04a94` docs(bench-plans): update kde-modes docstring to document ACR as default
- `e7b7c99` fix(view): use :test-results key instead of :silverman in print viewer
- `fa46474` feat: add KDE analysis step for benchmark samples (#74)
- `3e4f972` test(ziggurat): add autocorrelation tests and extract statistical helpers

## Test plan

- [x] All existing tests pass
- [x] New KDE modes rendering tests verify point markers and CI rule lines