### PR TITLE
feat(build): add dev target to Makefile for building agent and preparing deps

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,8 +12,8 @@ This is currently version 0.5.x (ALPHA) which represents a significant architect
 
 ### Testing
 ```bash
-# Prepare dependencies with Java sources (required once after checkout or deps.edn changes)
-cd bases/criterium && clojure -T:deps prep
+# Build agent and prepare dependencies (required once after checkout or deps.edn changes)
+make dev
 
 # Run tests with Kaocha
 clojure -M:kaocha:dev:test --reporter dots

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-watch docs eastwood cljfmt cloverage release deploy clean
+.PHONY: dev test test-watch docs eastwood cljfmt cloverage release deploy clean
 
 VERSION ?= 0.4.6-SNAPSHOT
 
@@ -6,6 +6,10 @@ TEST_PROFILES := :test
 
 FULL_PROFILES := :test.check:clj-xchart
 
+
+dev:
+	cd agent-cpp && cmake -B build && cmake --build build
+	cd bases/criterium && clojure -T:deps prep
 
 kondo:
 	clj-kondo --lint src


### PR DESCRIPTION
## Summary

Add a `dev` target to the top-level Makefile that builds the C++ agent and prepares Java dependencies in a single command.

## Changes

- Add `dev` target to Makefile that:
  1. Builds the C++ agent (`cmake -B build && cmake --build build` from agent-cpp/)
  2. Prepares Java dependencies (`clojure -T:deps prep` from bases/criterium/)
- Document `make dev` in CLAUDE.md Development Commands section

## Commits

- `feat(build): add dev target to Makefile` - Core implementation
- `docs: document make dev target in CLAUDE.md` - Documentation update