### PR TITLE
test: speed up test suite execution

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -163,6 +163,16 @@ Tests use Kaocha with the following structure:
 
 Skip slow tests with `:skip-meta [:very-slow]` in test metadata.
 
+**Agent Build Cache:**
+Agent build tests use a shared CMake build cache at `target/test-agent-build-cache` for faster incremental builds. This cache persists between test runs. Clear it when:
+- Switching between major CMake versions
+- After changes to `agent-cpp/CMakeLists.txt` that require a clean build
+- If you encounter stale build artifacts causing test failures
+
+```bash
+rm -rf target/test-agent-build-cache
+```
+
 ## Native Agent
 
 The C++ agent (`agent-cpp/`) provides enhanced allocation tracking and is bundled in the JAR for supported platforms (linux-x64, macos-x64, macos-arm64):

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,16 +80,24 @@ cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64
 ### REPL Development
 ```bash
 # Start development REPL (agent auto-loads when available)
-clojure -M:dev
+clojure -M:dev:test
 
 # For agent development: Use locally-built agent (macOS)
-clojure -M:dev:with-agent-mac
+clojure -M:dev:test:with-agent-mac
 
 # For agent development: Use locally-built agent (Linux)
-clojure -M:dev:with-agent-linux
+clojure -M:dev:test:with-agent-linux
 
-# For exploring with Portal viewer
-clojure -M:dev
+# For JDK 17+ compiler blackhole  (recommended)
+clojure -M:dev:test:blackhole
+```
+
+### NREPL server
+
+To start an NREPL server:
+
+``` bash
+clojure -M:nrepl:dev:test:with-agent-mac:blackhole
 ```
 
 ## Architecture

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -161,7 +161,17 @@ Tests use Kaocha with the following structure:
 - Performance regression tests
 - Test data in `bases/criterium/test/criterium/data/`
 
-Skip slow tests with `:skip-meta [:very-slow]` in test metadata.
+### Test Speed Optimizations
+
+The test suite uses several strategies to maintain fast execution:
+
+**Slow Test Marking:**
+Tests that take significant time (>30s) are marked with `^:slow` metadata and excluded from default runs via `:skip-meta [:slow]` in `tests.edn`. Run slow tests explicitly with `--focus-meta :slow`.
+
+**Minimal Iterations for API Tests:**
+Tests that validate API behavior (not benchmark accuracy) use reduced time limits:
+- `bench_test.clj`: `:limit-time-s 0.1` or `0.2` instead of full benchmark runs
+- Property tests in `well_test.clj`: 50 iterations (sufficient for correctness validation)
 
 **Agent Build Cache:**
 Agent build tests use a shared CMake build cache at `target/test-agent-build-cache` for faster incremental builds. This cache persists between test runs. Clear it when:

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,6 +6,7 @@
   {criterium.view/def-multi-view       hooks.impl/def-multi-view
    criterium.util.forms/cond*          hooks.impl/cond*}}
  :lint-as {babashka.fs/with-temp-dir                 clojure.core/with-open
+           build-test/with-cached-agent-build      clj-kondo.lint-as/def-catch-all
            clojure.test.check.clojure-test/defspec clojure.core/def
            clojure.test.check.properties/for-all   clojure.core/let
            criterium.util/optional-require         clojure.core/require

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -12,7 +12,7 @@
   (testing "bench"
     (bench-impl/last-bench! nil)
     (is (nil? (bench/last-bench)))
-    (let [out (with-out-str (bench/bench 1))]
+    (let [out (with-out-str (bench/bench 1 :limit-time-s 0.1))]
       (testing "outputs the estimated time on stdout"
         (is (re-find
              #"Elapsed Time: [0-9.]+ [mn]s  3σ \[[0-9.-]+ [0-9.]+]  min [0-9.]+"
@@ -27,7 +27,7 @@
         (is (not (re-find #"±" out))))))
   (testing "time returns expression-value"
     (with-out-str
-      (let [v (bench/bench 1)]
+      (let [v (bench/bench 1 :limit-time-s 0.1)]
         (is (= 1 v)))))
 
   (testing "all pipelines"
@@ -65,7 +65,7 @@
       (bench/bench (+ 1 1)
                    :viewer :kindly
                    :bench-plan bench-plans/log-histogram
-                   :limit-time-s 0.5)
+                   :limit-time-s 0.2)
       (is (empty? @kindly/accumulated)
           "accumulator is empty after flush - fragment was returned by flush-viewer"))
 
@@ -94,7 +94,7 @@
                                    (bench/bench (+ 1 1)
                                                 :viewer :print
                                                 :bench-plan bench-plans/log-histogram
-                                                :limit-time-s 0.5))
+                                                :limit-time-s 0.2))
                                  (bench/last-bench)))
                       :viewer)]
         ;; View with :kindly - bench/view returns the fragment
@@ -211,7 +211,7 @@
       (let [out (with-out-str
                   (bench/bench (str "allocate" "strings")
                                :with-allocation-trace true
-                               :limit-time-s 0.5))
+                               :limit-time-s 0.1))
             data (:data (bench/last-bench))]
         ;; If agent is attached, check allocation data is present
         (when (get-in data [:samples :allocation-trace])

--- a/bases/criterium/test/criterium/platform_test.clj
+++ b/bases/criterium/test/criterium/platform_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [criterium.platform :as platform]))
 
-(deftest platform-point-estimates-test
+(deftest ^:slow platform-point-estimates-test
   ;; Verifies that platform-point-estimates returns timing characterisation data
   ;; for the platform with expected structure.
   (testing "platform-point-estimates"

--- a/bases/criterium/test/criterium/util/well_test.clj
+++ b/bases/criterium/test/criterium/util/well_test.clj
@@ -29,13 +29,13 @@
                 0))
          well-1024a-res0)))
 
-(defspec add-mod-32-test-property 20
+(defspec add-mod-32-test-property 50
   (prop/for-all
    [a gen/small-integer
     b gen/small-integer]
    (is (<= 0 (well/add-mod-32 (long a) (long b)) 31))))
 
-(defspec well-1024a-test-property 20
+(defspec well-1024a-test-property 50
   (prop/for-all
    [random-seed (gen/large-integer* {:min 0x111111})
     well-index (gen-bounded 0 31)]

--- a/bases/criterium/test/criterium/util/well_test.clj
+++ b/bases/criterium/test/criterium/util/well_test.clj
@@ -29,13 +29,13 @@
                 0))
          well-1024a-res0)))
 
-(defspec add-mod-32-test-property 100
+(defspec add-mod-32-test-property 20
   (prop/for-all
    [a gen/small-integer
     b gen/small-integer]
    (is (<= 0 (well/add-mod-32 (long a) (long b)) 31))))
 
-(defspec well-1024a-test-property 100
+(defspec well-1024a-test-property 20
   (prop/for-all
    [random-seed (gen/large-integer* {:min 0x111111})
     well-index (gen-bounded 0 31)]

--- a/projects/agent/test/build_test.clj
+++ b/projects/agent/test/build_test.clj
@@ -102,6 +102,19 @@
   (doseq [^java.io.File f (reverse (file-seq dir))]
     (.delete f)))
 
+(def ^:private cached-build-dir
+  "Shared build directory for agent build tests.
+  CMake handles incremental builds, so we don't delete this between tests."
+  (io/file "target/test-agent-build-cache"))
+
+(defmacro with-cached-agent-build
+  "Executes body with agent built using a shared cached build directory.
+  Binds the library path to lib-path-sym. The build directory is NOT cleaned
+  up to enable fast incremental CMake builds on subsequent test runs."
+  [[lib-path-sym] & body]
+  `(let [~lib-path-sym (sut/build-agent-cpp! {:build-dir cached-build-dir})]
+     ~@body))
+
 ;; Tests for copy-agent-binary! function.
 ;; Contract: copy-agent-binary! copies source to target dir and creates hash file.
 (deftest copy-agent-binary-test
@@ -179,20 +192,16 @@
   (testing "build-agent-cpp!"
     (testing "builds agent library for current platform"
       (let [os (sut/detect-os)
-            arch (sut/detect-arch)
-            test-build-dir (io/file "target/test-agent-build")]
+            arch (sut/detect-arch)]
         (if (and (contains? #{:linux :macos} os)
                  (contains? #{:x64 :arm64} arch)
                  (not (and (= :linux os) (= :arm64 arch)))
                  (.isDirectory (io/file "agent-cpp")))
-          (try
-            (let [lib-path (sut/build-agent-cpp! {:build-dir test-build-dir})
-                  lib-file (io/file lib-path)]
+          (with-cached-agent-build [lib-path]
+            (let [lib-file (io/file lib-path)]
               (is (string? lib-path))
               (is (.exists lib-file))
-              (is (> (.length lib-file) 0)))
-            (finally
-              (delete-recursively test-build-dir)))
+              (is (> (.length lib-file) 0))))
           (is true "Skipping on unsupported platform or missing agent-cpp"))))
 
     (testing "throws when agent-cpp directory missing"
@@ -210,15 +219,14 @@
             arch (sut/detect-arch)
             platform (str (name os) "-" (name arch))
             resources-dir (io/file "target/test-build-resources")
-            test-build-dir (io/file "target/test-agent-build-copy")
             original-build-agent-cpp! sut/build-agent-cpp!]
         (if (and (contains? #{"linux-x64" "macos-x64" "macos-arm64"} platform)
                  (.isDirectory (io/file "agent-cpp")))
           (try
             (with-redefs [sut/resources-base-dir (constantly resources-dir)
                           sut/build-agent-cpp! (fn
-                                                 ([] (original-build-agent-cpp! {:build-dir test-build-dir}))
-                                                 ([opts] (original-build-agent-cpp! (assoc opts :build-dir test-build-dir))))]
+                                                 ([] (original-build-agent-cpp! {:build-dir cached-build-dir}))
+                                                 ([opts] (original-build-agent-cpp! (assoc opts :build-dir cached-build-dir))))]
               (let [result (sut/build-and-copy-agent!)
                     binary-file (io/file (:binary-path result))
                     hash-file (io/file (:hash-path result))]
@@ -228,6 +236,5 @@
                 (is (re-matches #"[0-9a-f]+\s+libcriterium\.(so|dylib)\n"
                                 (slurp hash-file)))))
             (finally
-              (delete-recursively resources-dir)
-              (delete-recursively test-build-dir)))
+              (delete-recursively resources-dir)))
           (is true "Skipping on unsupported platform or missing agent-cpp"))))))

--- a/projects/agent/test/build_test.clj
+++ b/projects/agent/test/build_test.clj
@@ -212,6 +212,8 @@
 
 ;; Integration test for build-and-copy-agent! function.
 ;; Contract: build-and-copy-agent! builds and copies agent to resources.
+;; Uses with-redefs to inject cached builds because we need to test
+;; build-and-copy-agent! itself, which internally calls build-agent-cpp!.
 (deftest ^:slow build-and-copy-agent-test
   (testing "build-and-copy-agent!"
     (testing "builds agent and copies to resources directory"

--- a/tests.edn
+++ b/tests.edn
@@ -19,7 +19,7 @@
                                   "build/test"
                                   "projects/agent/test"
                                   "development/test"]
-           :skip-meta            [:very-slow :requires-build-artifacts]}]
+           :skip-meta            [:slow :very-slow :requires-build-artifacts]}]
 
   :plugins                            [:kaocha.plugin/randomize
                                        :kaocha.plugin/filter


### PR DESCRIPTION
## Summary

Reduce test suite execution time through several optimizations:

- **CMake build caching**: Add `with-cached-agent-build` macro using shared `target/test-agent-build-cache` directory for incremental agent builds
- **Slow test marking**: Add `^:slow` metadata to `platform-point-estimates-test` (~78s) and skip by default via `tests.edn`
- **Reduced benchmark iterations**: Lower `:limit-time-s` in `bench_test.clj` for API validation tests
- **Reduced property test iterations**: Lower `num-tests` from 100 to 50 in `well_test.clj`

Also documented test speed optimization strategies in CLAUDE.md.

## Test plan

- [ ] Run `clojure -M:kaocha:dev:test --reporter dots` and verify tests complete faster
- [ ] Run slow tests with `clojure -M:kaocha:dev:test --focus-meta :slow` to verify they still pass
- [ ] Verify agent build tests work with cached builds