### PR TITLE
fix: measured/expr incorrect when expression function position is a local

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -103,6 +103,23 @@ To start an NREPL server:
 clojure -M:nrepl:dev:test:with-agent-mac:blackhole
 ```
 
+The command `clj-nrepl-eval` is installed on your path for evaluating Clojure code via nREPL.
+
+**Discover nREPL servers:**
+
+`clj-nrepl-eval --discover-ports`
+
+**Evaluate code:**
+
+`clj-nrepl-eval -p <port> "<clojure-code>"`
+
+With timeout (milliseconds)
+
+`clj-nrepl-eval -p <port> --timeout 5000 "<clojure-code>"`
+
+The REPL session persists between evaluations - namespaces and state are maintained.
+Always use `:reload` when requiring namespaces to pick up changes.
+
 ## Architecture
 
 ### Polylith Structure

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -309,8 +309,8 @@
         options)
       (fn ~'measured-expr []
         ~(list 'quote
-               `(let [~@(reduce into [] arg-vals)]
-                  (time ~expr)))))))
+               `(~'let [~@(reduce into [] arg-vals)]
+                       (~'time ~expr)))))))
 
 (defn measured-callable
   ([f]

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -77,27 +77,37 @@
       (:metamap x))))
 
 (defn ^:no-doc factor-form
-  "Factor form, extracting constant expressions."
-  [form]
+  "Factor form, extracting constant expressions.
+  env is the macro's &env, used to identify local bindings."
+  [form env]
   (let [subj (first form)
         tform (fn [x]
                 (if (and (s-expression? x) (= subj (first x)))
-                  (reduce
-                   (fn [res arg]
-                     (if (fn-call-expr? arg)
-                       (-> res
-                           (update :arg-syms conj arg)
-                           (update :arg-vals merge (:arg-vals arg)))
-                       (let [arg-sym (gen-arg-sym)]
+                  (let [op (first x)
+                        ;; Check if operator is a local binding
+                        op-is-local? (and (symbol? op)
+                                          (contains? env op))
+                        ;; If local, generate arg-sym for operator
+                        [op-sym op-arg-vals] (if op-is-local?
+                                               (let [sym (gen-arg-sym)]
+                                                 [sym {sym op}])
+                                               [op {}])]
+                    (reduce
+                     (fn [res arg]
+                       (if (fn-call-expr? arg)
                          (-> res
-                             (update :arg-syms conj arg-sym)
-                             (update :arg-vals assoc arg-sym arg)))))
-                   (->FnCallExpr
-                    (first x)
-                    []
-                    {}
-                    (meta x))
-                   (rest x))
+                             (update :arg-syms conj arg)
+                             (update :arg-vals merge (:arg-vals arg)))
+                         (let [arg-sym (gen-arg-sym)]
+                           (-> res
+                               (update :arg-syms conj arg-sym)
+                               (update :arg-vals assoc arg-sym arg)))))
+                     (->FnCallExpr
+                      op-sym
+                      []
+                      op-arg-vals
+                      (meta x))
+                     (rest x)))
                   x))
         res (util/postwalk
              tform
@@ -110,9 +120,12 @@
     {:expr arg-sym
      :arg-vals {arg-sym expr}}))
 
-(defn ^:no-doc factor-expr [expr]
+(defn ^:no-doc factor-expr
+  "Factor an expression, extracting constant expressions and local bindings.
+  env is the macro's &env, used to identify local bindings."
+  [expr env]
   (if (s-expression? expr)
-    (factor-form expr)
+    (factor-form expr env)
     (factor-const expr)))
 
 (defn ^:no-doc cast-fn
@@ -280,7 +293,7 @@
   Local bindings are captured at the call-site and passed through the
   measurement pipeline alongside hoisted constants."
   [expr options env]
-  (let [{:keys [expr arg-vals] :as _f} (factor-expr expr)
+  (let [{:keys [expr arg-vals] :as _f} (factor-expr expr env)
         arg-syms (keys arg-vals)
         local-arg-syms (identify-local-args arg-vals env)
         arg-metas (capture-arg-types

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -309,8 +309,8 @@
         options)
       (fn ~'measured-expr []
         ~(list 'quote
-               `(do (let [~@arg-vals]
-                      (time ~expr))))))))
+               `(let [~@(reduce into [] arg-vals)]
+                  (time ~expr)))))))
 
 (defn measured-callable
   ([f]

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -228,6 +228,32 @@
       (testing "returns empty set when no arg-vals are locals"
         (is (= #{} (impl/identify-local-args {'a '(+ 1 2)} env)))))))
 
+;;; form-print tests
+;; Tests verifying form-print handles both regular symbols and gensyms.
+
+(deftest form-print-test
+  ;; Tests that form-print correctly handles gensym operators.
+  ;; When factor-form captures a local operator, the :op becomes a gensym.
+  ;; form-print must use the gensym as-is in the output expression.
+  (testing "form-print"
+    (testing "returns symbol unchanged"
+      (is (= 'x (impl/form-print 'x)))
+      (is (= 'my-fn (impl/form-print 'my-fn))))
+    (testing "handles FnCallExpr with regular operator"
+      (let [fn-call (impl/->FnCallExpr '+ ['a 'b] {'a 1 'b 2} nil)]
+        (is (= '(+ a b) (impl/form-print fn-call)))))
+    (testing "handles FnCallExpr with gensym operator"
+      ;; This is the key test - when operator is a local, it becomes a gensym
+      (let [op-sym (gensym "arg")
+            fn-call (impl/->FnCallExpr op-sym ['x 'y] {op-sym 'f 'x 1 'y 2} nil)
+            result (impl/form-print fn-call)]
+        ;; The gensym should appear in operator position
+        (is (= op-sym (first result)))
+        (is (= '(x y) (rest result)))))
+    (testing "preserves metadata on expression"
+      (let [fn-call (impl/->FnCallExpr '+ ['a] {'a 1} {:custom :meta})]
+        (is (= {:custom :meta} (meta (impl/form-print fn-call))))))))
+
 ;;; factor-form tests for local operator handling
 ;; Tests verifying that local functions in operator position are factored out.
 

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -635,6 +635,115 @@
         (is (= 2 (count args)))
         (is (= :default (second (invoke m))))))))
 
+;;; Java Method Call Tests with Local Arguments
+;; Tests verifying that Java interop calls correctly handle local bindings
+;; as receiver and/or arguments. Method names (.methodName) are operators,
+;; not locals, while the receiver and arguments should be factored.
+
+(deftest java-interop-local-receiver-test
+  ;; Verifies: (let [s "hello"] (measured/expr (.toUpperCase s)))
+  ;; - .toUpperCase stays as operator
+  ;; - s is factored into arg-vals
+  (testing "Java method call with local receiver"
+    (testing "receiver is captured in args"
+      (let [s "hello"
+            m (measured/expr (.toUpperCase s))
+            args (measured/args m)]
+        (is (= 1 (count args)))
+        (is (= "hello" (first args)))))
+    (testing "produces correct result"
+      (let [s "hello"
+            m (measured/expr (.toUpperCase s))]
+        (is (= "HELLO" (second (invoke m))))))
+    (testing "receiver is used dynamically"
+      (let [s "abc"
+            m (measured/expr (.toUpperCase s))
+            original-result (second (invoke m))
+            new-args-fn (fn [] ["xyz"])
+            m-with-different (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-different))]
+        (is (= "ABC" original-result))
+        (is (= "XYZ" new-result))
+        (is (not= original-result new-result)
+            "results must differ to prove receiver is dynamic")))))
+
+(deftest java-interop-local-argument-test
+  ;; Verifies: (let [idx 1] (measured/expr (.nth [0 1 2] idx)))
+  ;; - .nth stays as operator
+  ;; - Both [0 1 2] and idx are factored
+  (testing "Java method call with local argument"
+    (testing "receiver and argument are captured in args"
+      (let [idx 1
+            m (measured/expr (.nth [0 1 2] idx))
+            args (measured/args m)]
+        (is (= 2 (count args)))
+        (is (some #(= [0 1 2] %) args) "vector should be in args")
+        (is (some #(= 1 %) args) "idx should be in args")))
+    (testing "produces correct result"
+      (let [idx 1
+            m (measured/expr (.nth [0 1 2] idx))]
+        (is (= 1 (second (invoke m))))))
+    (testing "argument is used dynamically"
+      (let [idx 1
+            m (measured/expr (.nth [0 1 2] idx))
+            original-result (second (invoke m))
+            ;; Replace the index with 2
+            args (measured/args m)
+            new-args-fn (fn [] (mapv #(if (= 1 %) 2 %) args))
+            m-with-different (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-different))]
+        (is (= 1 original-result) "original: vec.nth(1) = 1")
+        (is (= 2 new-result) "substituted: vec.nth(2) = 2")
+        (is (not= original-result new-result)
+            "results must differ to prove argument is dynamic")))))
+
+(deftest java-interop-both-local-test
+  ;; Verifies: (let [s "hello" n 3] (measured/expr (.substring s n)))
+  ;; - .substring stays as operator
+  ;; - Both s and n are factored
+  (testing "Java method call with both local receiver and argument"
+    (testing "both receiver and argument are captured in args"
+      (let [s "hello"
+            n 3
+            m (measured/expr (.substring s n))
+            args (measured/args m)]
+        (is (= 2 (count args)))
+        (is (some #(= "hello" %) args) "string should be in args")
+        (is (some #(= 3 %) args) "n should be in args")))
+    (testing "produces correct result"
+      (let [s "hello"
+            n 3
+            m (measured/expr (.substring s n))]
+        (is (= "lo" (second (invoke m))))))
+    (testing "receiver is used dynamically"
+      (let [s "hello"
+            n 3
+            m (measured/expr (.substring s n))
+            original-result (second (invoke m))
+            ;; Replace the string
+            args (measured/args m)
+            new-args-fn (fn [] (mapv #(if (= "hello" %) "world!" %) args))
+            m-with-different (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-different))]
+        (is (= "lo" original-result))
+        (is (= "ld!" new-result) "world!.substring(3) = ld!")
+        (is (not= original-result new-result)
+            "results must differ to prove receiver is dynamic")))
+    (testing "argument is used dynamically"
+      (let [s "hello"
+            n 3
+            m (measured/expr (.substring s n))
+            original-result (second (invoke m))
+            ;; Replace the index
+            args (measured/args m)
+            new-args-fn (fn [] (mapv #(if (= 3 %) 1 %) args))
+            m-with-different (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-different))]
+        (is (= "lo" original-result))
+        (is (= "ello" new-result) "hello.substring(1) = ello")
+        (is (not= original-result new-result)
+            "results must differ to prove argument is dynamic")))))
+
 (deftest edge-case-tc3-qualified-symbol-test
   ;; TC3: Qualified symbols (ns/fn) remain global var references.
   ;; Qualified symbols like clojure.core/+ or criterium.measured-test/public-add

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -408,3 +408,151 @@
                 res (second (invoke m))]
             (swap! results conj res)))
         (is (= [2 3 4] @results))))))
+
+;;; Local Operator Acceptance Tests
+;; Tests verifying that local functions in operator position are dynamically
+;; dispatched, not constant-folded. Each test proves dynamic dispatch by
+;; substituting a different function via with-args-fn and verifying the
+;; result changes.
+
+(deftest local-operator-ac1-test
+  ;; AC1: Local function in operator position - verify function is used dynamically.
+  ;; Proves the function is not constant-folded by substituting a different
+  ;; function via with-args-fn and verifying the result changes.
+  (testing "local function in operator position"
+    (testing "captures function in args"
+      (let [f +
+            m (measured/expr (f 1 2))
+            args (measured/args m)]
+        ;; The local function f should be captured in args
+        (is (some #(= + %) args) "function + should be in args")))
+    (testing "uses function dynamically (not constant-folded)"
+      (let [f +
+            m (measured/expr (f 10 5))
+            ;; Original invocation with +
+            original-result (second (invoke m))
+            ;; Create new measured with different function (-)
+            args (measured/args m)
+            ;; Find position of function in args and replace it
+            new-args-fn (fn []
+                          (mapv #(if (= + %) - %) args))
+            m-with-minus (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-minus))]
+        (is (= 15 original-result) "original should use +: 10 + 5 = 15")
+        (is (= 5 new-result) "substituted should use -: 10 - 5 = 5")
+        (is (not= original-result new-result)
+            "results must differ to prove dynamic dispatch")))))
+
+(deftest local-operator-ac2-test
+  ;; AC2: Local function with local arguments.
+  ;; The function and all arguments should be in args.
+  (testing "local function with local arguments"
+    (testing "captures function and arguments in args"
+      (let [f +
+            x 1
+            y 2
+            m (measured/expr (f x y))
+            args (measured/args m)]
+        ;; All three locals should be captured
+        (is (= 3 (count args)))
+        (is (some #(= + %) args) "function + should be in args")
+        (is (some #(= 1 %) args) "x=1 should be in args")
+        (is (some #(= 2 %) args) "y=2 should be in args")))
+    (testing "produces correct result"
+      (let [f +
+            x 10
+            y 20
+            m (measured/expr (f x y))]
+        (is (= 30 (second (invoke m))))))))
+
+(deftest local-operator-ac3-test
+  ;; AC3: Higher-order function pattern using partial.
+  ;; The partially applied function should be passed through args-fn.
+  (testing "higher-order function pattern"
+    (testing "partial function is captured in args"
+      (let [f (partial + 10)
+            m (measured/expr (f 5))
+            args (measured/args m)]
+        ;; The partial function and 5 should be in args
+        (is (= 2 (count args)))
+        (is (some #(= 5 %) args) "argument 5 should be in args")
+        (is (some fn? args) "partial function should be in args")))
+    (testing "uses partial function dynamically"
+      (let [f (partial + 10)
+            m (measured/expr (f 5))
+            original-result (second (invoke m))
+            ;; Substitute with a different partial function
+            args (measured/args m)
+            new-args-fn (fn []
+                          (mapv #(if (fn? %) (partial * 10) %) args))
+            m-with-mult (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-mult))]
+        (is (= 15 original-result) "original: (+ 10 5) = 15")
+        (is (= 50 new-result) "substituted: (* 10 5) = 50")))))
+
+(defn- double-it ^long [^long x] (* x 2))
+(defn- triple-it ^long [^long x] (* x 3))
+
+(deftest local-operator-ac4-test
+  ;; AC4: Nested local function calls.
+  ;; Current implementation: only factors expressions with SAME operator recursively.
+  ;; For different nested operators, only the outer is captured; inner is evaluated.
+  (testing "nested local function calls"
+    (testing "same operator used recursively - both captured"
+      ;; (f (f x)) - same operator, so both calls are factored
+      (let [f inc
+            m (measured/expr (f (f 5)))
+            args (measured/args m)]
+        ;; f is captured twice, plus the value 5
+        (is (= 3 (count args)))
+        (is (= 2 (count (filter #(= inc %) args))) "inc should appear twice")
+        (is (some #(= 5 %) args) "5 should be in args")))
+    (testing "same operator - produces correct result"
+      (let [f inc
+            m (measured/expr (f (f 5)))]
+        ;; inc(inc(5)) = 7
+        (is (= 7 (second (invoke m))))))
+    (testing "same operator - function is used dynamically"
+      (let [f double-it
+            m (measured/expr (f (f 2)))
+            original-result (second (invoke m))
+            ;; Replace double-it with triple-it
+            args (measured/args m)
+            new-args-fn (fn []
+                          (mapv #(if (= double-it %) triple-it %) args))
+            m-with-triple (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-triple))]
+        ;; Original: double-it(double-it(2)) = double-it(4) = 8
+        (is (= 8 original-result))
+        ;; Substituted: triple-it(triple-it(2)) = triple-it(6) = 18
+        (is (= 18 new-result))
+        (is (not= original-result new-result)
+            "results must differ to prove function is dynamic")))
+    (testing "different operators - outer captured, inner evaluated"
+      ;; (f (g x)) - different operators, only f is factored
+      ;; Inner (g x) is evaluated at macro expansion time
+      (let [f double-it
+            g inc
+            m (measured/expr (f (g 5)))
+            args (measured/args m)]
+        ;; Only f (double-it) and the result of (g 5) = 6 are captured
+        (is (= 2 (count args)))
+        (is (some #(= double-it %) args) "outer function should be in args")
+        (is (some #(= 6 %) args) "evaluated inner result (6) should be in args")))
+    (testing "different operators - outer function is dynamic"
+      (let [f double-it
+            g inc
+            m (measured/expr (f (g 5)))
+            original-result (second (invoke m))
+            ;; Replace outer function
+            args (measured/args m)
+            new-args-fn (fn []
+                          (mapv #(if (= double-it %) triple-it %) args))
+            m-with-triple (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-triple))]
+        ;; Original: double-it((inc 5)) = double-it(6) = 12
+        (is (= 12 original-result))
+        ;; Substituted: triple-it(6) = 18
+        (is (= 18 new-result))
+        (is (not= original-result new-result)
+            "results must differ to prove outer function is dynamic")))))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -91,11 +91,14 @@
       (let [fncall-m (measured/expr (identity ::value))]
         (is (= [::value] (measured/args fncall-m)))
         (is (= ::value (second (invoke fncall-m))))))
-    (testing "with recursive function call lifts innermost value"
+    (testing "with recursive function call lifts innermost value and local fn"
       (let [call-count         (volatile! 0)
             f                  (fn [v] (vswap! call-count inc-long) v)
-            recursive-fncall-m (measured/expr (f (f ::value)))]
-        (is (= [::value] (measured/args recursive-fncall-m)))
+            recursive-fncall-m (measured/expr (f (f ::value)))
+            args               (measured/args recursive-fncall-m)]
+        ;; Local function f is now captured twice (for both calls) plus ::value
+        (is (= 3 (count args)))
+        (is (= #{f ::value} (set args)))
         (is (= ::value (second (invoke recursive-fncall-m))))
         (is (= 2 @call-count))))
     (testing "with const expression lifts the evaluated value"
@@ -224,6 +227,54 @@
         (is (= #{'arg1 'arg3 'arg5} (impl/identify-local-args arg-vals env))))
       (testing "returns empty set when no arg-vals are locals"
         (is (= #{} (impl/identify-local-args {'a '(+ 1 2)} env)))))))
+
+;;; factor-form tests for local operator handling
+;; Tests verifying that local functions in operator position are factored out.
+
+(deftest factor-form-local-operator-test
+  ;; Tests that factor-form handles local operators correctly.
+  ;; When the operator is a local binding, it should be factored into arg-vals.
+  (let [env {'f 'local-binding-f}]
+    (testing "factor-form"
+      (testing "with local operator factors it into arg-vals"
+        (let [{:keys [expr arg-vals]} (impl/factor-form '(f x) env)]
+          ;; expr should have a gensym in operator position
+          (is (seq? expr))
+          (is (symbol? (first expr)))
+          (is (not= 'f (first expr)) "operator should be replaced with gensym")
+          ;; arg-vals should contain mapping for both operator and argument
+          (is (= 2 (count arg-vals)))
+          (is (contains? (set (vals arg-vals)) 'f) "f should be in arg-vals")
+          (is (contains? (set (vals arg-vals)) 'x) "x should be in arg-vals")))
+      (testing "with global operator keeps it unchanged"
+        (let [{:keys [expr arg-vals]} (impl/factor-form '(+ x y) nil)]
+          ;; expr should have + in operator position (global var)
+          (is (= '+ (first expr)))
+          ;; arg-vals should only contain x and y, not +
+          (is (= 2 (count arg-vals)))
+          (is (= #{'x 'y} (set (vals arg-vals))))))
+      (testing "with recursive local operator factors at each level"
+        ;; factor-form only factors expressions with the SAME operator as top-level
+        ;; So (f (f x)) factors both f's, but (f (g x)) only factors outer f
+        (let [{:keys [expr arg-vals]} (impl/factor-form '(f (f x)) {'f 'lb-f})]
+          ;; f should be factored twice, x once
+          (is (= 3 (count arg-vals)))
+          ;; f appears twice in vals (for both calls)
+          (is (= 2 (count (filter #(= 'f %) (vals arg-vals)))))
+          (is (contains? (set (vals arg-vals)) 'x))))
+      (testing "with different nested operator only factors outer"
+        ;; (f (g x)) - only f is factored since inner has different op
+        (let [{:keys [expr arg-vals]} (impl/factor-form '(f (g x)) {'f 'lb-f 'g 'lb-g})]
+          ;; Only f is factored, (g x) is stored as a single value
+          (is (= 2 (count arg-vals)))
+          (is (contains? (set (vals arg-vals)) 'f))
+          (is (contains? (set (vals arg-vals)) '(g x)))))
+      (testing "with method call operator keeps it unchanged"
+        (let [{:keys [expr arg-vals]} (impl/factor-form '(.toString x) nil)]
+          ;; .toString is a method, not a local - should stay unchanged
+          (is (= '.toString (first expr)))
+          (is (= 1 (count arg-vals)))
+          (is (= #{'x} (set (vals arg-vals)))))))))
 
 ;;; Local capture integration tests
 ;; Tests verifying that locals are correctly captured and passed through

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -282,7 +282,7 @@
       (testing "with recursive local operator factors at each level"
         ;; factor-form only factors expressions with the SAME operator as top-level
         ;; So (f (f x)) factors both f's, but (f (g x)) only factors outer f
-        (let [{:keys [expr arg-vals]} (impl/factor-form '(f (f x)) {'f 'lb-f})]
+        (let [{:keys [_expr arg-vals]} (impl/factor-form '(f (f x)) {'f 'lb-f})]
           ;; f should be factored twice, x once
           (is (= 3 (count arg-vals)))
           ;; f appears twice in vals (for both calls)
@@ -290,7 +290,7 @@
           (is (contains? (set (vals arg-vals)) 'x))))
       (testing "with different nested operator only factors outer"
         ;; (f (g x)) - only f is factored since inner has different op
-        (let [{:keys [expr arg-vals]} (impl/factor-form '(f (g x)) {'f 'lb-f 'g 'lb-g})]
+        (let [{:keys [_expr arg-vals]} (impl/factor-form '(f (g x)) {'f 'lb-f 'g 'lb-g})]
           ;; Only f is factored, (g x) is stored as a single value
           (is (= 2 (count arg-vals)))
           (is (contains? (set (vals arg-vals)) 'f))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -492,6 +492,7 @@
 
 (defn- double-it ^long [^long x] (* x 2))
 (defn- triple-it ^long [^long x] (* x 3))
+(defn public-add "A public function for qualified symbol testing." [a b] (+ a b))
 
 (deftest local-operator-ac4-test
   ;; AC4: Nested local function calls.
@@ -556,3 +557,122 @@
         (is (= 18 new-result))
         (is (not= original-result new-result)
             "results must differ to prove outer function is dynamic")))))
+
+;;; Edge Case Tests for Operator Handling
+;; Tests verifying that interop calls, keywords in function position,
+;; and qualified symbols are handled correctly and not treated as local operators.
+
+(deftest edge-case-tc1-interop-test
+  ;; TC1: Interop calls - receiver is argument, not operator.
+  ;; Method calls like (.methodName obj) should work correctly.
+  ;; The receiver (obj) should be captured in args, not the method name.
+  (testing "interop calls"
+    (testing "string method call works correctly"
+      (let [s "hello"
+            m (measured/expr (.toUpperCase s))
+            args (measured/args m)]
+        ;; The string should be captured as an argument
+        (is (= 1 (count args)))
+        (is (= "hello" (first args)))
+        ;; Result should be the uppercased string
+        (is (= "HELLO" (second (invoke m))))))
+    (testing "string method with argument works"
+      (let [s "hello world"
+            m (measured/expr (.substring s 0 5))
+            args (measured/args m)]
+        ;; String and indices should be captured
+        (is (= 3 (count args)))
+        (is (some #(= "hello world" %) args))
+        (is (= "hello" (second (invoke m))))))
+    (testing "local receiver is dynamically used"
+      ;; Prove the receiver is not constant-folded by substitution
+      (let [s "abc"
+            m (measured/expr (.length s))
+            original-result (second (invoke m))
+            ;; Substitute with different string
+            new-args-fn (fn [] ["longer string"])
+            m-with-longer (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-longer))]
+        (is (= 3 original-result) "original: \"abc\".length() = 3")
+        (is (= 13 new-result) "substituted: \"longer string\".length() = 13")
+        (is (not= original-result new-result)
+            "results must differ to prove receiver is dynamic")))))
+
+(deftest edge-case-tc2-keyword-operator-test
+  ;; TC2: Keywords in function position.
+  ;; Keywords can be used as functions to look up values in maps.
+  ;; The keyword should stay in operator position (not treated as local).
+  (testing "keywords in function position"
+    (testing "keyword lookup with literal keyword"
+      (let [m (measured/expr (:key {:key 42}))]
+        (is (= 42 (second (invoke m))))))
+    (testing "keyword lookup with local map"
+      (let [data {:key 99 :other 1}
+            m (measured/expr (:key data))
+            args (measured/args m)]
+        ;; The map should be captured as an argument
+        (is (= 1 (count args)))
+        (is (= data (first args)))
+        (is (= 99 (second (invoke m))))))
+    (testing "local map is dynamically used"
+      ;; Prove the map is not constant-folded by substitution
+      (let [data {:key 100}
+            m (measured/expr (:key data))
+            original-result (second (invoke m))
+            ;; Substitute with different map
+            new-args-fn (fn [] [{:key 200}])
+            m-with-different (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-different))]
+        (is (= 100 original-result))
+        (is (= 200 new-result))
+        (is (not= original-result new-result)
+            "results must differ to prove map is dynamic")))
+    (testing "keyword with default value"
+      (let [data {:other 1}
+            m (measured/expr (:missing data :default))
+            args (measured/args m)]
+        ;; Map and default should be captured
+        (is (= 2 (count args)))
+        (is (= :default (second (invoke m))))))))
+
+(deftest edge-case-tc3-qualified-symbol-test
+  ;; TC3: Qualified symbols (ns/fn) remain global var references.
+  ;; Qualified symbols like clojure.core/+ or criterium.measured-test/public-add
+  ;; should not be treated as locals - they reference global vars.
+  (testing "qualified symbols as operators"
+    (testing "clojure.core qualified symbol"
+      (let [m (measured/expr (clojure.core/+ 1 2))
+            args (measured/args m)]
+        ;; Only the arguments should be captured, not the qualified function
+        (is (= 2 (count args)))
+        (is (= #{1 2} (set args)))
+        (is (= 3 (second (invoke m))))))
+    (testing "current namespace qualified symbol"
+      (let [m (measured/expr (criterium.measured-test/public-add 10 20))
+            args (measured/args m)]
+        ;; Only the arguments should be captured
+        (is (= 2 (count args)))
+        (is (= #{10 20} (set args)))
+        (is (= 30 (second (invoke m))))))
+    (testing "qualified symbols are not captured in args"
+      ;; Unlike local operators, qualified symbols should NOT appear in args
+      (let [m (measured/expr (clojure.core/+ 5 5))
+            args (measured/args m)]
+        ;; clojure.core/+ should not be in args
+        (is (not (some #(= clojure.core/+ %) args))
+            "qualified function should not be captured in args")
+        (is (= 10 (second (invoke m))))))
+    (testing "arguments to qualified functions are dynamic"
+      ;; The arguments should still be dynamically passed
+      (let [x 3
+            y 4
+            m (measured/expr (clojure.core/+ x y))
+            original-result (second (invoke m))
+            ;; Substitute with different values
+            new-args-fn (fn [] [10 20])
+            m-with-different (measured/with-args-fn m new-args-fn)
+            new-result (second (invoke m-with-different))]
+        (is (= 7 original-result))
+        (is (= 30 new-result))
+        (is (not= original-result new-result)
+            "results must differ to prove arguments are dynamic")))))


### PR DESCRIPTION
## Summary

Fixes the handling of local bindings in function (operator) position within `measured/expr`. Previously, when a local was used as the function (e.g., `(let [f +] (measured/expr (f 1 2)))`), its value was captured at macro expansion time as a constant, allowing the JIT to fold the function call and defeating the purpose of benchmarking.

The fix modifies `factor-form` to treat local operators the same way as local arguments - capturing them through `args-fn` for dynamic dispatch at measurement time.

## Changes

- Modified `factor-form` to accept an `env` parameter and check if operators are local bindings
- Local operators are now factored into `arg-vals` and passed through `args-fn`
- Fixed `:expr-fn` generation to properly evaluate local operators
- Used unqualified symbols in `:expr-fn` quoted form for cleaner output
- Added comprehensive tests for acceptance criteria and edge cases

## Commits

- feat(measured): factor local operators in factor-form
- fix: measured/expr :expr-fn
- test(measured): add form-print tests for gensym operators
- test(measured): add acceptance tests for local function operators
- test(measured): add edge case tests for operator handling
- test(measured): add Java interop tests for local arguments
- fix(measured): use unqualified symbols in :expr-fn quoted form

## Test plan

- [x] AC1-AC4 acceptance tests verify local functions are captured dynamically
- [x] Edge case tests for Java interop (`.method` calls), keywords in function position, and qualified symbols
- [x] Existing tests continue to pass