### PR TITLE
refactor(validation): extract validation tests to mirror source structure

### DIFF
--- a/bases/criterium/validation/criterium/validation/kde_stats_validation_test.clj
+++ b/bases/criterium/validation/criterium/validation/kde_stats_validation_test.clj
@@ -13,7 +13,7 @@
    [criterium.analyse.metrics-samples :as metrics-samples]
    [criterium.test.assert :refer [approx=]]
    [criterium.util.kde :as kde]
-   [criterium.validation.r :as r :refer [vec->r-str]]))
+   [r-validation.r :as r :refer [vec->r-str]]))
 
 ;;; Test data sets
 ;; Reuse datasets from kde_validation_test for consistency

--- a/components/optimisation/validation/optimisation/regression_validation_test.clj
+++ b/components/optimisation/validation/optimisation/regression_validation_test.clj
@@ -1,0 +1,140 @@
+(ns optimisation.regression-validation-test
+  "Validation tests for optimisation.interface/linear-regression against R's lm().
+
+  Tests skip gracefully when R/Rserve is unavailable."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.test.assert :refer [approx=]]
+   [r-validation.r :as r :refer [vec->r-str]]
+   [optimisation.interface :as optimisation]))
+
+(defn near-zero=
+  "Check if both values are essentially zero (within abs-tol of 0).
+  Useful for comparing residual variance in perfect-fit regressions where
+  floating-point artifacts may produce tiny non-zero values."
+  [^double a ^double b ^double abs-tol]
+  (and (< (Math/abs a) abs-tol)
+       (< (Math/abs b) abs-tol)))
+
+;;; Paired data for linear regression tests
+
+(def linear-perfect-xs [1.0 2.0 3.0 4.0 5.0])
+(def linear-perfect-ys [2.0 4.0 6.0 8.0 10.0])  ; y = 2x (perfect fit)
+
+(def linear-offset-xs [1.0 2.0 3.0 4.0 5.0])
+(def linear-offset-ys [3.0 5.0 7.0 9.0 11.0])  ; y = 2x + 1 (perfect fit with intercept)
+
+(def linear-noise-xs [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0])
+(def linear-noise-ys [2.1 3.9 6.2 7.8 10.1 12.0 13.9 16.1 18.0 20.1])  ; y ≈ 2x (with noise)
+
+(def linear-neg-slope-xs [1.0 2.0 3.0 4.0 5.0])
+(def linear-neg-slope-ys [10.0 8.0 6.0 4.0 2.0])  ; y = 12 - 2x (negative slope)
+
+(def linear-small-xs [0.001 0.002 0.003 0.004 0.005])
+(def linear-small-ys [0.0021 0.0039 0.0061 0.0078 0.0102])  ; small values with noise
+
+(deftest linear-regression-validation-test
+  ;; Validates optimisation.interface/linear-regression against R's lm() function.
+  ;; R's lm() computes ordinary least squares regression. linear-regression
+  ;; returns {:coeffs [intercept slope] :variance residual-variance :r-sqr r-squared}.
+  (testing "linear-regression"
+    (if-not (r/r-available?)
+      (do
+        (println "Skipping linear-regression validation: R/Rserve not available")
+        (is true "Skipped - R unavailable"))
+      (do
+        (testing "with perfect fit (y = 2x)"
+          (let [r-result (r/r-eval
+                          (str "m <- lm(" (vec->r-str linear-perfect-ys) " ~ "
+                               (vec->r-str linear-perfect-xs) ");"
+                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
+                               (vec->r-str linear-perfect-ys) ")-2), summary(m)$r.squared)"))
+                [r-intercept r-slope r-var r-rsq] r-result
+                clj-result (optimisation/linear-regression linear-perfect-xs linear-perfect-ys)
+                [clj-intercept clj-slope] (:coeffs clj-result)]
+            ;; For y = 2x, expected intercept is 0. Use near-zero= for floating-point artifacts.
+            (is (near-zero= r-intercept clj-intercept 1e-10)
+                (format "intercept mismatch: R=%.15e, clj=%.15e" r-intercept clj-intercept))
+            (is (approx= r-slope clj-slope 1e-10)
+                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
+            ;; For perfect fit, both variances should be essentially zero.
+            ;; Use near-zero= since floating-point artifacts may produce tiny values.
+            (is (near-zero= r-var (:variance clj-result) 1e-20)
+                (format "variance mismatch: R=%.15e, clj=%.15e" r-var (:variance clj-result)))
+            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
+                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
+
+        (testing "with perfect fit and intercept (y = 2x + 1)"
+          (let [r-result (r/r-eval
+                          (str "m <- lm(" (vec->r-str linear-offset-ys) " ~ "
+                               (vec->r-str linear-offset-xs) ");"
+                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
+                               (vec->r-str linear-offset-ys) ")-2), summary(m)$r.squared)"))
+                [r-intercept r-slope r-var r-rsq] r-result
+                clj-result (optimisation/linear-regression linear-offset-xs linear-offset-ys)
+                [clj-intercept clj-slope] (:coeffs clj-result)]
+            (is (approx= r-intercept clj-intercept 1e-10)
+                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
+            (is (approx= r-slope clj-slope 1e-10)
+                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
+            ;; For perfect fit, both variances should be essentially zero.
+            (is (near-zero= r-var (:variance clj-result) 1e-20)
+                (format "variance mismatch: R=%.15e, clj=%.15e" r-var (:variance clj-result)))
+            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
+                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
+
+        (testing "with noisy data"
+          (let [r-result (r/r-eval
+                          (str "m <- lm(" (vec->r-str linear-noise-ys) " ~ "
+                               (vec->r-str linear-noise-xs) ");"
+                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
+                               (vec->r-str linear-noise-ys) ")-2), summary(m)$r.squared)"))
+                [r-intercept r-slope r-var r-rsq] r-result
+                clj-result (optimisation/linear-regression linear-noise-xs linear-noise-ys)
+                [clj-intercept clj-slope] (:coeffs clj-result)]
+            (is (approx= r-intercept clj-intercept 1e-10)
+                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
+            (is (approx= r-slope clj-slope 1e-10)
+                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
+            (is (approx= r-var (:variance clj-result) 1e-10)
+                (format "variance mismatch: R=%.15f, clj=%.15f" r-var (:variance clj-result)))
+            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
+                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
+
+        (testing "with negative slope"
+          ;; y = 10 - x (perfect fit with negative slope)
+          (let [r-result (r/r-eval
+                          (str "m <- lm(" (vec->r-str linear-neg-slope-ys) " ~ "
+                               (vec->r-str linear-neg-slope-xs) ");"
+                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
+                               (vec->r-str linear-neg-slope-ys) ")-2), summary(m)$r.squared)"))
+                [r-intercept r-slope r-var r-rsq] r-result
+                clj-result (optimisation/linear-regression linear-neg-slope-xs linear-neg-slope-ys)
+                [clj-intercept clj-slope] (:coeffs clj-result)]
+            (is (approx= r-intercept clj-intercept 1e-10)
+                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
+            (is (approx= r-slope clj-slope 1e-10)
+                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
+            ;; Perfect fit, both variances should be essentially zero.
+            (is (near-zero= r-var (:variance clj-result) 1e-20)
+                (format "variance mismatch: R=%.15e, clj=%.15e" r-var (:variance clj-result)))
+            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
+                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
+
+        (testing "with small values"
+          (let [r-result (r/r-eval
+                          (str "m <- lm(" (vec->r-str linear-small-ys) " ~ "
+                               (vec->r-str linear-small-xs) ");"
+                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
+                               (vec->r-str linear-small-ys) ")-2), summary(m)$r.squared)"))
+                [r-intercept r-slope r-var r-rsq] r-result
+                clj-result (optimisation/linear-regression linear-small-xs linear-small-ys)
+                [clj-intercept clj-slope] (:coeffs clj-result)]
+            (is (approx= r-intercept clj-intercept 1e-10)
+                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
+            (is (approx= r-slope clj-slope 1e-10)
+                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
+            (is (approx= r-var (:variance clj-result) 1e-10)
+                (format "variance mismatch: R=%.15f, clj=%.15f" r-var (:variance clj-result)))
+            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
+                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))))))

--- a/components/r-validation/src/r_validation/r.clj
+++ b/components/r-validation/src/r_validation/r.clj
@@ -1,4 +1,4 @@
-(ns criterium.validation.r
+(ns r-validation.r
   "R connection helper for validation tests.
 
   Provides functions to connect to R via Rserve and gracefully skip tests

--- a/components/r-validation/test/r_validation/r_test.clj
+++ b/components/r-validation/test/r_validation/r_test.clj
@@ -1,0 +1,17 @@
+(ns r-validation.r-test
+  "Tests for the R connection helper.
+
+  Verifies the R connection helper handles both available and unavailable cases."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [r-validation.r :as r]))
+
+(deftest r-connection-test
+  ;; Verifies the R connection helper handles both available and unavailable cases.
+  (testing "r-connection"
+    (testing "reports availability status"
+      (let [available? (r/r-available?)]
+        (is (boolean? available?)
+            "r-available? should return a boolean")
+        (when-not available?
+          (println "R/Rserve not available:" (r/unavailable-reason-msg)))))))

--- a/components/stats/validation/stats/bootstrap_validation_test.clj
+++ b/components/stats/validation/stats/bootstrap_validation_test.clj
@@ -56,9 +56,9 @@
   "Create an RNG factory that produces deterministic but different sequences.
   Each call to the returned factory uses a different seed based on a counter,
   ensuring reproducible test results across platforms."
-  [base-seed]
+  [^long base-seed]
   (let [counter (atom 0)]
-    #(random/well-rng-1024a (+ base-seed (swap! counter inc)))))
+    #(random/well-rng-1024a (+ base-seed ^long (swap! counter inc)))))
 
 ;;; Jackknife validation (deterministic - exact match)
 
@@ -137,7 +137,7 @@
         (testing "mean estimate converges to sample mean"
           ;; Both R and Clojure bootstrap means should be close to the original sample mean
           (let [data (vec (sort normal-data))
-                true-mean (stats/mean data)
+                true-mean (double (stats/mean data))
                 boot-size 1000
                 ;; Clojure bootstrap
                 clj-samples (stats/bootstrap-sample
@@ -163,10 +163,10 @@
         (testing "variance estimate is reasonable"
           ;; Bootstrap variance of the mean should approximate SE²
           (let [data (vec (sort normal-data))
-                n (count data)
+                n (double (count data))
                 boot-size 1000
                 ;; Analytical SE² = var(data) / n
-                analytical-var (/ (stats/variance data) n)
+                analytical-var (/ (double (stats/variance data)) n)
                 ;; Clojure bootstrap variance
                 clj-samples (stats/bootstrap-sample
                              data stats/mean boot-size random/well-rng-1024a)
@@ -315,7 +315,7 @@
 
         (testing "point estimate matches sample statistic"
           (let [data (vec (sort normal-data))
-                true-mean (stats/mean data)
+                true-mean (double (stats/mean data))
                 boot-size 500
                 alpha [0.5 0.025 0.975]
                 result (stats/bootstrap-bca

--- a/components/stats/validation/stats/bootstrap_validation_test.clj
+++ b/components/stats/validation/stats/bootstrap_validation_test.clj
@@ -1,5 +1,5 @@
-(ns criterium.validation.bootstrap-validation-test
-  "Validation tests for criterium.util.bootstrap against R's boot package.
+(ns stats.bootstrap-validation-test
+  "Validation tests for stats.interface bootstrap functions against R's boot package.
 
   Bootstrap methods involve random sampling, so exact matching is not possible.
   Instead, we validate:
@@ -11,10 +11,9 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [criterium.test.assert :refer [approx=]]
-   [criterium.util.bootstrap :as bootstrap]
-   [criterium.util.stats :as stats]
-   [criterium.util.well :as well]
-   [criterium.validation.r :as r :refer [vec->r-str]])
+   [r-validation.r :as r :refer [vec->r-str]]
+   [random.interface :as random]
+   [stats.interface :as stats])
   (:import
    [stats.bootstrap BcaEstimate]))
 
@@ -59,12 +58,12 @@
   ensuring reproducible test results across platforms."
   [base-seed]
   (let [counter (atom 0)]
-    #(well/well-rng-1024a (+ base-seed (swap! counter inc)))))
+    #(random/well-rng-1024a (+ base-seed (swap! counter inc)))))
 
 ;;; Jackknife validation (deterministic - exact match)
 
 (deftest jackknife-validation-test
-  ;; Validates criterium.util.bootstrap/jacknife against R's leave-one-out implementation.
+  ;; Validates stats.interface/jacknife against R's leave-one-out implementation.
   ;; Jackknife is deterministic, so results should match exactly.
   (testing "jacknife"
     (if-not (r/r-available?)
@@ -75,7 +74,7 @@
         (testing "computes leave-one-out means"
           ;; Jackknife mean: for each i, compute mean of data without element i
           (let [data (vec (sort simple-data))
-                clj-jack (bootstrap/jacknife data stats/mean)
+                clj-jack (stats/jacknife data stats/mean)
                 ;; R: sapply(1:length(x), function(i) mean(x[-i]))
                 r-jack (r/r-eval
                         (str "x <- " (vec->r-str data) "; "
@@ -90,7 +89,7 @@
 
         (testing "computes leave-one-out variances"
           (let [data (vec (sort simple-data))
-                clj-jack (bootstrap/jacknife data stats/variance)
+                clj-jack (stats/jacknife data stats/variance)
                 r-jack (r/r-eval
                         (str "x <- " (vec->r-str data) "; "
                              "sapply(1:length(x), function(i) var(x[-i]))"))]
@@ -104,7 +103,7 @@
 
         (testing "with normal-like data"
           (let [data (vec (sort normal-data))
-                clj-jack (bootstrap/jacknife data stats/mean)
+                clj-jack (stats/jacknife data stats/mean)
                 r-jack (r/r-eval
                         (str "x <- " (vec->r-str data) "; "
                              "sapply(1:length(x), function(i) mean(x[-i]))"))]
@@ -115,7 +114,7 @@
 
         (testing "with skewed data"
           (let [data (vec (sort skewed-data))
-                clj-jack (bootstrap/jacknife data stats/mean)
+                clj-jack (stats/jacknife data stats/mean)
                 r-jack (r/r-eval
                         (str "x <- " (vec->r-str data) "; "
                              "sapply(1:length(x), function(i) mean(x[-i]))"))]
@@ -141,8 +140,8 @@
                 true-mean (stats/mean data)
                 boot-size 1000
                 ;; Clojure bootstrap
-                clj-samples (bootstrap/bootstrap-sample
-                             data stats/mean boot-size well/well-rng-1024a)
+                clj-samples (stats/bootstrap-sample
+                             data stats/mean boot-size random/well-rng-1024a)
                 clj-boot-mean (stats/mean clj-samples)
                 ;; R bootstrap
                 r-boot-mean (first (r/r-eval
@@ -169,8 +168,8 @@
                 ;; Analytical SE² = var(data) / n
                 analytical-var (/ (stats/variance data) n)
                 ;; Clojure bootstrap variance
-                clj-samples (bootstrap/bootstrap-sample
-                             data stats/mean boot-size well/well-rng-1024a)
+                clj-samples (stats/bootstrap-sample
+                             data stats/mean boot-size random/well-rng-1024a)
                 clj-boot-var (stats/variance clj-samples)
                 ;; R bootstrap variance
                 r-boot-var (first (r/r-eval
@@ -204,8 +203,8 @@
                 boot-size 1000
                 alpha [0.025 0.5 0.975]
                 ;; Clojure BCa
-                clj-bca (bootstrap/bca-nonparametric
-                         data stats/mean boot-size alpha well/well-rng-1024a)
+                clj-bca (stats/bca-nonparametric
+                         data stats/mean boot-size alpha random/well-rng-1024a)
                 [clj-ci _ _ _ _] clj-bca
                 [clj-lower _clj-median clj-upper] clj-ci
                 ;; R BCa using boot package
@@ -238,7 +237,7 @@
                 boot-size 1000
                 alpha [0.025 0.5 0.975]
                 ;; Clojure BCa with deterministic RNG for reproducibility
-                clj-bca (bootstrap/bca-nonparametric
+                clj-bca (stats/bca-nonparametric
                          data stats/mean boot-size alpha
                          (deterministic-rng-factory 42))
                 [clj-ci clj-z0 _clj-acc _ _] clj-bca
@@ -269,8 +268,8 @@
                 boot-size 1000
                 alpha [0.025 0.5 0.975]
                 ;; Clojure BCa
-                clj-bca (bootstrap/bca-nonparametric
-                         data stats/mean boot-size alpha well/well-rng-1024a)
+                clj-bca (stats/bca-nonparametric
+                         data stats/mean boot-size alpha random/well-rng-1024a)
                 [clj-ci _ _ _ _] clj-bca
                 [clj-lower _ clj-upper] clj-ci
                 ;; R BCa
@@ -303,8 +302,8 @@
           (let [data (vec (sort normal-data))
                 boot-size 500
                 alpha [0.5 0.025 0.975]
-                result (bootstrap/bootstrap-bca
-                        data stats/mean boot-size alpha well/well-rng-1024a)]
+                result (stats/bootstrap-bca
+                        data stats/mean boot-size alpha random/well-rng-1024a)]
             (is (instance? BcaEstimate result)
                 "Result should be BcaEstimate record")
             (is (number? (:point-estimate result))
@@ -319,8 +318,8 @@
                 true-mean (stats/mean data)
                 boot-size 500
                 alpha [0.5 0.025 0.975]
-                result (bootstrap/bootstrap-bca
-                        data stats/mean boot-size alpha well/well-rng-1024a)
+                result (stats/bootstrap-bca
+                        data stats/mean boot-size alpha random/well-rng-1024a)
                 ;; Point estimate (at alpha=0.5) should be close to true mean
                 point-est (:point-estimate result)
                 se (/ (Math/sqrt (stats/variance data)) (Math/sqrt (count data)))

--- a/components/stats/validation/stats/core_validation_test.clj
+++ b/components/stats/validation/stats/core_validation_test.clj
@@ -1,20 +1,12 @@
-(ns criterium.validation.stats-validation-test
-  "Validation tests for criterium.util.stats against R reference implementations.
+(ns stats.core-validation-test
+  "Validation tests for stats.interface core functions against R reference.
 
   Tests skip gracefully when R/Rserve is unavailable."
   (:require
    [clojure.test :refer [deftest is testing]]
    [criterium.test.assert :refer [approx=]]
-   [criterium.util.stats :as stats]
-   [criterium.validation.r :as r :refer [vec->r-str]]))
-
-(defn near-zero=
-  "Check if both values are essentially zero (within abs-tol of 0).
-  Useful for comparing residual variance in perfect-fit regressions where
-  floating-point artifacts may produce tiny non-zero values."
-  [^double a ^double b ^double abs-tol]
-  (and (< (Math/abs a) abs-tol)
-       (< (Math/abs b) abs-tol)))
+   [r-validation.r :as r :refer [vec->r-str]]
+   [stats.interface :as stats]))
 
 ;;; Test data sets
 ;; Fixed datasets for reproducible validation
@@ -33,18 +25,8 @@
 
 ;;; Tests
 
-(deftest r-connection-test
-  ;; Verifies the R connection helper handles both available and unavailable cases.
-  (testing "r-connection"
-    (testing "reports availability status"
-      (let [available? (r/r-available?)]
-        (is (boolean? available?)
-            "r-available? should return a boolean")
-        (when-not available?
-          (println "R/Rserve not available:" (r/unavailable-reason-msg)))))))
-
 (deftest mean-validation-test
-  ;; Validates criterium.util.stats/mean against R's mean() function.
+  ;; Validates stats.interface/mean against R's mean() function.
   ;; The mean function should produce identical results to R for all test cases.
   (testing "mean"
     (if-not (r/r-available?)
@@ -89,9 +71,9 @@
                 (format "mean mismatch: R=%.15f, clj=%.15f" r-mean clj-mean))))))))
 
 (deftest variance-validation-test
-  ;; Validates criterium.util.stats/variance against R's var() function.
+  ;; Validates stats.interface/variance against R's var() function.
   ;; R's var() computes sample variance (n-1 denominator) by default,
-  ;; which matches criterium's (variance data) or (variance data 1).
+  ;; which matches stats/variance with df=1.
   (testing "variance"
     (if-not (r/r-available?)
       (do
@@ -164,8 +146,8 @@
                           r-var clj-var)))))))))
 
 (deftest median-validation-test
-  ;; Validates criterium.util.stats/median against R's median() function.
-  ;; Note: criterium's median expects sorted data and returns [median lower upper].
+  ;; Validates stats.interface/median against R's median() function.
+  ;; Note: stats/median expects sorted data and returns [median lower upper].
   (testing "median"
     (if-not (r/r-available?)
       (do
@@ -229,9 +211,9 @@
                 (format "median mismatch: R=%.15f, clj=%.15f" r-med clj-med))))))))
 
 (deftest quantile-validation-test
-  ;; Validates criterium.util.stats/quantile against R's quantile() function.
-  ;; R's default type=7 uses linear interpolation matching criterium's implementation.
-  ;; Note: criterium's quantile expects sorted data.
+  ;; Validates stats.interface/quantile against R's quantile() function.
+  ;; R's default type=7 uses linear interpolation matching our implementation.
+  ;; Note: stats/quantile expects sorted data.
   (testing "quantile"
     (if-not (r/r-available?)
       (do
@@ -314,126 +296,3 @@
                   (is (approx= r-q clj-q 1e-10)
                       (format "quantile mismatch at q=%.2f: R=%.15f, clj=%.15f"
                               q r-q clj-q)))))))))))
-
-;;; Paired data for linear regression tests
-
-(def linear-perfect-xs [1.0 2.0 3.0 4.0 5.0])
-(def linear-perfect-ys [2.0 4.0 6.0 8.0 10.0])  ; y = 2x (perfect fit)
-
-(def linear-offset-xs [1.0 2.0 3.0 4.0 5.0])
-(def linear-offset-ys [3.0 5.0 7.0 9.0 11.0])  ; y = 2x + 1 (perfect fit with intercept)
-
-(def linear-noise-xs [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0])
-(def linear-noise-ys [2.1 3.9 6.2 7.8 10.1 12.0 13.9 16.1 18.0 20.1])  ; y ≈ 2x (with noise)
-
-(def linear-neg-slope-xs [1.0 2.0 3.0 4.0 5.0])
-(def linear-neg-slope-ys [10.0 8.0 6.0 4.0 2.0])  ; y = 12 - 2x (negative slope)
-
-(def linear-small-xs [0.001 0.002 0.003 0.004 0.005])
-(def linear-small-ys [0.0021 0.0039 0.0061 0.0078 0.0102])  ; small values with noise
-
-(deftest linear-regression-validation-test
-  ;; Validates criterium.util.stats/linear-regression against R's lm() function.
-  ;; R's lm() computes ordinary least squares regression. Criterium's linear-regression
-  ;; returns {:coeffs [intercept slope] :variance residual-variance :r-sqr r-squared}.
-  (testing "linear-regression"
-    (if-not (r/r-available?)
-      (do
-        (println "Skipping linear-regression validation: R/Rserve not available")
-        (is true "Skipped - R unavailable"))
-      (do
-        (testing "with perfect fit (y = 2x)"
-          (let [r-result (r/r-eval
-                          (str "m <- lm(" (vec->r-str linear-perfect-ys) " ~ "
-                               (vec->r-str linear-perfect-xs) ");"
-                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
-                               (vec->r-str linear-perfect-ys) ")-2), summary(m)$r.squared)"))
-                [r-intercept r-slope r-var r-rsq] r-result
-                clj-result (stats/linear-regression linear-perfect-xs linear-perfect-ys)
-                [clj-intercept clj-slope] (:coeffs clj-result)]
-            ;; For y = 2x, expected intercept is 0. Use near-zero= for floating-point artifacts.
-            (is (near-zero= r-intercept clj-intercept 1e-10)
-                (format "intercept mismatch: R=%.15e, clj=%.15e" r-intercept clj-intercept))
-            (is (approx= r-slope clj-slope 1e-10)
-                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
-            ;; For perfect fit, both variances should be essentially zero.
-            ;; Use near-zero= since floating-point artifacts may produce tiny values.
-            (is (near-zero= r-var (:variance clj-result) 1e-20)
-                (format "variance mismatch: R=%.15e, clj=%.15e" r-var (:variance clj-result)))
-            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
-                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
-
-        (testing "with perfect fit and intercept (y = 2x + 1)"
-          (let [r-result (r/r-eval
-                          (str "m <- lm(" (vec->r-str linear-offset-ys) " ~ "
-                               (vec->r-str linear-offset-xs) ");"
-                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
-                               (vec->r-str linear-offset-ys) ")-2), summary(m)$r.squared)"))
-                [r-intercept r-slope r-var r-rsq] r-result
-                clj-result (stats/linear-regression linear-offset-xs linear-offset-ys)
-                [clj-intercept clj-slope] (:coeffs clj-result)]
-            (is (approx= r-intercept clj-intercept 1e-10)
-                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
-            (is (approx= r-slope clj-slope 1e-10)
-                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
-            ;; For perfect fit, both variances should be essentially zero.
-            (is (near-zero= r-var (:variance clj-result) 1e-20)
-                (format "variance mismatch: R=%.15e, clj=%.15e" r-var (:variance clj-result)))
-            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
-                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
-
-        (testing "with noisy data"
-          (let [r-result (r/r-eval
-                          (str "m <- lm(" (vec->r-str linear-noise-ys) " ~ "
-                               (vec->r-str linear-noise-xs) ");"
-                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
-                               (vec->r-str linear-noise-ys) ")-2), summary(m)$r.squared)"))
-                [r-intercept r-slope r-var r-rsq] r-result
-                clj-result (stats/linear-regression linear-noise-xs linear-noise-ys)
-                [clj-intercept clj-slope] (:coeffs clj-result)]
-            (is (approx= r-intercept clj-intercept 1e-10)
-                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
-            (is (approx= r-slope clj-slope 1e-10)
-                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
-            (is (approx= r-var (:variance clj-result) 1e-10)
-                (format "variance mismatch: R=%.15f, clj=%.15f" r-var (:variance clj-result)))
-            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
-                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
-
-        (testing "with negative slope"
-          ;; y = 10 - x (perfect fit with negative slope)
-          (let [r-result (r/r-eval
-                          (str "m <- lm(" (vec->r-str linear-neg-slope-ys) " ~ "
-                               (vec->r-str linear-neg-slope-xs) ");"
-                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
-                               (vec->r-str linear-neg-slope-ys) ")-2), summary(m)$r.squared)"))
-                [r-intercept r-slope r-var r-rsq] r-result
-                clj-result (stats/linear-regression linear-neg-slope-xs linear-neg-slope-ys)
-                [clj-intercept clj-slope] (:coeffs clj-result)]
-            (is (approx= r-intercept clj-intercept 1e-10)
-                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
-            (is (approx= r-slope clj-slope 1e-10)
-                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
-            ;; Perfect fit, both variances should be essentially zero.
-            (is (near-zero= r-var (:variance clj-result) 1e-20)
-                (format "variance mismatch: R=%.15e, clj=%.15e" r-var (:variance clj-result)))
-            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
-                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))
-
-        (testing "with small values"
-          (let [r-result (r/r-eval
-                          (str "m <- lm(" (vec->r-str linear-small-ys) " ~ "
-                               (vec->r-str linear-small-xs) ");"
-                               "c(coef(m)[1], coef(m)[2], sum(residuals(m)^2)/(length("
-                               (vec->r-str linear-small-ys) ")-2), summary(m)$r.squared)"))
-                [r-intercept r-slope r-var r-rsq] r-result
-                clj-result (stats/linear-regression linear-small-xs linear-small-ys)
-                [clj-intercept clj-slope] (:coeffs clj-result)]
-            (is (approx= r-intercept clj-intercept 1e-10)
-                (format "intercept mismatch: R=%.15f, clj=%.15f" r-intercept clj-intercept))
-            (is (approx= r-slope clj-slope 1e-10)
-                (format "slope mismatch: R=%.15f, clj=%.15f" r-slope clj-slope))
-            (is (approx= r-var (:variance clj-result) 1e-10)
-                (format "variance mismatch: R=%.15f, clj=%.15f" r-var (:variance clj-result)))
-            (is (approx= r-rsq (:r-sqr clj-result) 1e-10)
-                (format "r-squared mismatch: R=%.15f, clj=%.15f" r-rsq (:r-sqr clj-result)))))))))

--- a/components/stats/validation/stats/kde_validation_test.clj
+++ b/components/stats/validation/stats/kde_validation_test.clj
@@ -1,12 +1,12 @@
-(ns criterium.validation.kde-validation-test
-  "Validation tests for criterium.util.kde against R reference implementations.
+(ns stats.kde-validation-test
+  "Validation tests for stats.interface KDE functions against R reference.
 
   Tests skip gracefully when R/Rserve is unavailable."
   (:require
    [clojure.test :refer [deftest is testing]]
    [criterium.test.assert :refer [approx=]]
-   [criterium.util.kde :as kde]
-   [criterium.validation.r :as r :refer [vec->r-str]]))
+   [r-validation.r :as r :refer [vec->r-str]]
+   [stats.interface :as stats]))
 
 ;;; Test data sets
 ;; Fixed datasets for reproducible validation
@@ -33,10 +33,10 @@
 ;;; Tests
 
 (deftest silverman-bandwidth-validation-test
-  ;; Validates criterium.util.kde/silverman-bandwidth against R's bw.nrd0().
+  ;; Validates stats.interface/silverman-bandwidth against R's bw.nrd0().
   ;; R's bw.nrd0() implements Silverman's rule of thumb:
   ;; h = 0.9 * min(sd(x), IQR(x)/1.34) * n^(-0.2)
-  ;; This matches criterium's implementation.
+  ;; This matches our implementation.
   (testing "silverman-bandwidth"
     (if-not (r/r-available?)
       (do
@@ -45,48 +45,48 @@
       (do
         (testing "with simple integers"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str simple-integers) ")")))
-                clj-bw (kde/silverman-bandwidth simple-integers)]
+                clj-bw (stats/silverman-bandwidth simple-integers)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))
 
         (testing "with simple doubles"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str simple-doubles) ")")))
-                clj-bw (kde/silverman-bandwidth simple-doubles)]
+                clj-bw (stats/silverman-bandwidth simple-doubles)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))
 
         (testing "with mixed positive and negative values"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str mixed-signs) ")")))
-                clj-bw (kde/silverman-bandwidth mixed-signs)]
+                clj-bw (stats/silverman-bandwidth mixed-signs)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))
 
         (testing "with two values"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str two-values) ")")))
-                clj-bw (kde/silverman-bandwidth two-values)]
+                clj-bw (stats/silverman-bandwidth two-values)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))
 
         (testing "with large range of values"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str large-range) ")")))
-                clj-bw (kde/silverman-bandwidth large-range)]
+                clj-bw (stats/silverman-bandwidth large-range)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))
 
         (testing "with normal-like distribution"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str normal-like) ")")))
-                clj-bw (kde/silverman-bandwidth normal-like)]
+                clj-bw (stats/silverman-bandwidth normal-like)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))
 
         (testing "with bimodal data"
           (let [r-bw (first (r/r-eval (str "bw.nrd0(" (vec->r-str bimodal-data) ")")))
-                clj-bw (kde/silverman-bandwidth bimodal-data)]
+                clj-bw (stats/silverman-bandwidth bimodal-data)]
             (is (approx= r-bw clj-bw 1e-10)
                 (format "bandwidth mismatch: R=%.15f, clj=%.15f" r-bw clj-bw))))))))
 
 (deftest gaussian-kde-validation-test
-  ;; Validates criterium.util.kde/gaussian-kde against R's density().
+  ;; Validates stats.interface/gaussian-kde against R's density().
   ;; R's density() with kernel="gaussian" uses the same Gaussian kernel:
   ;; K(u) = (1/√2π) * exp(-u²/2)
   ;; We compare density values at the same grid points using the same bandwidth.
@@ -96,7 +96,7 @@
         (println "Skipping gaussian-kde validation: R/Rserve not available")
         (is true "Skipped - R unavailable"))
       (letfn [(make-grid ^doubles [data ^long n-points]
-                ;; Match the grid construction from criterium.util.kde/kde
+                ;; Match the grid construction from stats.kde/kde
                 (let [x-min (double (reduce min data))
                       x-max (double (reduce max data))
                       margin (/ (- x-max x-min) 10.0)
@@ -112,9 +112,9 @@
               (compare-kde [data description]
                 (testing description
                   (let [n-points (int 64)
-                        bw (kde/silverman-bandwidth data)
+                        bw (stats/silverman-bandwidth data)
                         ^doubles grid (make-grid data n-points)
-                        ^doubles clj-density (kde/gaussian-kde data bw grid)
+                        ^doubles clj-density (stats/gaussian-kde data bw grid)
                         ;; R's density with matching parameters
                         r-cmd (str "density(" (vec->r-str data)
                                    ", bw=" bw
@@ -141,7 +141,7 @@
         (compare-kde bimodal-data "with bimodal data")))))
 
 (deftest silverman-test-validation-test
-  ;; Validates criterium.util.kde/silverman-test against R's multimode::modetest.
+  ;; Validates stats.interface/silverman-test against R's multimode::modetest.
   ;; Both tests are bootstrap-based with random elements, so exact p-value
   ;; matching is not possible. We validate:
   ;; - Critical bandwidth (deterministic) should match closely
@@ -155,9 +155,9 @@
       (do
         (testing "with unimodal data"
           ;; Normal-like data should have p-value > 0.05 (fail to reject unimodality)
-          (let [clj-result (kde/silverman-test normal-like 1
-                                               {:n-bootstrap 200
-                                                :n-points 512})
+          (let [clj-result (stats/silverman-test normal-like 1
+                                                 {:n-bootstrap 200
+                                                  :n-points 512})
                 ;; R modetest with SI method
                 r-result (r/r-eval
                           (str "library(multimode); set.seed(42); "
@@ -179,9 +179,9 @@
 
         (testing "with bimodal data"
           ;; Bimodal data should have p-value < 0.05 (reject unimodality)
-          (let [clj-result (kde/silverman-test bimodal-data 1
-                                               {:n-bootstrap 200
-                                                :n-points 512})
+          (let [clj-result (stats/silverman-test bimodal-data 1
+                                                 {:n-bootstrap 200
+                                                  :n-points 512})
                 r-result (r/r-eval
                           (str "library(multimode); set.seed(42); "
                                "x <- " (vec->r-str bimodal-data) "; "
@@ -202,7 +202,7 @@
                 (format "R p-value should be valid: p=%.4f" r-pvalue))))))))
 
 (deftest acr-test-validation-test
-  ;; Validates criterium.util.kde/acr-test against R's multimode::modetest.
+  ;; Validates stats.interface/acr-test against R's multimode::modetest.
   ;; The ACR test uses excess mass as the test statistic, which should be
   ;; more stable than mode counting. We validate:
   ;; - Excess mass statistic is in reasonable range
@@ -215,9 +215,9 @@
       (do
         (testing "with unimodal data"
           ;; Normal-like data should have p-value > 0.05 (fail to reject unimodality)
-          (let [clj-result (kde/acr-test normal-like 1
-                                         {:n-bootstrap 200
-                                          :n-points 512})
+          (let [clj-result (stats/acr-test normal-like 1
+                                           {:n-bootstrap 200
+                                            :n-points 512})
                 ;; R modetest with ACR method
                 r-result (r/r-eval
                           (str "library(multimode); set.seed(42); "
@@ -240,9 +240,9 @@
 
         (testing "with bimodal data"
           ;; Bimodal data should have larger excess mass and low p-value
-          (let [clj-result (kde/acr-test bimodal-data 1
-                                         {:n-bootstrap 200
-                                          :n-points 512})
+          (let [clj-result (stats/acr-test bimodal-data 1
+                                           {:n-bootstrap 200
+                                            :n-points 512})
                 r-result (r/r-eval
                           (str "library(multimode); set.seed(42); "
                                "x <- " (vec->r-str bimodal-data) "; "

--- a/components/stats/validation/stats/probability_validation_test.clj
+++ b/components/stats/validation/stats/probability_validation_test.clj
@@ -52,8 +52,8 @@
           ;; qnorm(p) = -qnorm(1-p) for any p
           (doseq [^double p [0.1 0.25 0.05 0.01]]
             (testing (str "p=" p " and p=" (- 1.0 p))
-              (let [q-low (stats/normal-quantile p)
-                    q-high (stats/normal-quantile (- 1.0 p))]
+              (let [^double q-low (stats/normal-quantile p)
+                    ^double q-high (stats/normal-quantile (- 1.0 p))]
                 (is (approx= (- q-low) q-high 1e-10)
                     (format "symmetry mismatch: q(%.2f)=%.15f, q(%.2f)=%.15f"
                             p q-low (- 1.0 p) q-high))))))
@@ -95,8 +95,8 @@
           ;; Use absolute tolerance since relative error is misleading.
           (doseq [x tail-x-values]
             (testing (str "at x=" x)
-              (let [r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    clj-p (stats/normal-cdf x)
+              (let [^double r-p (first (r/r-eval (str "pnorm(" x ")")))
+                    ^double clj-p (stats/normal-cdf x)
                     abs-diff (Math/abs (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6 (well within erf max error)
                 (is (< abs-diff 1e-6)
@@ -116,8 +116,8 @@
           ;; pnorm(x) + pnorm(-x) = 1 for any x
           (doseq [^double x [0.5 1.0 2.0 3.0]]
             (testing (str "x=" x " and x=" (- x))
-              (let [p-pos (stats/normal-cdf x)
-                    p-neg (stats/normal-cdf (- x))]
+              (let [^double p-pos (stats/normal-cdf x)
+                    ^double p-neg (stats/normal-cdf (- x))]
                 (is (approx= 1.0 (+ p-pos p-neg) 1e-10)
                     (format "symmetry mismatch: pnorm(%.1f)=%.15f, pnorm(%.1f)=%.15f, sum=%.15f"
                             x p-pos (- x) p-neg (+ p-pos p-neg)))))))
@@ -127,8 +127,8 @@
           ;; Use absolute tolerance since these are edge cases.
           (doseq [x [-5.0 -6.0 5.0 6.0]]
             (testing (str "at x=" x)
-              (let [r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    clj-p (stats/normal-cdf x)
+              (let [^double r-p (first (r/r-eval (str "pnorm(" x ")")))
+                    ^double clj-p (stats/normal-cdf x)
                     abs-diff (Math/abs (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6
                 (is (< abs-diff 1e-6)

--- a/components/stats/validation/stats/probability_validation_test.clj
+++ b/components/stats/validation/stats/probability_validation_test.clj
@@ -50,10 +50,10 @@
 
         (testing "at symmetric probability pairs"
           ;; qnorm(p) = -qnorm(1-p) for any p
-          (doseq [^double p [0.1 0.25 0.05 0.01]]
+          (doseq [p [0.1 0.25 0.05 0.01]]
             (testing (str "p=" p " and p=" (- 1.0 p))
-              (let [^double q-low (stats/normal-quantile p)
-                    ^double q-high (stats/normal-quantile (- 1.0 p))]
+              (let [q-low (stats/normal-quantile p)
+                    q-high (stats/normal-quantile (- 1.0 p))]
                 (is (approx= (- q-low) q-high 1e-10)
                     (format "symmetry mismatch: q(%.2f)=%.15f, q(%.2f)=%.15f"
                             p q-low (- 1.0 p) q-high))))))
@@ -95,9 +95,9 @@
           ;; Use absolute tolerance since relative error is misleading.
           (doseq [x tail-x-values]
             (testing (str "at x=" x)
-              (let [^double r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    ^double clj-p (stats/normal-cdf x)
-                    abs-diff (Math/abs ^double (- r-p clj-p))]
+              (let [r-p (double (first (r/r-eval (str "pnorm(" x ")"))))
+                    clj-p (stats/normal-cdf x)
+                    abs-diff (Math/abs (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6 (well within erf max error)
                 (is (< abs-diff 1e-6)
                     (format "normal-cdf mismatch at x=%.1f: R=%.15f, clj=%.15f, diff=%.2e"
@@ -114,10 +114,10 @@
 
         (testing "symmetry around the mean"
           ;; pnorm(x) + pnorm(-x) = 1 for any x
-          (doseq [^double x [0.5 1.0 2.0 3.0]]
+          (doseq [x [0.5 1.0 2.0 3.0]]
             (testing (str "x=" x " and x=" (- x))
-              (let [^double p-pos (stats/normal-cdf x)
-                    ^double p-neg (stats/normal-cdf (- x))]
+              (let [p-pos (stats/normal-cdf x)
+                    p-neg (stats/normal-cdf (- x))]
                 (is (approx= 1.0 (+ p-pos p-neg) 1e-10)
                     (format "symmetry mismatch: pnorm(%.1f)=%.15f, pnorm(%.1f)=%.15f, sum=%.15f"
                             x p-pos (- x) p-neg (+ p-pos p-neg)))))))
@@ -127,9 +127,9 @@
           ;; Use absolute tolerance since these are edge cases.
           (doseq [x [-5.0 -6.0 5.0 6.0]]
             (testing (str "at x=" x)
-              (let [^double r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    ^double clj-p (stats/normal-cdf x)
-                    abs-diff (Math/abs ^double (- r-p clj-p))]
+              (let [r-p (double (first (r/r-eval (str "pnorm(" x ")"))))
+                    clj-p (stats/normal-cdf x)
+                    abs-diff (Math/abs (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6
                 (is (< abs-diff 1e-6)
                     (format "normal-cdf mismatch at x=%.1f: R=%.15f, clj=%.15f, diff=%.2e"

--- a/components/stats/validation/stats/probability_validation_test.clj
+++ b/components/stats/validation/stats/probability_validation_test.clj
@@ -97,7 +97,7 @@
             (testing (str "at x=" x)
               (let [^double r-p (first (r/r-eval (str "pnorm(" x ")")))
                     ^double clj-p (stats/normal-cdf x)
-                    abs-diff (Math/abs (- r-p clj-p))]
+                    abs-diff (Math/abs ^double (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6 (well within erf max error)
                 (is (< abs-diff 1e-6)
                     (format "normal-cdf mismatch at x=%.1f: R=%.15f, clj=%.15f, diff=%.2e"
@@ -129,7 +129,7 @@
             (testing (str "at x=" x)
               (let [^double r-p (first (r/r-eval (str "pnorm(" x ")")))
                     ^double clj-p (stats/normal-cdf x)
-                    abs-diff (Math/abs (- r-p clj-p))]
+                    abs-diff (Math/abs ^double (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6
                 (is (< abs-diff 1e-6)
                     (format "normal-cdf mismatch at x=%.1f: R=%.15f, clj=%.15f, diff=%.2e"

--- a/components/stats/validation/stats/probability_validation_test.clj
+++ b/components/stats/validation/stats/probability_validation_test.clj
@@ -1,12 +1,12 @@
-(ns criterium.validation.probability-validation-test
-  "Validation tests for criterium.util.probability against R reference implementations.
+(ns stats.probability-validation-test
+  "Validation tests for stats.interface probability functions against R reference.
 
   Tests skip gracefully when R/Rserve is unavailable."
   (:require
    [clojure.test :refer [deftest is testing]]
    [criterium.test.assert :refer [approx=]]
-   [criterium.util.probability :as prob]
-   [criterium.validation.r :as r]))
+   [r-validation.r :as r]
+   [stats.interface :as stats]))
 
 ;;; Test quantiles
 ;; Standard quantile points to test across the distribution
@@ -21,7 +21,7 @@
 ;;; Tests
 
 (deftest normal-quantile-validation-test
-  ;; Validates criterium.util.probability/normal-quantile against R's qnorm() function.
+  ;; Validates stats.interface/normal-quantile against R's qnorm() function.
   ;; R's qnorm(p) returns the quantile of the standard normal distribution at probability p.
   ;; The Wichura AS241 algorithm is highly accurate (machine precision for central values).
   (testing "normal-quantile"
@@ -34,14 +34,14 @@
           (doseq [p standard-quantiles]
             (testing (str "at p=" p)
               (let [r-q (first (r/r-eval (str "qnorm(" p ")")))
-                    clj-q (prob/normal-quantile p)]
+                    clj-q (stats/normal-quantile p)]
                 (is (approx= r-q clj-q 1e-10)
                     (format "normal-quantile mismatch at p=%.3f: R=%.15f, clj=%.15f"
                             p r-q clj-q))))))
 
         (testing "at the median (p=0.5)"
           (let [r-q (first (r/r-eval "qnorm(0.5)"))
-                clj-q (prob/normal-quantile 0.5)]
+                clj-q (stats/normal-quantile 0.5)]
             ;; Median of standard normal should be exactly 0
             (is (approx= r-q clj-q 1e-14)
                 (format "median mismatch: R=%.15f, clj=%.15f" r-q clj-q))
@@ -52,8 +52,8 @@
           ;; qnorm(p) = -qnorm(1-p) for any p
           (doseq [^double p [0.1 0.25 0.05 0.01]]
             (testing (str "p=" p " and p=" (- 1.0 p))
-              (let [q-low (prob/normal-quantile p)
-                    q-high (prob/normal-quantile (- 1.0 p))]
+              (let [q-low (stats/normal-quantile p)
+                    q-high (stats/normal-quantile (- 1.0 p))]
                 (is (approx= (- q-low) q-high 1e-10)
                     (format "symmetry mismatch: q(%.2f)=%.15f, q(%.2f)=%.15f"
                             p q-low (- 1.0 p) q-high))))))
@@ -62,14 +62,14 @@
           (doseq [p [0.0001 0.00001 0.9999 0.99999]]
             (testing (str "at p=" p)
               (let [r-q (first (r/r-eval (str "qnorm(" p ")")))
-                    clj-q (prob/normal-quantile p)]
+                    clj-q (stats/normal-quantile p)]
                 ;; Slightly larger tolerance for extreme values
                 (is (approx= r-q clj-q 1e-8)
                     (format "normal-quantile mismatch at p=%.5f: R=%.15f, clj=%.15f"
                             p r-q clj-q))))))))))
 
 (deftest normal-cdf-validation-test
-  ;; Validates criterium.util.probability/normal-cdf against R's pnorm() function.
+  ;; Validates stats.interface/normal-cdf against R's pnorm() function.
   ;; R's pnorm(x) returns the cumulative probability P(X < x) for standard normal.
   ;; Note: The implementation uses polynomial erf approximation with max error 1.5e-7.
   (testing "normal-cdf"
@@ -84,7 +84,7 @@
           (doseq [x central-x-values]
             (testing (str "at x=" x)
               (let [r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    clj-p (prob/normal-cdf x)]
+                    clj-p (stats/normal-cdf x)]
                 ;; 1e-5 tolerance accounts for erf approximation propagation
                 (is (approx= r-p clj-p 1e-5)
                     (format "normal-cdf mismatch at x=%.1f: R=%.15f, clj=%.15f"
@@ -96,7 +96,7 @@
           (doseq [x tail-x-values]
             (testing (str "at x=" x)
               (let [r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    clj-p (prob/normal-cdf x)
+                    clj-p (stats/normal-cdf x)
                     abs-diff (Math/abs (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6 (well within erf max error)
                 (is (< abs-diff 1e-6)
@@ -105,7 +105,7 @@
 
         (testing "at x=0 (the median)"
           (let [r-p (first (r/r-eval "pnorm(0)"))
-                clj-p (prob/normal-cdf 0.0)]
+                clj-p (stats/normal-cdf 0.0)]
             ;; CDF at 0 should be exactly 0.5
             (is (approx= r-p clj-p 1e-10)
                 (format "median CDF mismatch: R=%.15f, clj=%.15f" r-p clj-p))
@@ -116,8 +116,8 @@
           ;; pnorm(x) + pnorm(-x) = 1 for any x
           (doseq [^double x [0.5 1.0 2.0 3.0]]
             (testing (str "x=" x " and x=" (- x))
-              (let [p-pos (prob/normal-cdf x)
-                    p-neg (prob/normal-cdf (- x))]
+              (let [p-pos (stats/normal-cdf x)
+                    p-neg (stats/normal-cdf (- x))]
                 (is (approx= 1.0 (+ p-pos p-neg) 1e-10)
                     (format "symmetry mismatch: pnorm(%.1f)=%.15f, pnorm(%.1f)=%.15f, sum=%.15f"
                             x p-pos (- x) p-neg (+ p-pos p-neg)))))))
@@ -128,7 +128,7 @@
           (doseq [x [-5.0 -6.0 5.0 6.0]]
             (testing (str "at x=" x)
               (let [r-p (first (r/r-eval (str "pnorm(" x ")")))
-                    clj-p (prob/normal-cdf x)
+                    clj-p (stats/normal-cdf x)
                     abs-diff (Math/abs (- r-p clj-p))]
                 ;; Absolute error should be < 1e-6
                 (is (< abs-diff 1e-6)
@@ -143,8 +143,8 @@
       (testing "pnorm(qnorm(p)) = p"
         (doseq [p [0.1 0.25 0.5 0.75 0.9 0.95 0.99]]
           (testing (str "at p=" p)
-            (let [x (prob/normal-quantile p)
-                  p-back (prob/normal-cdf x)]
+            (let [x (stats/normal-quantile p)
+                  p-back (stats/normal-cdf x)]
               ;; Due to erf approximation, use 1e-6 tolerance
               (is (approx= p p-back 1e-6)
                   (format "inverse mismatch: p=%.2f, qnorm(p)=%.15f, pnorm(qnorm(p))=%.15f"
@@ -153,9 +153,9 @@
       (testing "qnorm(pnorm(x)) = x"
         (doseq [x [-2.0 -1.0 0.0 1.0 2.0]]
           (testing (str "at x=" x)
-            (let [p (prob/normal-cdf x)
-                  x-back (prob/normal-quantile p)]
-              ;; Due to erf approximation, use 1e-6 tolerance
+            (let [p (stats/normal-cdf x)
+                  x-back (stats/normal-quantile p)]
+              ;; Due to erf approximation, use 1e-5 tolerance
               (is (approx= x x-back 1e-5)
                   (format "inverse mismatch: x=%.1f, pnorm(x)=%.15f, qnorm(pnorm(x))=%.15f"
                           x p x-back)))))))))

--- a/deps.edn
+++ b/deps.edn
@@ -95,6 +95,9 @@
                 :jvm-opts ["-Djdk.attach.allowAttachSelf"]
                 :main-opts ["-m" "criterium.notebook.render"]}
   :validation {:extra-paths ["bases/criterium/validation"
+                             "components/stats/validation"
+                             "components/optimisation/validation"
+                             "components/r-validation/test"
                              "development/src"]
                :extra-deps
                {poly/criterium {:local/root "bases/criterium"}

--- a/validation-tests.edn
+++ b/validation-tests.edn
@@ -3,10 +3,18 @@
            :id                   :validation
            :ns-patterns          ["-validation-test$"]
            :source-paths         ["bases/criterium/src"
+                                  "components/stats/src"
+                                  "components/optimisation/src"
+                                  "components/random/src"
                                   "components/r-validation/src"]
            :kaocha/source-paths  ["bases/criterium/src"
+                                  "components/stats/src"
+                                  "components/optimisation/src"
+                                  "components/random/src"
                                   "components/r-validation/src"]
-           :test-paths           ["bases/criterium/validation"]}]
+           :test-paths           ["components/stats/validation"
+                                  "components/optimisation/validation"
+                                  "components/r-validation/test"]}]
 
   :plugins                            [:kaocha.plugin/randomize
                                        :kaocha.plugin/filter


### PR DESCRIPTION
## Summary

Extract validation tests from `bases/criterium/validation/` to component-level validation directories, aligning test structure with source code organization.

### Changes

- Add validation directories to stats and optimisation components
- Split `stats_validation_test.clj`: basic stats → stats, regression → optimisation  
- Move `probability_validation_test.clj` → stats component
- Move `bootstrap_validation_test.clj` → stats component
- Move `kde_validation_test.clj` → stats component
- Rename R connection namespace from `criterium.validation.r` to `r-validation.r`
- Update `:validation` alias with component validation paths
- Add type hints to eliminate boxed math warnings

### Validation Test Mapping

| Original Location | New Location |
|------------------|--------------|
| bases/criterium/validation/stats | components/stats/validation/ |
| bases/criterium/validation/probability | components/stats/validation/ |
| bases/criterium/validation/bootstrap | components/stats/validation/ |
| bases/criterium/validation/kde | components/stats/validation/ |
| stats (linear-regression) | components/optimisation/validation/ |

## Test Plan

- [ ] Run `clojure -M:validation` to verify all validation tests pass
- [ ] Verify R integration tests work when R/Rserve available
- [ ] Check for any boxed math warnings with `*warn-on-reflection*`