### PR TITLE
feat(analyse): add stats analysis for KDE-based summary statistics

### DIFF
--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -506,6 +506,63 @@
                  (assoc data-map id modes-map))
                data-map))))))))
 
+(defn kde-stats
+  "Calculates descriptive statistics derived from KDE density estimates.
+
+  Returns a function that computes statistics by integrating over the KDE
+  density function. This provides a smoothed view of the underlying distribution
+  compared to sample-based statistics.
+
+  Parameters:
+    opts - Optional map with keys:
+      :id         - Key for stats in output (default: :kde-stats)
+      :kde-id     - Key for source KDE data (default: :kde)
+      :metric-ids - Set of metric ids to analyze (default: all quantitative)
+
+  The returned function:
+  - Takes a data map containing KDE analysis results
+  - Returns the map with statistics added under :id key
+  - Returns data-map unchanged if KDE data unavailable
+  - For each metric, calculates:
+    - mean: density-weighted mean ∫ x·f(x) dx
+    - variance: density-weighted variance ∫ (x-μ)²·f(x) dx
+    - min-val/max-val: grid bounds (effective support)
+    - mean ±3σ bounds
+    - n: sample count from KDE metadata
+
+  Example:
+  (let [analyze (kde-stats)
+        result (analyze {:kde {...}})]
+    (get-in result [:kde-stats :elapsed-time]))
+  ;; Returns {:mean 100.0 :variance 16.0 ...}"
+  ([] (kde-stats {}))
+  ([{:keys [id kde-id metric-ids]}]
+   (let [id (or id :kde-stats)
+         kde-id (or kde-id :kde)]
+     (fn [data-map]
+       (let [kde-map (get data-map kde-id)]
+         (if-not kde-map
+           data-map
+           (let [metrics-defs (-> (have (:metrics-defs kde-map))
+                                  (metric/select-metrics metric-ids)
+                                  (metric/filter-metrics
+                                   (metric/type-pred :quantitative)))
+                 metric-configs (metric/all-metric-configs metrics-defs)
+                 stats (methods/stats
+                        kde-map
+                        nil ; no outliers - already filtered in KDE
+                        metric-configs
+                        {})
+                 stats-map (util/->stats-map
+                            (merge
+                             {:type :criterium/stats
+                              :metrics-defs metrics-defs
+                              :source-id kde-id
+                              :outliers-id nil
+                              :batch-size (:batch-size kde-map)}
+                             stats))]
+             (assoc data-map id stats-map))))))))
+
 (defn- min-f
   ^double [f ^double q ^double r]
   (min ^double (f q) ^double (f r)))

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -140,6 +140,79 @@
      :stats stats
      :transform collect-plan/identity-transforms}))
 
+;;; KDE-based statistics
+
+(defn- trapezoidal-integrate
+  "Numerical integration using the trapezoidal rule.
+  f-values is a sequence of function values at evenly spaced grid points.
+  grid is the x-coordinates of those points.
+  Returns the integral estimate."
+  ^double [grid f-values]
+  (let [n (count grid)]
+    (if (< n 2)
+      0.0
+      (loop [i 1
+             sum 0.0]
+        (if (< i n)
+          (let [x0 (double (nth grid (dec i)))
+                x1 (double (nth grid i))
+                f0 (double (nth f-values (dec i)))
+                f1 (double (nth f-values i))
+                dx (- x1 x0)]
+            (recur (inc i) (+ sum (* 0.5 dx (+ f0 f1)))))
+          sum)))))
+
+(defn- kde-mean
+  "Compute density-weighted mean: ∫ x·f(x) dx.
+  Assumes density is normalized (integrates to 1)."
+  ^double [grid density]
+  (let [xf (mapv * grid density)]
+    (trapezoidal-integrate grid xf)))
+
+(defn- kde-variance
+  "Compute density-weighted variance: ∫ (x-μ)²·f(x) dx.
+  Requires mean to be pre-computed."
+  ^double [grid density ^double mean]
+  (let [sq-dev (mapv (fn [^double x ^double f]
+                       (let [d (- x mean)]
+                         (* d d f)))
+                     grid density)]
+    (trapezoidal-integrate grid sq-dev)))
+
+(defn- kde-stats-for-metric
+  "Compute standard statistics from a KDE density estimate for a single metric.
+  Returns the same structure as sample-based stats."
+  [kde-data]
+  (let [{:keys [grid density n]} kde-data
+        mean (kde-mean grid density)
+        variance (kde-variance grid density mean)
+        min-val (double (first grid))
+        max-val (double (last grid))
+        three-sigma (* 3.0 (Math/sqrt variance))]
+    {:mean mean
+     :variance variance
+     :min-val min-val
+     :max-val max-val
+     :mean-plus-3sigma (+ mean three-sigma)
+     :mean-minus-3sigma (- mean three-sigma)
+     :n n}))
+
+(defmethod methods/stats :criterium/kde
+  [kde-map _outliers metric-configs _options]
+  (let [kdes (:kdes kde-map)
+        stats (reduce
+               (fn [result metric-config]
+                 (let [p (:path metric-config)
+                       kde-data (get kdes p)]
+                   (if kde-data
+                     (assoc-in result p (kde-stats-for-metric kde-data))
+                     result)))
+               {}
+               metric-configs)]
+    {:type :criterium/stats
+     :stats stats
+     :transform (:transform kde-map)}))
+
 (defmethod methods/event-stats :criterium/metrics-samples
   [metrics-samples metrics-defs _options]
   (let [metric->values (util/metric->values metrics-samples)

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -120,6 +120,7 @@
              [:stats {:samples-id :log-samples :id :log-stats}]
              :histogram
              :kde
+             :kde-stats
              :event-stats
              :allocation-summary
              [:allocation-hotspots {:limit 10}]
@@ -127,6 +128,7 @@
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
           [:stats {:stats-id :log-stats}]
+          [:stats {:stats-id :kde-stats}]
           :quantiles
           :event-stats
           :outlier-counts
@@ -156,6 +158,7 @@
              [:stats {:samples-id :log-samples :id :log-stats}]
              :histogram
              :kde
+             :kde-stats
              :modes
              :event-stats
              :allocation-summary
@@ -164,6 +167,7 @@
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
           [:stats {:stats-id :log-stats}]
+          [:stats {:stats-id :kde-stats}]
           :quantiles
           :event-stats
           :outlier-counts

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -867,8 +867,8 @@
             metric-configs [{:path [:elapsed-time]}]
             result (criterium.analyse.methods/stats kde-data nil metric-configs {})
             stats (get-in result [:stats :elapsed-time])
-            mean (:mean stats)
-            variance (:variance stats)
+            ^double mean (:mean stats)
+            ^double variance (:variance stats)
             expected-3sigma (* 3.0 (Math/sqrt variance))]
         (is (approx= (+ mean expected-3sigma) (:mean-plus-3sigma stats))
             "mean-plus-3sigma should be mean + 3*stddev")
@@ -876,7 +876,7 @@
             "mean-minus-3sigma should be mean - 3*stddev")))
 
     (testing "preserves transform from kde-map"
-      (let [custom-transform {:sample-> #(* % 2.0) :->sample #(/ % 2.0)}
+      (let [custom-transform {:sample-> #(* ^double % 2.0) :->sample #(/ ^double % 2.0)}
             kde-data {:type :criterium/kde
                       :kdes {[:elapsed-time]
                              {:grid [1.0 2.0 3.0]

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
+   [criterium.analyse.methods]
    [criterium.benchmark :as benchmark]
    [criterium.collect-plan :as collect-plan]
    [criterium.collector.metrics :as metrics]
@@ -783,3 +784,145 @@
               elapsed-hist (get-in hist-data [:histograms [:elapsed-time]])]
           (is (<= (long (:optimal-bins elapsed-hist)) 10)
               "optimal-bins should respect max-bins limit"))))))
+
+;;; Tests for KDE-based stats computation
+;; Validates that defmethod methods/stats :criterium/kde produces correct
+;; statistics derived from density integration.
+
+(deftest kde-stats-test
+  (testing "methods/stats :criterium/kde"
+    (testing "returns stats with correct structure"
+      (let [;; Create a simple KDE data structure
+            kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid [1.0 2.0 3.0 4.0 5.0]
+                              :density [0.1 0.2 0.4 0.2 0.1]
+                              :bandwidth 0.5
+                              :n 100}}
+                      :transform {:sample-> identity :->sample identity}}
+            metric-configs [{:path [:elapsed-time]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})]
+        (is (= :criterium/stats (:type result))
+            "result type should be :criterium/stats")
+        (is (map? (:stats result))
+            "result should contain :stats map")
+        (is (contains? (:stats result) :elapsed-time)
+            "stats should contain elapsed-time metric")
+        (let [s (get-in result [:stats :elapsed-time])]
+          (is (number? (:mean s)) "should have :mean")
+          (is (number? (:variance s)) "should have :variance")
+          (is (number? (:min-val s)) "should have :min-val")
+          (is (number? (:max-val s)) "should have :max-val")
+          (is (number? (:mean-plus-3sigma s)) "should have :mean-plus-3sigma")
+          (is (number? (:mean-minus-3sigma s)) "should have :mean-minus-3sigma")
+          (is (= 100 (:n s)) "should have :n from KDE metadata"))))
+
+    (testing "computes correct mean for symmetric density"
+      ;; Symmetric density centered at 3.0 should have mean ≈ 3.0
+      ;; Using a uniform density simplifies verification
+      (let [grid [1.0 2.0 3.0 4.0 5.0]
+            ;; Uniform density: f(x) = 0.25 for x in [1,5]
+            ;; ∫f(x)dx from 1 to 5 = 0.25 * 4 = 1.0 (normalized)
+            ;; Mean = ∫x*f(x)dx = 0.25 * ∫x dx from 1 to 5
+            ;;      = 0.25 * [x²/2] from 1 to 5 = 0.25 * (12.5 - 0.5) = 3.0
+            density [0.25 0.25 0.25 0.25 0.25]
+            kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid grid
+                              :density density
+                              :bandwidth 0.5
+                              :n 50}}
+                      :transform {:sample-> identity :->sample identity}}
+            metric-configs [{:path [:elapsed-time]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})
+            mean (get-in result [:stats :elapsed-time :mean])]
+        (is (approx= 3.0 mean 0.01)
+            (str "mean of uniform density should be at center, got: " mean))))
+
+    (testing "computes correct min/max from grid bounds"
+      (let [grid [10.0 20.0 30.0 40.0 50.0]
+            kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid grid
+                              :density [0.2 0.2 0.2 0.2 0.2]
+                              :bandwidth 1.0
+                              :n 25}}
+                      :transform {:sample-> identity :->sample identity}}
+            metric-configs [{:path [:elapsed-time]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})
+            stats (get-in result [:stats :elapsed-time])]
+        (is (= 10.0 (:min-val stats))
+            "min-val should be first grid point")
+        (is (= 50.0 (:max-val stats))
+            "max-val should be last grid point")))
+
+    (testing "mean-plus/minus-3sigma derived from variance"
+      (let [kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid [0.0 1.0 2.0 3.0 4.0]
+                              :density [0.1 0.2 0.4 0.2 0.1]
+                              :bandwidth 0.3
+                              :n 30}}
+                      :transform {:sample-> identity :->sample identity}}
+            metric-configs [{:path [:elapsed-time]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})
+            stats (get-in result [:stats :elapsed-time])
+            mean (:mean stats)
+            variance (:variance stats)
+            expected-3sigma (* 3.0 (Math/sqrt variance))]
+        (is (approx= (+ mean expected-3sigma) (:mean-plus-3sigma stats))
+            "mean-plus-3sigma should be mean + 3*stddev")
+        (is (approx= (- mean expected-3sigma) (:mean-minus-3sigma stats))
+            "mean-minus-3sigma should be mean - 3*stddev")))
+
+    (testing "preserves transform from kde-map"
+      (let [custom-transform {:sample-> #(* % 2.0) :->sample #(/ % 2.0)}
+            kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid [1.0 2.0 3.0]
+                              :density [0.25 0.5 0.25]
+                              :bandwidth 0.2
+                              :n 10}}
+                      :transform custom-transform}
+            metric-configs [{:path [:elapsed-time]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})]
+        (is (= custom-transform (:transform result))
+            "transform should be preserved from kde-map")))
+
+    (testing "handles multiple metrics"
+      (let [kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid [1.0 2.0 3.0]
+                              :density [0.25 0.5 0.25]
+                              :bandwidth 0.3
+                              :n 100}
+                             [:memory :used]
+                             {:grid [100.0 200.0 300.0]
+                              :density [0.25 0.5 0.25]
+                              :bandwidth 10.0
+                              :n 100}}
+                      :transform {:sample-> identity :->sample identity}}
+            metric-configs [{:path [:elapsed-time]}
+                            {:path [:memory :used]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})]
+        (is (contains? (:stats result) :elapsed-time)
+            "should have elapsed-time stats")
+        (is (contains? (get-in result [:stats :memory]) :used)
+            "should have memory/used stats")))
+
+    (testing "skips metrics not in kde-map"
+      (let [kde-data {:type :criterium/kde
+                      :kdes {[:elapsed-time]
+                             {:grid [1.0 2.0 3.0]
+                              :density [0.25 0.5 0.25]
+                              :bandwidth 0.3
+                              :n 100}}
+                      :transform {:sample-> identity :->sample identity}}
+            ;; Request stats for a metric that doesn't exist in kdes
+            metric-configs [{:path [:elapsed-time]}
+                            {:path [:nonexistent :metric]}]
+            result (criterium.analyse.methods/stats kde-data nil metric-configs {})]
+        (is (contains? (:stats result) :elapsed-time)
+            "should have elapsed-time stats")
+        (is (not (contains? (:stats result) :nonexistent))
+            "should not have nonexistent metric")))))

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -926,3 +926,61 @@
             "should have elapsed-time stats")
         (is (not (contains? (:stats result) :nonexistent))
             "should not have nonexistent metric")))))
+
+;;; Tests for kde-stats analysis function
+;; Validates the full analysis pipeline from samples through KDE to stats.
+
+(deftest kde-stats-analysis-test
+  ;; Tests the analyse/kde-stats function which provides a high-level
+  ;; interface for computing stats from KDE density estimates.
+  (testing "kde-stats"
+    (testing "computes stats from KDE data"
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
+            samples (metrics-samples {[:elapsed-time] raw-data} 1)
+            data-map {:samples samples}
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            with-kde ((analyse/kde {:n-bootstrap 10 :n-points 64}) with-log)
+            result ((analyse/kde-stats) with-kde)]
+        (is (contains? result :kde-stats) "result should have :kde-stats key")
+        (let [stats-data (:kde-stats result)]
+          (is (= :criterium/stats (:type stats-data)))
+          (is (= :kde (:source-id stats-data)))
+          (let [s (-> stats-data util/stats :elapsed-time)]
+            (is (number? (:mean s)) "should have :mean")
+            (is (number? (:variance s)) "should have :variance")
+            (is (number? (:min-val s)) "should have :min-val")
+            (is (number? (:max-val s)) "should have :max-val")))))
+
+    (testing "returns data-map unchanged when KDE unavailable"
+      (let [data-map {:other-data 123}
+            result ((analyse/kde-stats) data-map)]
+        (is (= data-map result))
+        (is (not (contains? result :kde-stats)))))
+
+    (testing "uses custom kde-id"
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
+            samples (metrics-samples {[:elapsed-time] raw-data} 1)
+            data-map {:samples samples}
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            with-kde ((analyse/kde {:id :my-kde
+                                    :n-bootstrap 10
+                                    :n-points 32})
+                      with-log)
+            result ((analyse/kde-stats {:kde-id :my-kde}) with-kde)]
+        (is (contains? result :kde-stats))))
+
+    (testing "uses custom output id"
+      (let [raw-data (mapv #(+ 100.0 (* 0.5 (double %))) (range 50))
+            samples (metrics-samples {[:elapsed-time] raw-data} 1)
+            data-map {:samples samples}
+            with-log ((analyse/transform-log {:id :log-samples
+                                              :samples-id :samples})
+                      data-map)
+            with-kde ((analyse/kde {:n-bootstrap 10 :n-points 32}) with-log)
+            result ((analyse/kde-stats {:id :my-kde-stats}) with-kde)]
+        (is (contains? result :my-kde-stats))
+        (is (not (contains? result :kde-stats)))))))

--- a/bases/criterium/validation/criterium/validation/kde_stats_validation_test.clj
+++ b/bases/criterium/validation/criterium/validation/kde_stats_validation_test.clj
@@ -1,8 +1,11 @@
 (ns criterium.validation.kde-stats-validation-test
-  "Validation tests for KDE-based statistics against R reference implementations.
+  "Validation tests for KDE-based statistics integration against R reference.
 
-  Tests compare criterium's density-weighted mean and variance integration
-  against equivalent computations in R using density() output.
+  Tests validate criterium's trapezoidal integration for computing
+  density-weighted mean and variance by comparing against R's integration
+  on the SAME grid/density data from criterium's KDE.
+
+  This validates the integration math, not the KDE computation itself.
 
   Tests skip gracefully when R/Rserve is unavailable."
   (:require
@@ -30,17 +33,15 @@
 
 ;;; Helper functions
 
-(defn- r-kde-stats
-  "Compute KDE-based statistics in R using density() and trapezoidal integration.
+(defn- r-kde-stats-from-grid
+  "Compute KDE-based statistics in R using trapezoidal integration on provided grid.
+  Takes the grid and density arrays from criterium's KDE output.
   Returns [mean variance] computed from density-weighted integration."
-  [data n-points]
-  (let [bw (kde/silverman-bandwidth data)
-        ;; R code to compute density-weighted mean and variance
+  [grid density]
+  (let [;; R code to compute density-weighted mean and variance on provided grid
         r-code (str
-                "x <- " (vec->r-str data) ";"
-                "d <- density(x, bw=" bw ", n=" n-points ", kernel='gaussian');"
-                "grid <- d$x;"
-                "dens <- d$y;"
+                "grid <- " (vec->r-str (vec grid)) ";"
+                "dens <- " (vec->r-str (vec density)) ";"
                 "dx <- diff(grid)[1];"
                 ;; Trapezoidal integration for mean: ∫ x·f(x) dx
                 "xf <- grid * dens;"
@@ -53,18 +54,20 @@
 
 (defn- clj-kde-stats
   "Compute KDE-based statistics using criterium's implementation.
-  Returns {:mean mean :variance variance}."
+  Returns map with :mean, :variance, :grid, :density."
   [data n-points]
   (let [kde-result (kde/kde data {:n-points n-points})
         stats (#'metrics-samples/kde-stats-for-metric kde-result)]
     {:mean (:mean stats)
-     :variance (:variance stats)}))
+     :variance (:variance stats)
+     :grid (:grid kde-result)
+     :density (:density kde-result)}))
 
 ;;; Tests
 
 (deftest kde-stats-mean-validation-test
-  ;; Validates criterium's KDE-based mean against R's density-weighted integration.
-  ;; Both compute ∫ x·f(x) dx using trapezoidal rule over the KDE density.
+  ;; Validates criterium's KDE-based mean integration against R's trapezoidal integration.
+  ;; Both compute ∫ x·f(x) dx using trapezoidal rule over the SAME grid/density.
   (testing "kde-stats mean"
     (if-not (r/r-available?)
       (do
@@ -72,33 +75,33 @@
         (is true "Skipped - R unavailable"))
       (let [n-points 512]
         (testing "with simple doubles"
-          (let [[r-mean _] (r-kde-stats simple-doubles n-points)
-                clj-stats (clj-kde-stats simple-doubles n-points)]
-            ;; Use 1% tolerance due to differences in KDE grid construction
-            (is (approx= r-mean (:mean clj-stats) 0.01)
+          (let [clj-stats (clj-kde-stats simple-doubles n-points)
+                [r-mean _] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            ;; Use 0.1% tolerance - should match closely since same grid/density
+            (is (approx= r-mean (:mean clj-stats) 0.001)
                 (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))
 
         (testing "with normal-like distribution"
-          (let [[r-mean _] (r-kde-stats normal-like n-points)
-                clj-stats (clj-kde-stats normal-like n-points)]
-            (is (approx= r-mean (:mean clj-stats) 0.01)
+          (let [clj-stats (clj-kde-stats normal-like n-points)
+                [r-mean _] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            (is (approx= r-mean (:mean clj-stats) 0.001)
                 (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))
 
         (testing "with bimodal data"
-          (let [[r-mean _] (r-kde-stats bimodal-data n-points)
-                clj-stats (clj-kde-stats bimodal-data n-points)]
-            (is (approx= r-mean (:mean clj-stats) 0.01)
+          (let [clj-stats (clj-kde-stats bimodal-data n-points)
+                [r-mean _] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            (is (approx= r-mean (:mean clj-stats) 0.001)
                 (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))
 
         (testing "with skewed data"
-          (let [[r-mean _] (r-kde-stats skewed-data n-points)
-                clj-stats (clj-kde-stats skewed-data n-points)]
-            (is (approx= r-mean (:mean clj-stats) 0.01)
+          (let [clj-stats (clj-kde-stats skewed-data n-points)
+                [r-mean _] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            (is (approx= r-mean (:mean clj-stats) 0.001)
                 (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))))))
 
 (deftest kde-stats-variance-validation-test
-  ;; Validates criterium's KDE-based variance against R's density-weighted integration.
-  ;; Both compute ∫ (x-μ)²·f(x) dx using trapezoidal rule over the KDE density.
+  ;; Validates criterium's KDE-based variance integration against R's trapezoidal integration.
+  ;; Both compute ∫ (x-μ)²·f(x) dx using trapezoidal rule over the SAME grid/density.
   (testing "kde-stats variance"
     (if-not (r/r-available?)
       (do
@@ -106,55 +109,51 @@
         (is true "Skipped - R unavailable"))
       (let [n-points 512]
         (testing "with simple doubles"
-          (let [[_ r-var] (r-kde-stats simple-doubles n-points)
-                clj-stats (clj-kde-stats simple-doubles n-points)]
-            ;; Use 5% tolerance for variance due to higher sensitivity to grid differences
-            (is (approx= r-var (:variance clj-stats) 0.05)
+          (let [clj-stats (clj-kde-stats simple-doubles n-points)
+                [_ r-var] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            ;; Use 0.1% tolerance - should match closely since same grid/density
+            (is (approx= r-var (:variance clj-stats) 0.001)
                 (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))
 
         (testing "with normal-like distribution"
-          (let [[_ r-var] (r-kde-stats normal-like n-points)
-                clj-stats (clj-kde-stats normal-like n-points)]
-            (is (approx= r-var (:variance clj-stats) 0.05)
+          (let [clj-stats (clj-kde-stats normal-like n-points)
+                [_ r-var] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            (is (approx= r-var (:variance clj-stats) 0.001)
                 (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))
 
         (testing "with bimodal data"
-          (let [[_ r-var] (r-kde-stats bimodal-data n-points)
-                clj-stats (clj-kde-stats bimodal-data n-points)]
-            (is (approx= r-var (:variance clj-stats) 0.05)
+          (let [clj-stats (clj-kde-stats bimodal-data n-points)
+                [_ r-var] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            (is (approx= r-var (:variance clj-stats) 0.001)
                 (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))
 
         (testing "with skewed data"
-          (let [[_ r-var] (r-kde-stats skewed-data n-points)
-                clj-stats (clj-kde-stats skewed-data n-points)]
-            (is (approx= r-var (:variance clj-stats) 0.05)
+          (let [clj-stats (clj-kde-stats skewed-data n-points)
+                [_ r-var] (r-kde-stats-from-grid (:grid clj-stats) (:density clj-stats))]
+            (is (approx= r-var (:variance clj-stats) 0.001)
                 (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))))))
 
-(deftest kde-stats-consistency-validation-test
+(deftest kde-stats-consistency-test
   ;; Validates that KDE-based statistics are consistent with sample statistics
   ;; for distributions where they should converge (unimodal, symmetric).
-  ;; The KDE mean should be close to sample mean for normal-like data.
+  ;; This test doesn't require R.
   (testing "kde-stats consistency with sample statistics"
-    (if-not (r/r-available?)
-      (do
-        (println "Skipping kde-stats consistency validation: R/Rserve not available")
-        (is true "Skipped - R unavailable"))
-      (let [n-points 512]
-        (testing "mean converges to sample mean for normal-like data"
-          (let [sample-mean (/ (reduce + normal-like) (count normal-like))
-                clj-stats (clj-kde-stats normal-like n-points)]
-            ;; KDE mean should be within 5% of sample mean for unimodal data
-            (is (approx= sample-mean (:mean clj-stats) 0.05)
-                (format "KDE mean should approximate sample mean: sample=%.10f, kde=%.10f"
-                        sample-mean (:mean clj-stats)))))
+    (let [n-points 512]
+      (testing "mean converges to sample mean for normal-like data"
+        (let [sample-mean (/ (double (reduce + normal-like)) (count normal-like))
+              clj-stats (clj-kde-stats normal-like n-points)]
+          ;; KDE mean should be within 5% of sample mean for unimodal data
+          (is (approx= sample-mean (:mean clj-stats) 0.05)
+              (format "KDE mean should approximate sample mean: sample=%.10f, kde=%.10f"
+                      sample-mean (:mean clj-stats)))))
 
-        (testing "variance converges to sample variance for normal-like data"
-          (let [sample-mean (/ (reduce + normal-like) (count normal-like))
-                sample-var (/ (reduce + (map #(Math/pow (- % sample-mean) 2) normal-like))
-                              (dec (count normal-like)))
-                clj-stats (clj-kde-stats normal-like n-points)]
-            ;; KDE variance should be within 20% of sample variance
-            ;; (KDE smoothing tends to increase apparent variance slightly)
-            (is (approx= sample-var (:variance clj-stats) 0.20)
-                (format "KDE variance should approximate sample variance: sample=%.10f, kde=%.10f"
-                        sample-var (:variance clj-stats)))))))))
+      (testing "variance converges to sample variance for normal-like data"
+        (let [sample-mean (/ (double (reduce + normal-like)) (count normal-like))
+              sample-var (/ (double (reduce + (map #(Math/pow (- ^double % sample-mean) 2) normal-like)))
+                            (dec (count normal-like)))
+              clj-stats (clj-kde-stats normal-like n-points)]
+          ;; KDE variance should be within 20% of sample variance
+          ;; (KDE smoothing tends to increase apparent variance slightly)
+          (is (approx= sample-var (:variance clj-stats) 0.20)
+              (format "KDE variance should approximate sample variance: sample=%.10f, kde=%.10f"
+                      sample-var (:variance clj-stats))))))))

--- a/bases/criterium/validation/criterium/validation/kde_stats_validation_test.clj
+++ b/bases/criterium/validation/criterium/validation/kde_stats_validation_test.clj
@@ -1,0 +1,160 @@
+(ns criterium.validation.kde-stats-validation-test
+  "Validation tests for KDE-based statistics against R reference implementations.
+
+  Tests compare criterium's density-weighted mean and variance integration
+  against equivalent computations in R using density() output.
+
+  Tests skip gracefully when R/Rserve is unavailable."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.analyse.metrics-samples :as metrics-samples]
+   [criterium.test.assert :refer [approx=]]
+   [criterium.util.kde :as kde]
+   [criterium.validation.r :as r :refer [vec->r-str]]))
+
+;;; Test data sets
+;; Reuse datasets from kde_validation_test for consistency
+
+(def simple-doubles [1.5 2.3 3.7 4.1 5.9 6.2 7.8 8.4 9.1 10.0])
+
+(def normal-like
+  [2.1 3.5 4.2 4.8 5.1 5.3 5.5 5.7 5.9 6.0
+   6.1 6.2 6.3 6.5 6.7 6.9 7.1 7.5 8.2 9.8])
+
+(def bimodal-data
+  [1.0 1.2 1.5 1.8 2.0 2.1 2.3
+   8.0 8.2 8.5 8.7 9.0 9.1 9.3])
+
+(def skewed-data
+  [1.0 1.1 1.2 1.3 1.5 1.8 2.0 2.5 3.0 4.0 6.0 10.0])
+
+;;; Helper functions
+
+(defn- r-kde-stats
+  "Compute KDE-based statistics in R using density() and trapezoidal integration.
+  Returns [mean variance] computed from density-weighted integration."
+  [data n-points]
+  (let [bw (kde/silverman-bandwidth data)
+        ;; R code to compute density-weighted mean and variance
+        r-code (str
+                "x <- " (vec->r-str data) ";"
+                "d <- density(x, bw=" bw ", n=" n-points ", kernel='gaussian');"
+                "grid <- d$x;"
+                "dens <- d$y;"
+                "dx <- diff(grid)[1];"
+                ;; Trapezoidal integration for mean: ∫ x·f(x) dx
+                "xf <- grid * dens;"
+                "mean_kde <- sum((xf[-1] + xf[-length(xf)]) * dx / 2);"
+                ;; Trapezoidal integration for variance: ∫ (x-μ)²·f(x) dx
+                "sq_dev <- (grid - mean_kde)^2 * dens;"
+                "var_kde <- sum((sq_dev[-1] + sq_dev[-length(sq_dev)]) * dx / 2);"
+                "c(mean_kde, var_kde)")]
+    (r/r-eval r-code)))
+
+(defn- clj-kde-stats
+  "Compute KDE-based statistics using criterium's implementation.
+  Returns {:mean mean :variance variance}."
+  [data n-points]
+  (let [kde-result (kde/kde data {:n-points n-points})
+        stats (#'metrics-samples/kde-stats-for-metric kde-result)]
+    {:mean (:mean stats)
+     :variance (:variance stats)}))
+
+;;; Tests
+
+(deftest kde-stats-mean-validation-test
+  ;; Validates criterium's KDE-based mean against R's density-weighted integration.
+  ;; Both compute ∫ x·f(x) dx using trapezoidal rule over the KDE density.
+  (testing "kde-stats mean"
+    (if-not (r/r-available?)
+      (do
+        (println "Skipping kde-stats mean validation: R/Rserve not available")
+        (is true "Skipped - R unavailable"))
+      (let [n-points 512]
+        (testing "with simple doubles"
+          (let [[r-mean _] (r-kde-stats simple-doubles n-points)
+                clj-stats (clj-kde-stats simple-doubles n-points)]
+            ;; Use 1% tolerance due to differences in KDE grid construction
+            (is (approx= r-mean (:mean clj-stats) 0.01)
+                (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))
+
+        (testing "with normal-like distribution"
+          (let [[r-mean _] (r-kde-stats normal-like n-points)
+                clj-stats (clj-kde-stats normal-like n-points)]
+            (is (approx= r-mean (:mean clj-stats) 0.01)
+                (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))
+
+        (testing "with bimodal data"
+          (let [[r-mean _] (r-kde-stats bimodal-data n-points)
+                clj-stats (clj-kde-stats bimodal-data n-points)]
+            (is (approx= r-mean (:mean clj-stats) 0.01)
+                (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))
+
+        (testing "with skewed data"
+          (let [[r-mean _] (r-kde-stats skewed-data n-points)
+                clj-stats (clj-kde-stats skewed-data n-points)]
+            (is (approx= r-mean (:mean clj-stats) 0.01)
+                (format "mean mismatch: R=%.10f, clj=%.10f" r-mean (:mean clj-stats)))))))))
+
+(deftest kde-stats-variance-validation-test
+  ;; Validates criterium's KDE-based variance against R's density-weighted integration.
+  ;; Both compute ∫ (x-μ)²·f(x) dx using trapezoidal rule over the KDE density.
+  (testing "kde-stats variance"
+    (if-not (r/r-available?)
+      (do
+        (println "Skipping kde-stats variance validation: R/Rserve not available")
+        (is true "Skipped - R unavailable"))
+      (let [n-points 512]
+        (testing "with simple doubles"
+          (let [[_ r-var] (r-kde-stats simple-doubles n-points)
+                clj-stats (clj-kde-stats simple-doubles n-points)]
+            ;; Use 5% tolerance for variance due to higher sensitivity to grid differences
+            (is (approx= r-var (:variance clj-stats) 0.05)
+                (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))
+
+        (testing "with normal-like distribution"
+          (let [[_ r-var] (r-kde-stats normal-like n-points)
+                clj-stats (clj-kde-stats normal-like n-points)]
+            (is (approx= r-var (:variance clj-stats) 0.05)
+                (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))
+
+        (testing "with bimodal data"
+          (let [[_ r-var] (r-kde-stats bimodal-data n-points)
+                clj-stats (clj-kde-stats bimodal-data n-points)]
+            (is (approx= r-var (:variance clj-stats) 0.05)
+                (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))
+
+        (testing "with skewed data"
+          (let [[_ r-var] (r-kde-stats skewed-data n-points)
+                clj-stats (clj-kde-stats skewed-data n-points)]
+            (is (approx= r-var (:variance clj-stats) 0.05)
+                (format "variance mismatch: R=%.10f, clj=%.10f" r-var (:variance clj-stats)))))))))
+
+(deftest kde-stats-consistency-validation-test
+  ;; Validates that KDE-based statistics are consistent with sample statistics
+  ;; for distributions where they should converge (unimodal, symmetric).
+  ;; The KDE mean should be close to sample mean for normal-like data.
+  (testing "kde-stats consistency with sample statistics"
+    (if-not (r/r-available?)
+      (do
+        (println "Skipping kde-stats consistency validation: R/Rserve not available")
+        (is true "Skipped - R unavailable"))
+      (let [n-points 512]
+        (testing "mean converges to sample mean for normal-like data"
+          (let [sample-mean (/ (reduce + normal-like) (count normal-like))
+                clj-stats (clj-kde-stats normal-like n-points)]
+            ;; KDE mean should be within 5% of sample mean for unimodal data
+            (is (approx= sample-mean (:mean clj-stats) 0.05)
+                (format "KDE mean should approximate sample mean: sample=%.10f, kde=%.10f"
+                        sample-mean (:mean clj-stats)))))
+
+        (testing "variance converges to sample variance for normal-like data"
+          (let [sample-mean (/ (reduce + normal-like) (count normal-like))
+                sample-var (/ (reduce + (map #(Math/pow (- % sample-mean) 2) normal-like))
+                              (dec (count normal-like)))
+                clj-stats (clj-kde-stats normal-like n-points)]
+            ;; KDE variance should be within 20% of sample variance
+            ;; (KDE smoothing tends to increase apparent variance slightly)
+            (is (approx= sample-var (:variance clj-stats) 0.20)
+                (format "KDE variance should approximate sample variance: sample=%.10f, kde=%.10f"
+                        sample-var (:variance clj-stats)))))))))


### PR DESCRIPTION
## Summary

Add a `methods/stats` multimethod implementation for `:criterium/kde` type that derives standard statistics from the KDE density estimate.

The KDE-based stats produce the same output structure as the existing sample-based stats:
- `:mean` - density-weighted mean: ∫ x·f(x) dx
- `:variance` - density-weighted variance: ∫ (x-μ)²·f(x) dx
- `:min-val` / `:max-val` - effective support from grid
- `:mean-plus-3sigma` / `:mean-minus-3sigma` - derived from variance
- `:n` - sample count (from KDE metadata)

### Changes

- `defmethod methods/stats :criterium/kde` with trapezoidal integration for mean/variance
- `kde-stats` analysis function in `criterium.analyse` with `:id` and `:kde-id` options
- Updated `kde-histogram` and `kde-modes` bench plans to include `:kde-stats` analysis
- R validation tests comparing density-weighted integration against equivalent R computations

## Commits

- feat(analyse): add methods/stats multimethod for :criterium/kde type
- feat(analyse): add kde-stats analysis function
- feat(bench-plans): add kde-stats to kde-histogram and kde-modes plans
- fix(test): add type hints to fix boxed math warnings in kde-stats tests
- feat(validation): add R validation test for KDE-based statistics

## Test plan

- [x] Unit tests for density integration accuracy
- [x] Integration test for full analysis pipeline
- [x] Schema validation
- [x] R validation tests (skip gracefully when R/Rserve unavailable)