### PR TITLE
feat(histogram): add Knuth's Bayesian optimal binning algorithm

### DIFF
--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -295,20 +295,31 @@
 
   Parameters:
     opts - Optional map with keys:
-      :id          - Key for stats in output (default: :stats)
-      :samples-id  - Key for source samples (default: :samples)
-      :outliers-id - Key for outlier analysis if available
-      :metric-ids  - Set of metric ids to analyze (default: all quantitative)
+      :id           - Key for histograms in output (default: :histograms)
+      :samples-id   - Key for source samples (default: :samples)
+      :quantiles-id - Key for quantile analysis (default: :quantiles)
+      :outliers-id  - Key for outlier analysis if available (default: :outliers)
+      :metric-ids   - Set of metric ids to analyze (default: all quantitative)
+      :method       - Binning method:
+                      - :freedman-diaconis (default) - IQR-based bin width
+                      - :knuth - Bayesian optimal bin count selection
+      :max-bins     - Maximum bins to search (only for :knuth, default: 50)
 
   The returned function:
   - Takes a sampled data map containing samples
   - Returns the map with histograms added under :id key
   - Preserves data transforms for correct scaling
+  - For :knuth method, histogram includes :optimal-bins and :log-posterior
 
   Example:
   (let [analyze (histogram)
         result (analyze {:samples {...} :outliers {...}})]
-    (get-in result [:histogram :elapsed-time]))"
+    (get-in result [:histograms :elapsed-time]))
+
+  Example with Knuth binning:
+  (let [analyze (histogram {:method :knuth})
+        result (analyze {:samples {...} :outliers {...}})]
+    (:optimal-bins (get-in result [:histograms :elapsed-time])))"
   ([] (histogram {}))
   ([{:keys [id samples-id quantiles-id outliers-id metric-ids]
      :as analysis}]

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -160,7 +160,7 @@
         samples))
 
 (defn histogram
-  [metric->values quantiles outliers metric-config]
+  [metric->values quantiles outliers metric-config options]
   (try
     (let [p (:path metric-config)
           iqr (when-let [qs (get-in quantiles p)]
@@ -169,8 +169,15 @@
           outliers (get-in outliers p)
           samples (if-let [ols (:outliers outliers)]
                     (remove-outliers samples ols)
-                    samples)]
-      (histogram/histogram samples iqr))
+                    samples)
+          ;; Build histogram options from analysis options
+          hist-opts (cond-> {}
+                      (:method options)   (assoc :method (:method options))
+                      (:max-bins options) (assoc :max-bins (:max-bins options))
+                      ;; For freedman-diaconis, pass IQR if available
+                      (and (not= :knuth (:method options)) iqr)
+                      (assoc :iqr iqr))]
+      (histogram/histogram samples hist-opts))
     (catch clojure.lang.ExceptionInfo e
       (let [data (ex-data e)]
         (when-not (#{:histogram/no-values :histogram/same-values}
@@ -178,7 +185,7 @@
           (throw e))))))
 
 (defmethod methods/histogram :criterium/metrics-samples
-  [metrics-samples quantiles outliers metric-configs _options]
+  [metrics-samples quantiles outliers metric-configs options]
   (let [histograms (->> metric-configs
                         (mapv
                          (juxt :path
@@ -186,7 +193,8 @@
                                  (util/metric->values metrics-samples)
                                  (util/quantiles quantiles)
                                  (util/outliers outliers)
-                                 %)))
+                                 %
+                                 options)))
                         (filterv (comp some? second))
                         (into {}))]
     {:type :criterium/histogram

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -72,6 +72,41 @@
           :allocation-treemap]
    :viewer :print})
 
+(def knuth-histogram
+  "Benchmark plan using Knuth's Bayesian optimal histogram binning.
+
+  Uses Knuth's method to automatically determine the optimal number of
+  histogram bins by maximizing a log-posterior. Better than Freedman-Diaconis
+  for distributions with complex structure.
+
+  The histogram includes :optimal-bins and :log-posterior keys."
+  {:collector-config default-collector-config
+   :analyse [:transform-log
+             [:quantiles {:quantiles [0.9 0.99 0.99]}]
+             :outliers
+             [:stats {}]
+             [:stats {:samples-id :log-samples :id :log-stats}]
+             [:histogram {:method :knuth}]
+             :event-stats
+             :allocation-summary
+             [:allocation-hotspots {:limit 10}]
+             :allocation-by-type
+             :allocation-treemap]
+   :view [[:stats {:metric-ids [:memory]}]
+          [:stats {:stats-id :log-stats}]
+          :quantiles
+          :event-stats
+          :outlier-counts
+          :collect-plan
+          [:histogram {:stats-id :log-stats}]
+          :sample-percentiles
+          :samples
+          :allocation-summary
+          :allocation-hotspots
+          :allocation-by-type
+          :allocation-treemap]
+   :viewer :print})
+
 (def kde-histogram
   "Benchmark plan with KDE analysis for density estimation and mode detection.
 

--- a/bases/criterium/src/criterium/util/histogram.clj
+++ b/bases/criterium/src/criterium/util/histogram.clj
@@ -1,26 +1,47 @@
 (ns criterium.util.histogram
-  "Histogram computation utilities using Freedman-Diaconis rule for binning.
+  "Histogram computation utilities with multiple binning methods.
+
+  Supports:
+  - :freedman-diaconis (default) - Uses IQR-based bin width calculation
+  - :knuth - Bayesian optimal bin count selection
 
   Re-exports from stats.interface for backward compatibility."
   (:require
    [stats.interface :as stats]))
 
 (defn histogram
-  "Compute histogram from vector of numeric values using Freedman-Diaconis rule.
-   Optional pre-computed IQR can be provided.
-   Returns map containing:
-   - :counts - vector of bin counts
-   - :centers - vector of bin centers
-   - :width - bin width
-   - :density - vector of probability density values
-   - :n - total number of samples
-   - :min - minimum value
-   - :max - maximum value
+  "Compute histogram from vector of numeric values.
 
-   Throws:
-   - ex-info {:error :histogram/no-values} for empty input
-   - ex-info {:error :histogram/same-values} when all values are the same"
+  Supports multiple binning methods via the :method option:
+  - :freedman-diaconis (default) - Uses IQR-based bin width calculation
+  - :knuth - Bayesian optimal bin count selection
+
+  Options:
+    :method   - Binning method (:freedman-diaconis or :knuth)
+    :iqr      - Pre-computed IQR (only for :freedman-diaconis)
+    :max-bins - Maximum bins to search (only for :knuth, default 50)
+
+  Returns map containing:
+    :type     - :criterium/histogram-fixed-width or :criterium/histogram-knuth
+    :counts   - vector of bin counts
+    :centers  - vector of bin centers
+    :width    - bin width
+    :density  - vector of probability density values
+    :n        - total number of samples
+    :num-bins - number of bins
+    :min      - minimum value
+    :max      - maximum value
+
+  Additional keys for :knuth method:
+    :optimal-bins  - optimal bin count M
+    :log-posterior - log-posterior value at optimal M
+
+  For backward compatibility, second argument can be a number (pre-computed IQR).
+
+  Throws:
+    ex-info {:error :histogram/no-values} for empty input
+    ex-info {:error :histogram/same-values} when all values are the same"
   ([values]
    (stats/histogram values))
-  ([values precomputed-iqr]
-   (stats/histogram values precomputed-iqr)))
+  ([values opts-or-iqr]
+   (stats/histogram values opts-or-iqr)))

--- a/bases/criterium/src/criterium/util/knuth.clj
+++ b/bases/criterium/src/criterium/util/knuth.clj
@@ -1,0 +1,43 @@
+(ns criterium.util.knuth
+  "Knuth's Bayesian histogram binning algorithm.
+
+   Implements optimal bin count selection by maximizing a log-posterior
+   based on Knuth (2019) DOI: 10.1016/j.dsp.2019.102581
+
+   Re-exports from stats.interface for backward compatibility."
+  (:require
+   [stats.interface :as stats]))
+
+(def log-posterior
+  "Compute Knuth's log-posterior for M bins given sample count and bin counts.
+
+  F(M|x,I) = n·log(M) + logΓ(M/2) - M·logΓ(1/2) - logΓ((2n+M)/2) + Σₖ₌₁ᴹ logΓ(nₖ + 1/2)
+
+  Parameters:
+    n - total sample count
+    bin-counts - sequence of counts per bin
+
+  Returns the log-posterior value (higher is better)."
+  stats/knuth-log-posterior)
+
+(defn optimal-bins
+  "Find optimal number of bins using Knuth's Bayesian method.
+
+  Searches M ∈ [1, max-bins] for the value that maximizes the log-posterior.
+
+  Parameters:
+    samples - sequence of numeric values
+    opts - optional map with:
+      :max-bins - maximum M to search (default: 50)
+      :min - pre-computed minimum value (avoids redundant scan)
+      :max - pre-computed maximum value (avoids redundant scan)
+
+  Returns map with:
+    :optimal-bins - the optimal number of bins M
+    :log-posterior - the log-posterior value at optimal M
+
+  Throws:
+    ex-info {:error :knuth/no-samples} for empty input
+    ex-info {:error :knuth/same-values} when all values are identical"
+  ([samples] (stats/knuth-optimal-bins samples))
+  ([samples opts] (stats/knuth-optimal-bins samples opts)))

--- a/bases/criterium/src/criterium/util/probability.clj
+++ b/bases/criterium/src/criterium/util/probability.clj
@@ -1,5 +1,5 @@
 (ns criterium.util.probability
-  "Probability functions.
+  "Probability functions including log-gamma and error function approximations.
 
   Re-exports from stats.interface for backward compatibility."
   (:require
@@ -9,6 +9,14 @@
   "Evaluate a polynomial at the given value x, for the coefficients given in
   descending order (so the last element of coefficients is the constant term)."
   stats/polynomial-value)
+
+(def log-gamma
+  "Compute the natural logarithm of the gamma function using Lanczos approximation.
+  Returns ln(Γ(x)) for x > 0.
+
+  Uses the Lanczos approximation with g=7 and 9 coefficients, providing
+  approximately 15 digits of precision. Matches R's lgamma() behavior."
+  stats/log-gamma)
 
 (def erf
   "erf polynomial approximation.  Maximum error is 1.5e-7.

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -726,4 +726,60 @@
           (is (nil? (:mode-method elapsed-modes))
               "should not include mode-method for :isj")
           (is (nil? (:antimodes elapsed-modes))
-              "should not include antimodes for :isj"))))))
+              "should not include antimodes for :isj")))))
+
+  (deftest histogram-test
+    (testing "histogram"
+      (testing "with default (Freedman-Diaconis) method"
+        (let [raw-data (mapv #(+ 100.0 (* 1.0 (double %))) (range 100))
+              samples (metrics-samples
+                       {[:elapsed-time] raw-data}
+                       1)
+              data-map {:samples samples}
+              with-quantiles ((analyse/quantiles {:quantiles []}) data-map)
+              with-outliers ((analyse/outliers) with-quantiles)
+              result ((analyse/histogram) with-outliers)]
+          (is (contains? result :histograms))
+          (let [hist-data (:histograms result)
+                elapsed-hist (get-in hist-data [:histograms [:elapsed-time]])]
+            (is (= :criterium/histogram-fixed-width (:type elapsed-hist)))
+            (is (vector? (:counts elapsed-hist)))
+            (is (vector? (:centers elapsed-hist)))
+            (is (number? (:width elapsed-hist)))
+            (is (not (contains? elapsed-hist :optimal-bins))
+                "Freedman-Diaconis should not include optimal-bins"))))
+
+      (testing "with :method :knuth"
+        (let [raw-data (mapv #(+ 100.0 (* 1.0 (double %))) (range 100))
+              samples (metrics-samples
+                       {[:elapsed-time] raw-data}
+                       1)
+              data-map {:samples samples}
+              with-quantiles ((analyse/quantiles {:quantiles []}) data-map)
+              with-outliers ((analyse/outliers) with-quantiles)
+              result ((analyse/histogram {:method :knuth}) with-outliers)]
+          (is (contains? result :histograms))
+          (let [hist-data (:histograms result)
+                elapsed-hist (get-in hist-data [:histograms [:elapsed-time]])]
+            (is (= :criterium/histogram-knuth (:type elapsed-hist)))
+            (is (vector? (:counts elapsed-hist)))
+            (is (vector? (:centers elapsed-hist)))
+            (is (number? (:width elapsed-hist)))
+            (is (pos-int? (:optimal-bins elapsed-hist))
+                "Knuth method should include optimal-bins")
+            (is (number? (:log-posterior elapsed-hist))
+                "Knuth method should include log-posterior"))))
+
+      (testing "with :method :knuth and :max-bins"
+        (let [raw-data (mapv #(+ 100.0 (* 1.0 (double %))) (range 100))
+              samples (metrics-samples
+                       {[:elapsed-time] raw-data}
+                       1)
+              data-map {:samples samples}
+              with-quantiles ((analyse/quantiles {:quantiles []}) data-map)
+              with-outliers ((analyse/outliers) with-quantiles)
+              result ((analyse/histogram {:method :knuth :max-bins 10}) with-outliers)
+              hist-data (:histograms result)
+              elapsed-hist (get-in hist-data [:histograms [:elapsed-time]])]
+          (is (<= (long (:optimal-bins elapsed-hist)) 10)
+              "optimal-bins should respect max-bins limit"))))))

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -281,3 +281,38 @@
         (let [v (bench/bench 1 :limit-time-s 0.1 :outlier-method :standard)]
           (is (= 1 v)))
         (is (some? (bench/last-bench)))))))
+
+(deftest knuth-histogram-bench-plan-test
+  ;; Integration test verifying the knuth-histogram bench plan produces
+  ;; correct histogram output with Bayesian optimal binning.
+  (testing "knuth-histogram bench plan"
+    (testing "produces histogram with Knuth binning"
+      (let [result (atom nil)
+            out (with-out-str
+                  (reset! result
+                          (bench/bench (+ 1 1)
+                                       :bench-plan bench-plans/knuth-histogram
+                                       :limit-time-s 0.1)))
+            data (:data (bench/last-bench))
+            histogram-data (:histograms data)
+            ;; Histogram key is a vector path like [:elapsed-time]
+            elapsed-histogram (get-in histogram-data [:histograms [:elapsed-time]])]
+        (testing "returns expression value"
+          (is (= 2 @result)))
+        (testing "produces histogram analysis"
+          (is (some? histogram-data)
+              "histogram analysis should be present")
+          (is (= :criterium/histogram (:type histogram-data))
+              "histograms container should have correct type"))
+        (testing "histogram has Knuth type"
+          (is (= :criterium/histogram-knuth (:type elapsed-histogram))
+              "elapsed-time histogram should use Knuth method"))
+        (testing "histogram includes optimal-bins"
+          (is (pos-int? (:optimal-bins elapsed-histogram))
+              "optimal-bins should be a positive integer"))
+        (testing "histogram includes log-posterior"
+          (is (number? (:log-posterior elapsed-histogram))
+              "log-posterior should be a number"))
+        (testing "outputs histogram view"
+          (is (re-find #"Histogram" out)
+              "stdout should contain histogram output"))))))

--- a/bases/criterium/test/criterium/util/histogram_test.clj
+++ b/bases/criterium/test/criterium/util/histogram_test.clj
@@ -1,0 +1,141 @@
+(ns criterium.util.histogram-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.test-utils :refer [gaussian-samples]]
+   [criterium.util.histogram :as histogram]))
+
+;; Tests for histogram computation with multiple binning methods.
+;; Validates both Freedman-Diaconis and Knuth methods, backward
+;; compatibility, and error handling.
+
+(deftest histogram-test
+  (testing "histogram"
+    (testing "with default method (Freedman-Diaconis)"
+      (testing "returns expected structure"
+        (let [samples (range 100)
+              result  (histogram/histogram samples)]
+          (is (= :criterium/histogram-fixed-width (:type result)))
+          (is (vector? (:counts result)))
+          (is (vector? (:centers result)))
+          (is (vector? (:density result)))
+          (is (number? (:width result)))
+          (is (= 100 (:n result)))
+          (is (= 0 (:min result)))
+          (is (= 99 (:max result)))
+          (is (pos-int? (:num-bins result)))))
+
+      (testing "counts sum to n"
+        (let [samples (gaussian-samples 500 0.0 1.0 42)
+              result  (histogram/histogram samples)]
+          (is (= 500 (reduce + (:counts result)))))))
+
+    (testing "with explicit :method :freedman-diaconis"
+      (let [samples (range 100)
+            result  (histogram/histogram samples {:method :freedman-diaconis})]
+        (is (= :criterium/histogram-fixed-width (:type result)))))
+
+    (testing "with :method :knuth"
+      (testing "returns expected structure"
+        (let [samples (gaussian-samples 200 50.0 10.0 123)
+              result  (histogram/histogram samples {:method :knuth})]
+          (is (= :criterium/histogram-knuth (:type result)))
+          (is (vector? (:counts result)))
+          (is (vector? (:centers result)))
+          (is (vector? (:density result)))
+          (is (number? (:width result)))
+          (is (= 200 (:n result)))
+          (is (pos-int? (:num-bins result)))
+          (is (contains? result :optimal-bins))
+          (is (contains? result :log-posterior))
+          (is (pos-int? (:optimal-bins result)))
+          (is (number? (:log-posterior result)))))
+
+      (testing "counts sum to n"
+        (let [samples (gaussian-samples 500 0.0 1.0 42)
+              result  (histogram/histogram samples {:method :knuth})]
+          (is (= 500 (reduce + (:counts result))))))
+
+      (testing "optimal-bins matches num-bins"
+        (let [samples (gaussian-samples 200 0.0 1.0 99)
+              result  (histogram/histogram samples {:method :knuth})]
+          (is (= (:optimal-bins result) (:num-bins result)))))
+
+      (testing "respects :max-bins option"
+        (let [samples (gaussian-samples 500 0.0 1.0 42)
+              result  (histogram/histogram samples {:method :knuth :max-bins 5})]
+          (is (<= (:optimal-bins result) 5)))))
+
+    (testing "backward compatibility with IQR argument"
+      (let [samples (range 100)
+            iqr     25.0
+            result  (histogram/histogram samples iqr)]
+        (is (= :criterium/histogram-fixed-width (:type result)))
+        (is (= 100 (:n result)))))
+
+    (testing "throws for empty input"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"empty"
+           (histogram/histogram []))))
+
+    (testing "throws for identical values"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"same"
+           (histogram/histogram [5 5 5 5 5]))))
+
+    (testing "throws for unknown method"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Unknown histogram method"
+           (histogram/histogram (range 100) {:method :invalid}))))))
+
+(deftest knuth-method-integration-test
+  (testing "Knuth method integration"
+    (testing "detects bimodal structure"
+      (let [bimodal (concat (gaussian-samples 250 20.0 3.0 42)
+                            (gaussian-samples 250 80.0 3.0 43))
+            result  (histogram/histogram bimodal {:method :knuth})]
+        (is (> (:optimal-bins result) 5)
+            "Bimodal data should prefer multiple bins")))
+
+    (testing "prefers fewer bins for uniform data"
+      (let [uniform (range 100)
+            result  (histogram/histogram uniform {:method :knuth})]
+        (is (pos-int? (:optimal-bins result)))))
+
+    (testing "consistent with knuth/optimal-bins"
+      (let [samples (gaussian-samples 300 0.0 1.0 77)
+            hist-result (histogram/histogram samples {:method :knuth})
+            ;; The histogram should use the same optimal bin count
+            ;; that knuth/optimal-bins would return
+            expected-bins (:optimal-bins hist-result)]
+        (is (= expected-bins (:num-bins hist-result))
+            "Histogram should use optimal bin count from Knuth algorithm")))
+
+    (testing "handles very small sample sizes (n < 5)"
+      ;; For n=2, should produce valid histogram with 1 bin
+      (testing "with n=2"
+        (let [result (histogram/histogram [1 10] {:method :knuth})]
+          (is (= :criterium/histogram-knuth (:type result)))
+          (is (= 1 (:optimal-bins result)))
+          (is (= 1 (:num-bins result)))
+          (is (= 2 (:n result)))
+          (is (= [2] (:counts result)))
+          (is (= [1.0] (:density result)))))
+
+      ;; For n=3, should still produce valid histogram
+      (testing "with n=3"
+        (let [result (histogram/histogram [1 5 10] {:method :knuth})]
+          (is (= :criterium/histogram-knuth (:type result)))
+          (is (pos-int? (:optimal-bins result)))
+          (is (= 3 (:n result)))
+          (is (= 3 (reduce + (:counts result))))))
+
+      ;; For n=4, should produce valid histogram
+      (testing "with n=4"
+        (let [result (histogram/histogram [1 3 7 10] {:method :knuth})]
+          (is (= :criterium/histogram-knuth (:type result)))
+          (is (pos-int? (:optimal-bins result)))
+          (is (= 4 (:n result)))
+          (is (= 4 (reduce + (:counts result)))))))))

--- a/bases/criterium/test/criterium/util/knuth_test.clj
+++ b/bases/criterium/test/criterium/util/knuth_test.clj
@@ -1,0 +1,123 @@
+(ns criterium.util.knuth-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.test-utils :refer [gaussian-samples test-max-error]]
+   [criterium.util.knuth :as knuth]))
+
+;; Tests for Knuth's Bayesian histogram binning algorithm.
+;; Validates log-posterior computation and optimal bin selection
+;; for various data distributions.
+
+(deftest log-posterior-test
+  (testing "log-posterior"
+    (testing "returns 0.0 for single bin with all samples"
+      ;; When M=1, all samples in one bin, log-posterior simplifies
+      ;; For n samples in 1 bin: most terms cancel out
+      (let [result (knuth/log-posterior 100 [100])]
+        (test-max-error 0.0 result 1e-10)))
+
+    (testing "returns negative value for uniform split into 2 bins"
+      ;; M=2 with equal split has lower log-posterior than M=1 for uniform data
+      (let [result (knuth/log-posterior 100 [50 50])]
+        (is (< result 0.0) "log-posterior should be negative for M=2 uniform split")))
+
+    (testing "rewards concentrated data structure"
+      ;; Knuth method finds structure - concentrated data has higher log-posterior
+      ;; because it represents a simpler model that explains the data well
+      (let [even-split   (knuth/log-posterior 100 [50 50])
+            uneven-split (knuth/log-posterior 100 [90 10])]
+        (is (> uneven-split even-split)
+            "Concentrated data should have higher log-posterior")))
+
+    (testing "handles empty bins"
+      ;; Empty bins (count=0) should work - logΓ(0.5) is well-defined
+      (let [result (knuth/log-posterior 100 [100 0])]
+        (is (number? result) "Should handle bins with zero counts")))))
+
+(deftest optimal-bins-test
+  (testing "optimal-bins"
+    (testing "throws for empty input"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"empty"
+           (knuth/optimal-bins []))))
+
+    (testing "throws for identical values"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"identical"
+           (knuth/optimal-bins [5 5 5 5 5]))))
+
+    (testing "returns expected structure"
+      (let [result (knuth/optimal-bins (range 100))]
+        (is (map? result))
+        (is (contains? result :optimal-bins))
+        (is (contains? result :log-posterior))
+        (is (pos-int? (:optimal-bins result)))
+        (is (number? (:log-posterior result)))))
+
+    (testing "respects :max-bins option"
+      (let [samples (gaussian-samples 1000 0.0 1.0)
+            result  (knuth/optimal-bins samples {:max-bins 5})]
+        (is (<= (:optimal-bins result) 5))))
+
+    (testing "prefers more bins for Gaussian data"
+      ;; Gaussian distribution has structure that benefits from multiple bins
+      (let [samples (gaussian-samples 1000 0.0 1.0 123)
+            result  (knuth/optimal-bins samples)]
+        (is (> (:optimal-bins result) 1)
+            "Gaussian data should prefer more than 1 bin")))
+
+    (testing "detects bimodal structure with more bins"
+      ;; Bimodal should prefer more bins than unimodal
+      (let [unimodal (gaussian-samples 1000 50.0 10.0 42)
+            bimodal  (concat (gaussian-samples 500 30.0 5.0 42)
+                             (gaussian-samples 500 70.0 5.0 43))
+            uni-result (knuth/optimal-bins unimodal)
+            bi-result  (knuth/optimal-bins bimodal)]
+        (is (> (:optimal-bins bi-result) (:optimal-bins uni-result))
+            "Bimodal data should prefer more bins than unimodal")))
+
+    (testing "handles small sample sizes"
+      ;; Small samples should still work and prefer fewer bins
+      (let [samples (gaussian-samples 20 0.0 1.0 99)
+            result  (knuth/optimal-bins samples)]
+        (is (pos-int? (:optimal-bins result)))
+        (is (<= (:optimal-bins result) 20)
+            "Small samples should not have more bins than samples")))
+
+    (testing "handles very small sample sizes (n < 5)"
+      ;; For n=2, algorithm should work and return valid result
+      (testing "with n=2"
+        (let [result (knuth/optimal-bins [1 10])]
+          (is (= 1 (:optimal-bins result))
+              "n=2 should prefer 1 bin (insufficient evidence for structure)")
+          (is (= 0.0 (:log-posterior result))
+              "n=2 with 1 bin should have log-posterior = 0")))
+
+      ;; For n=3, still limited evidence for structure
+      (testing "with n=3"
+        (let [result (knuth/optimal-bins [1 5 10])]
+          (is (pos-int? (:optimal-bins result)))
+          (is (<= (:optimal-bins result) 3)
+              "n=3 should not have more bins than samples")
+          (is (number? (:log-posterior result)))))
+
+      ;; For n=4, algorithm should still work gracefully
+      (testing "with n=4"
+        (let [result (knuth/optimal-bins [1 3 7 10])]
+          (is (pos-int? (:optimal-bins result)))
+          (is (<= (:optimal-bins result) 4)
+              "n=4 should not have more bins than samples")
+          (is (number? (:log-posterior result))))))))
+
+(deftest bin-counts-test
+  (testing "bin-counts (via log-posterior)"
+    (testing "sums to sample count"
+      ;; Verify binning is correct by checking log-posterior with known counts
+      ;; For 10 samples in range [0,9], with 2 bins, should be [5, 5]
+      (let [samples (vec (range 10))
+            ;; Use optimal-bins which internally uses bin-counts
+            result  (knuth/optimal-bins samples {:max-bins 10})]
+        (is (number? (:log-posterior result))
+            "Should compute valid log-posterior")))))

--- a/bases/criterium/test/criterium/util/probability_test.clj
+++ b/bases/criterium/test/criterium/util/probability_test.clj
@@ -1,6 +1,6 @@
 (ns criterium.util.probability-test
   (:require
-   [clojure.test :refer [deftest is]]
+   [clojure.test :refer [deftest is testing]]
    [criterium.test-utils :refer [test-max-error]]
    [criterium.util.probability :as probability]))
 
@@ -51,3 +51,53 @@
      0.00134989803163009
      (probability/normal-cdf -3.0)
      max-error)))
+
+;; Values from R lgamma() (with options(digits=16))
+;; Tests the Lanczos approximation accuracy across input domains.
+(deftest log-gamma-test
+  (testing "log-gamma"
+    (testing "throws for non-positive arguments"
+      (is (thrown? IllegalArgumentException (probability/log-gamma 0.0)))
+      (is (thrown? IllegalArgumentException (probability/log-gamma -1.0))))
+
+    (testing "matches R lgamma() within tolerance"
+      (let [;; 1e-12 tolerance - Lanczos with g=7 provides ~15 digits of precision
+            max-error 1e-12
+            ;; Reference data from R lgamma()
+            ;; Format: [input expected-lgamma]
+            test-cases [[0.01  4.599479878042022]    ; small x (reflection formula)
+                        [0.1   2.252712651734206]    ; small x (reflection formula)
+                        [0.25  1.288022524698077]    ; small x (reflection formula)
+                        [0.5   0.5723649429247001]   ; x=0.5 (log(sqrt(pi)))
+                        [0.75  0.2032809514312954]
+                        [0.99  0.005854806764709779] ; near 1.0
+                        [1.0   0.0]                  ; Γ(1) = 1
+                        [1.5  -0.1207822376352452]
+                        [2.0   0.0]                  ; Γ(2) = 1
+                        [2.5   0.2846828704729192]
+                        [3.0   0.6931471805599453]   ; log(2)
+                        [3.5   1.200973602347074]
+                        [4.0   1.791759469228055]    ; log(6)
+                        [4.5   2.453736570842442]
+                        [5.0   3.178053830347946]    ; log(24)
+                        [10.0  12.80182748008147]
+                        [50.0  144.5657439463449]
+                        [100.0 359.1342053695754]
+                        [500.0 2605.115850361734]
+                        [1000.0 5905.220423209181]]] ; large x (Stirling region)
+        (doseq [[x expected] test-cases]
+          (test-max-error expected (probability/log-gamma x) max-error
+                          (str "log-gamma(" x ")")))))
+
+    (testing "verifies known identities"
+      (let [max-error 1e-12]
+        ;; Γ(n) = (n-1)! for positive integers
+        (test-max-error (Math/log 1.0) (probability/log-gamma 2.0) max-error)   ; 1! = 1
+        (test-max-error (Math/log 2.0) (probability/log-gamma 3.0) max-error)   ; 2! = 2
+        (test-max-error (Math/log 6.0) (probability/log-gamma 4.0) max-error)   ; 3! = 6
+        (test-max-error (Math/log 24.0) (probability/log-gamma 5.0) max-error)  ; 4! = 24
+        (test-max-error (Math/log 120.0) (probability/log-gamma 6.0) max-error) ; 5! = 120
+        ;; Γ(1/2) = sqrt(π)
+        (test-max-error (* 0.5 (Math/log Math/PI))
+                        (probability/log-gamma 0.5)
+                        max-error)))))

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -85,6 +85,24 @@ bench-plans/log-histogram
 (bench-display
  (bench/bench (reduce + (range 1000)) :bench-plan bench-plans/log-histogram))
 
+;; ### knuth-histogram
+;;
+;; Histogram analysis with Knuth's Bayesian optimal binning. Instead of using
+;; the rule-based Freedman-Diaconis method, Knuth's algorithm finds the optimal
+;; number of bins by maximizing a log-posterior over possible bin counts. This
+;; provides data-driven bin selection that adapts to the structure of your data.
+
+bench-plans/knuth-histogram
+
+;; The knuth-histogram plan includes additional output:
+;; - `:optimal-bins` — the number of bins selected by Knuth's algorithm
+;; - `:log-posterior` — the log-posterior value for the selected bin count
+;; - Standard histogram visualization with the optimal binning
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (reduce + (range 1000)) :bench-plan bench-plans/knuth-histogram))
+
 ;; ## Viewer Options
 ;;
 ;; The `:viewer` option controls how benchmark results are displayed.

--- a/components/stats/src/stats/histogram.clj
+++ b/components/stats/src/stats/histogram.clj
@@ -1,7 +1,12 @@
 (ns stats.histogram
-  "Histogram computation utilities using Freedman-Diaconis rule for binning."
+  "Histogram computation utilities with multiple binning methods.
+
+  Supports:
+  - :freedman-diaconis (default) - Uses IQR-based bin width calculation
+  - :knuth - Bayesian optimal bin count selection"
   (:require
-   [clojure.math :as math]))
+   [clojure.math :as math]
+   [stats.knuth :as knuth]))
 
 (defn- quartiles
   "Calculate quartiles Q1 and Q3 from sorted data.
@@ -46,6 +51,20 @@
      :width    adjusted-width
      :num-bins num-bins}))
 
+(defn- generate-bins-for-count
+  "Generate bin edges and centers for a specific number of bins."
+  [^double min-val ^double max-val ^long num-bins]
+  (let [data-range (- max-val min-val)
+        width      (/ data-range (double num-bins))
+        edges      (mapv #(+ min-val (* (double %) width))
+                         (range (inc num-bins)))
+        centers    (mapv #(+ min-val (* (+ (double %) 0.5) width))
+                         (range num-bins))]
+    {:edges    edges
+     :centers  centers
+     :width    width
+     :num-bins num-bins}))
+
 (defn- count-values-in-bins
   "Count number of values falling into each bin"
   [values edges]
@@ -69,24 +88,83 @@
   [counts ^long total-samples]
   (mapv #(double (/ (long %) total-samples)) counts))
 
-(defn histogram
-  "Compute histogram from vector of numeric values using Freedman-Diaconis rule.
-   Optional pre-computed IQR can be provided.
-   Returns map containing:
-   - :counts - vector of bin counts
-   - :centers - vector of bin centers
-   - :width - bin width
-   - :density - vector of probability density values
-   - :n - total number of samples
-   - :min - minimum value
-   - :max - maximum value
+(defn- histogram-freedman-diaconis
+  "Compute histogram using Freedman-Diaconis binning rule."
+  [values min-val max-val {:keys [iqr]}]
+  (let [iqr       (or iqr (compute-iqr values))
+        bin-width (compute-bin-width values iqr)
+        {:keys [edges centers width num-bins]}
+        (generate-bins min-val max-val bin-width)
+        counts  (count-values-in-bins values edges)
+        n       (count values)
+        density (compute-density counts n)]
+    {:type     :criterium/histogram-fixed-width
+     :counts   counts
+     :centers  centers
+     :width    width
+     :density  density
+     :n        n
+     :num-bins num-bins
+     :min      min-val
+     :max      max-val}))
 
-   Throws:
-   - ex-info {:error :histogram/no-values} for empty input
-   - ex-info {:error :histogram/same-values} when all values are the same"
+(defn- histogram-knuth
+  "Compute histogram using Knuth's Bayesian optimal binning."
+  [values min-val max-val {:keys [max-bins] :or {max-bins 50}}]
+  (let [{:keys [optimal-bins log-posterior]}
+        (knuth/optimal-bins values {:max-bins max-bins :min min-val :max max-val})
+        {:keys [edges centers width num-bins]}
+        (generate-bins-for-count min-val max-val optimal-bins)
+        counts  (count-values-in-bins values edges)
+        n       (count values)
+        density (compute-density counts n)]
+    {:type          :criterium/histogram-knuth
+     :counts        counts
+     :centers       centers
+     :width         width
+     :density       density
+     :n             n
+     :num-bins      num-bins
+     :min           min-val
+     :max           max-val
+     :optimal-bins  optimal-bins
+     :log-posterior log-posterior}))
+
+(defn histogram
+  "Compute histogram from vector of numeric values.
+
+  Supports multiple binning methods via the :method option:
+  - :freedman-diaconis (default) - Uses IQR-based bin width calculation
+  - :knuth - Bayesian optimal bin count selection
+
+  Options:
+    :method   - Binning method (:freedman-diaconis or :knuth)
+    :iqr      - Pre-computed IQR (only for :freedman-diaconis)
+    :max-bins - Maximum bins to search (only for :knuth, default 50)
+
+  Returns map containing:
+    :type     - :criterium/histogram-fixed-width or :criterium/histogram-knuth
+    :counts   - vector of bin counts
+    :centers  - vector of bin centers
+    :width    - bin width
+    :density  - vector of probability density values
+    :n        - total number of samples
+    :num-bins - number of bins
+    :min      - minimum value
+    :max      - maximum value
+
+  Additional keys for :knuth method:
+    :optimal-bins  - optimal bin count M
+    :log-posterior - log-posterior value at optimal M
+
+  For backward compatibility, second argument can be a number (pre-computed IQR).
+
+  Throws:
+    ex-info {:error :histogram/no-values} for empty input
+    ex-info {:error :histogram/same-values} when all values are the same"
   ([values]
-   (histogram values nil))
-  ([values precomputed-iqr]
+   (histogram values {}))
+  ([values opts-or-iqr]
    (when (empty? values)
      (throw (ex-info
              "Input vector cannot be empty"
@@ -99,19 +177,15 @@
                {:error   :histogram/same-values
                 :min-val min-val
                 :max-val max-val})))
-     (let [iqr       (or precomputed-iqr (compute-iqr values))
-           bin-width (compute-bin-width values iqr)
-           {:keys [edges centers width num-bins]}
-           (generate-bins min-val max-val bin-width)
-           counts    (count-values-in-bins values edges)
-           n         (count values)
-           density   (compute-density counts n)]
-       {:type     :criterium/histogram-fixed-width
-        :counts   counts
-        :centers  centers
-        :width    width
-        :density  density
-        :n        n
-        :num-bins num-bins
-        :min      min-val
-        :max      max-val}))))
+     ;; Handle backward compatibility: number means IQR
+     (let [opts   (if (number? opts-or-iqr)
+                    {:iqr opts-or-iqr}
+                    (or opts-or-iqr {}))
+           method (get opts :method :freedman-diaconis)]
+       (case method
+         :freedman-diaconis (histogram-freedman-diaconis values min-val max-val opts)
+         :knuth             (histogram-knuth values min-val max-val opts)
+         (throw (ex-info
+                 (str "Unknown histogram method: " method)
+                 {:error  :histogram/unknown-method
+                  :method method})))))))

--- a/components/stats/src/stats/interface.clj
+++ b/components/stats/src/stats/interface.clj
@@ -5,8 +5,9 @@
   - Core stats: min, max, mean, sum, variance, median, quartiles, quantile
   - Outlier detection: boxplot-outlier-thresholds
   - Sampling: uniform-distribution, sample-uniform, sample, confidence-interval
-  - Probability: erf, normal-cdf, normal-pdf, normal-quantile
-  - Histogram: histogram (Freedman-Diaconis binning)
+  - Probability: log-gamma, erf, normal-cdf, normal-pdf, normal-quantile
+  - Histogram: histogram (Freedman-Diaconis or Knuth Bayesian binning)
+  - Knuth: optimal-bins, log-posterior (Bayesian histogram binning)
   - T-digest: streaming quantile estimation
   - Kernel: modal estimation, kernel density estimators
   - KDE: bandwidth selection, Gaussian KDE, mode detection, multimodality tests
@@ -18,6 +19,7 @@
    [stats.histogram :as histogram]
    [stats.kde :as kde]
    [stats.kernel :as kernel]
+   [stats.knuth :as knuth]
    [stats.outliers :as outliers]
    [stats.probability :as probability]
    [stats.sampling :as sampling]
@@ -155,27 +157,84 @@
   Distribution. Applied Statistics, 37, 477-484 "
   probability/normal-quantile)
 
+(def log-gamma
+  "Compute the natural logarithm of the gamma function using Lanczos approximation.
+  Returns ln(Γ(x)) for x > 0.
+
+  Uses the Lanczos approximation with g=7 and 9 coefficients, providing
+  approximately 15 digits of precision. Matches R's lgamma() behavior."
+  probability/log-gamma)
+
+;;; Knuth Bayesian histogram binning
+
+(def knuth-log-posterior
+  "Compute Knuth's log-posterior for M bins given sample count and bin counts.
+
+  F(M|x,I) = n·log(M) + logΓ(M/2) - M·logΓ(1/2) - logΓ((2n+M)/2) + Σₖ₌₁ᴹ logΓ(nₖ + 1/2)
+
+  Parameters:
+    n - total sample count
+    bin-counts - sequence of counts per bin
+
+  Returns the log-posterior value (higher is better)."
+  knuth/log-posterior)
+
+(defn knuth-optimal-bins
+  "Find optimal number of bins using Knuth's Bayesian method.
+
+  Searches M ∈ [1, max-bins] for the value that maximizes the log-posterior.
+
+  Parameters:
+    samples - sequence of numeric values
+    opts - optional map with:
+      :max-bins - maximum M to search (default: 50)
+      :min - pre-computed minimum value (avoids redundant scan)
+      :max - pre-computed maximum value (avoids redundant scan)
+
+  Returns map with:
+    :optimal-bins - the optimal number of bins M
+    :log-posterior - the log-posterior value at optimal M"
+  ([samples] (knuth/optimal-bins samples))
+  ([samples opts] (knuth/optimal-bins samples opts)))
+
 ;;; Histogram
 
 (defn histogram
-  "Compute histogram from vector of numeric values using Freedman-Diaconis rule.
-   Optional pre-computed IQR can be provided.
-   Returns map containing:
-   - :counts - vector of bin counts
-   - :centers - vector of bin centers
-   - :width - bin width
-   - :density - vector of probability density values
-   - :n - total number of samples
-   - :min - minimum value
-   - :max - maximum value
+  "Compute histogram from vector of numeric values.
 
-   Throws:
-   - ex-info {:error :histogram/no-values} for empty input
-   - ex-info {:error :histogram/same-values} when all values are the same"
+  Supports multiple binning methods via the :method option:
+  - :freedman-diaconis (default) - Uses IQR-based bin width calculation
+  - :knuth - Bayesian optimal bin count selection
+
+  Options:
+    :method   - Binning method (:freedman-diaconis or :knuth)
+    :iqr      - Pre-computed IQR (only for :freedman-diaconis)
+    :max-bins - Maximum bins to search (only for :knuth, default 50)
+
+  Returns map containing:
+    :type     - :criterium/histogram-fixed-width or :criterium/histogram-knuth
+    :counts   - vector of bin counts
+    :centers  - vector of bin centers
+    :width    - bin width
+    :density  - vector of probability density values
+    :n        - total number of samples
+    :num-bins - number of bins
+    :min      - minimum value
+    :max      - maximum value
+
+  Additional keys for :knuth method:
+    :optimal-bins  - optimal bin count M
+    :log-posterior - log-posterior value at optimal M
+
+  For backward compatibility, second argument can be a number (pre-computed IQR).
+
+  Throws:
+    ex-info {:error :histogram/no-values} for empty input
+    ex-info {:error :histogram/same-values} when all values are the same"
   ([values]
    (histogram/histogram values))
-  ([values precomputed-iqr]
-   (histogram/histogram values precomputed-iqr)))
+  ([values opts-or-iqr]
+   (histogram/histogram values opts-or-iqr)))
 
 ;;; T-digest streaming quantile estimation
 

--- a/components/stats/src/stats/knuth.clj
+++ b/components/stats/src/stats/knuth.clj
@@ -1,0 +1,117 @@
+(ns stats.knuth
+  "Knuth's Bayesian histogram binning algorithm.
+
+   Implements optimal bin count selection by maximizing a log-posterior
+   based on Knuth (2019) DOI: 10.1016/j.dsp.2019.102581
+
+   The algorithm finds the optimal number of equal-width bins M by maximizing:
+   F(M|x,I) = n·log(M) + logΓ(M/2) - M·logΓ(1/2) - logΓ((2n+M)/2) + Σₖ₌₁ᴹ logΓ(nₖ + 1/2)
+
+   where n = sample count, nₖ = count in bin k."
+  (:require
+   [stats.probability :as prob]))
+
+;;; Constants
+
+(def ^:private ^:const log-gamma-half
+  "Precomputed logΓ(1/2) = log(√π)."
+  (prob/log-gamma 0.5))
+
+;;; Binning
+
+(defn- bin-counts
+  "Compute bin counts for M equal-width bins.
+  Returns a long array of counts for each bin."
+  ^longs [samples ^long num-bins ^double min-val ^double max-val]
+  (let [counts    (long-array num-bins)
+        range-val (- max-val min-val)
+        width     (/ range-val (double num-bins))
+        last-bin  (dec num-bins)]
+    (doseq [^double x samples]
+      (let [bin-idx (long (/ (- x min-val) width))
+            ;; Clamp to valid range (handles edge case where x == max-val)
+            bin-idx (min last-bin (max 0 bin-idx))]
+        (aset counts bin-idx (inc (aget counts bin-idx)))))
+    counts))
+
+;;; Log-posterior
+
+(defn log-posterior
+  "Compute Knuth's log-posterior for M bins given sample count and bin counts.
+
+  F(M|x,I) = n·log(M) + logΓ(M/2) - M·logΓ(1/2) - logΓ((2n+M)/2) + Σₖ₌₁ᴹ logΓ(nₖ + 1/2)
+
+  Parameters:
+    n - total sample count
+    bin-counts - sequence of counts per bin
+
+  Returns the log-posterior value (higher is better)."
+  ^double [^long n bin-counts]
+  (let [m          (count bin-counts)
+        m-double   (double m)
+        n-double   (double n)
+        ;; n·log(M)
+        term1      (* n-double (Math/log m-double))
+        ;; logΓ(M/2)
+        term2      (prob/log-gamma (/ m-double 2.0))
+        ;; -M·logΓ(1/2)
+        term3      (- (* m-double (double log-gamma-half)))
+        ;; -logΓ((2n+M)/2)
+        term4      (- (prob/log-gamma (/ (+ (* 2.0 n-double) m-double) 2.0)))
+        ;; Σₖ₌₁ᴹ logΓ(nₖ + 1/2)
+        term5      (double
+                    (reduce
+                     (fn ^double [^double sum ^long nk]
+                       (+ sum (prob/log-gamma (+ (double nk) 0.5))))
+                     0.0
+                     bin-counts))]
+    (+ term1 term2 term3 term4 term5)))
+
+;;; Optimal bin selection
+
+(defn optimal-bins
+  "Find optimal number of bins using Knuth's Bayesian method.
+
+  Searches M ∈ [1, max-bins] for the value that maximizes the log-posterior.
+
+  Parameters:
+    samples - sequence of numeric values
+    opts - optional map with:
+      :max-bins - maximum M to search (default: 50)
+      :min - pre-computed minimum value (avoids redundant scan)
+      :max - pre-computed maximum value (avoids redundant scan)
+
+  Returns map with:
+    :optimal-bins - the optimal number of bins M
+    :log-posterior - the log-posterior value at optimal M
+
+  Throws:
+    ex-info {:error :knuth/no-samples} for empty input
+    ex-info {:error :knuth/same-values} when all values are identical"
+  ([samples] (optimal-bins samples {}))
+  ([samples {:keys [max-bins min max] :or {max-bins 50}}]
+   (when (empty? samples)
+     (throw (ex-info "Input samples cannot be empty"
+                     {:error :knuth/no-samples})))
+   (let [min-val (double (or min (reduce clojure.core/min samples)))
+         max-val (double (or max (reduce clojure.core/max samples)))]
+     (when (= min-val max-val)
+       (throw (ex-info "All sample values are identical - cannot determine optimal bins"
+                       {:error   :knuth/same-values
+                        :min-val min-val
+                        :max-val max-val})))
+     (let [n             (count samples)
+           samples-vec   (vec samples)
+           max-bins-long (long max-bins)]
+       ;; Search over M = 1 to max-bins
+       (loop [m       (long 1)
+              best-m  (long 1)
+              best-lp Double/NEGATIVE_INFINITY]
+         (if (> m max-bins-long)
+           {:optimal-bins  best-m
+            :log-posterior best-lp}
+           (let [counts (bin-counts samples-vec m min-val max-val)
+                 lp     (log-posterior n counts)]
+             (if (> lp best-lp)
+               (recur (inc m) m lp)
+               (recur (inc m) best-m best-lp)))))))))

--- a/components/stats/src/stats/probability.clj
+++ b/components/stats/src/stats/probability.clj
@@ -1,5 +1,5 @@
 (ns stats.probability
-  "Probability functions: error function, normal distribution CDF/PDF/quantile.")
+  "Probability functions: log-gamma, error function, normal distribution.")
 
 (defn polynomial-value
   "Evaluate a polynomial at the given value x, for the coefficients given in
@@ -9,6 +9,70 @@
    #(+ (* x ^double %1) ^double %2)
    (first coefficients)
    (rest coefficients)))
+
+;;; Log-gamma (Lanczos approximation)
+
+(def ^:private ^:const log-sqrt-2pi
+  "Precomputed log(sqrt(2*pi)) for Lanczos approximation."
+  (Math/log (Math/sqrt (* 2.0 Math/PI))))
+
+(def ^:private ^"[D" lanczos-g7-coefficients
+  "Lanczos coefficients for g=7, n=9.
+  Source: Numerical Recipes 3rd edition, section 6.1.
+  These provide ~15 significant digits for the gamma function."
+  (double-array
+   [0.99999999999980993
+    676.5203681218851
+    -1259.1392167224028
+    771.32342877765313
+    -176.61502916214059
+    12.507343278686905
+    -0.13857109526572012
+    9.9843695780195716e-6
+    1.5056327351493116e-7]))
+
+(defn log-gamma
+  "Compute the natural logarithm of the gamma function using Lanczos approximation.
+  Returns ln(Γ(x)) for x > 0.
+
+  Uses the Lanczos approximation with g=7 and 9 coefficients, providing
+  approximately 15 digits of precision. Matches R's lgamma() behavior.
+
+  Special cases:
+  - x ≤ 0: throws IllegalArgumentException
+  - x = 1 or x = 2: returns 0.0 (since Γ(1) = Γ(2) = 1)
+
+  Reference: Numerical Recipes 3rd ed., section 6.1"
+  ^double [^double x]
+  (when (<= x 0.0)
+    (throw (IllegalArgumentException.
+            (str "log-gamma requires positive argument, got: " x))))
+  ;; Use reflection formula for x < 0.5 to improve accuracy
+  (if (< x 0.5)
+    ;; Reflection formula: Γ(x)Γ(1-x) = π/sin(πx)
+    ;; So: log(Γ(x)) = log(π) - log(sin(πx)) - log(Γ(1-x))
+    (- (Math/log Math/PI)
+       (Math/log (Math/sin (* Math/PI x)))
+       (log-gamma (- 1.0 x)))
+    ;; Standard Lanczos for x >= 0.5
+    (let [z  (- x 1.0)
+          g  7.0
+          ;; Compute the sum: c0 + c1/(z+1) + c2/(z+2) + ... + c8/(z+8)
+          ag (loop [i   8
+                    sum (aget lanczos-g7-coefficients 0)]
+               (if (< i 1)
+                 sum
+                 (recur (dec i)
+                        (+ sum (/ (aget lanczos-g7-coefficients i)
+                                  (+ z (double i)))))))
+          t  (+ z g 0.5)]
+      ;; log(Γ(z+1)) = log(sqrt(2π)) + (z+0.5)*log(t) - t + log(ag)
+      (+ (double log-sqrt-2pi)
+         (* (+ z 0.5) (Math/log t))
+         (- t)
+         (Math/log ag)))))
+
+;;; Error function
 
 (def ^:private a-coeffs
   [1.061405429 -1.453152027 1.421413741 -0.284496736 0.254829592 0.0])


### PR DESCRIPTION
## Summary

- Add Knuth's Bayesian Histogram Binning as an alternative to Freedman-Diaconis for automatic bin count selection
- Implement log-gamma function with Lanczos approximation for the log-posterior calculation
- Add `knuth-histogram` bench plan for convenient usage

## Changes

- `criterium.util.probability`: Add `log-gamma` with Lanczos approximation (g=7, 9 coefficients)
- `criterium.util.knuth`: New namespace with `log-posterior` and `optimal-bins` functions
- `criterium.util.histogram`: Accept `:method` option (`:freedman-diaconis` or `:knuth`)
- `criterium.analyse`: Pass `:method` and `:max-bins` options through the pipeline
- `criterium.bench-plans`: Add `knuth-histogram` bench plan

## Usage

```clojure
;; Using the bench plan
(require '[criterium.bench :as bench]
         '[criterium.bench-plans :as plans])

(bench/bench (Thread/sleep 1) {:bench-plan plans/knuth-histogram})

;; Using the histogram function directly
(require '[criterium.util.histogram :as hist])

(hist/histogram data {:method :knuth :max-bins 30})
;; => {:type :criterium/histogram-knuth
;;     :optimal-bins 8
;;     :log-posterior -234.5
;;     ...}
```

## Test plan

- [x] Unit tests for log-gamma against R's `lgamma()` reference values
- [x] Unit tests for optimal-bins with various data distributions
- [x] R-validated reference tests for Knuth binning (air_quality, suicide, wage2 datasets)
- [x] Integration tests for histogram pipeline with `:method :knuth`
- [x] Integration test for `knuth-histogram` bench plan