### PR TITLE
feat: add error bars to bar charts and confidence bands to line charts

### DIFF
--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -174,7 +174,11 @@
   domain must have an :implementations key.
 
   Options:
-    :metric-ids - When metric-path is nil, filter to only these metric-ids.
+    :metric-ids        - When metric-path is nil, filter to only these metric-ids.
+    :with-error-bounds - When true and extracting :mean values, also
+                         extracts :mean-plus-3sigma and :mean-minus-3sigma
+                         as error bounds. Values become maps with :value,
+                         :lower, and :upper keys.
 
   Single metric example:
   (compare-by domain :impl [:stats :elapsed-time :mean])
@@ -194,38 +198,72 @@
   ;;               :thread-allocation {:metric [...] :data {...}}}}"
   ([domain axis-key metric-path]
    (compare-by domain axis-key metric-path {}))
-  ([domain axis-key metric-path {:keys [metric-ids]}]
+  ([domain axis-key metric-path {:keys [metric-ids with-error-bounds]}]
    (let [runs (types/runs domain)
          impls (:implementations domain)
          grouped (:data (group-by-axis domain axis-key))
          compare-single
          (fn [metric-path]
-           (let [[stats-id metric-id value-key] metric-path]
+           (let [[stats-id metric-id value-key] metric-path
+                 extract-bounds? (and with-error-bounds
+                                      (= value-key :mean))]
              {:metric metric-path
+              :with-error-bounds (boolean extract-bounds?)
               :data (into {}
                           (map (fn [[axis-val sub-domain]]
                                  [axis-val
                                   (mapv (fn [{:keys [coord data]}]
-                                          {:coord coord
-                                           :value (util/stats-value
-                                                   data stats-id
-                                                   metric-id value-key)})
+                                          (let [value (util/stats-value
+                                                       data stats-id
+                                                       metric-id value-key)]
+                                            {:coord coord
+                                             :value (if extract-bounds?
+                                                      (let [lower (util/stats-value
+                                                                   data stats-id
+                                                                   metric-id
+                                                                   :mean-minus-3sigma)
+                                                            upper (util/stats-value
+                                                                   data stats-id
+                                                                   metric-id
+                                                                   :mean-plus-3sigma)]
+                                                        (when value
+                                                          {:value value
+                                                           :lower lower
+                                                           :upper upper}))
+                                                      value)}))
                                         (types/runs sub-domain))]))
                           grouped)}))]
      (if metric-path
        ;; Single metric mode
-       (let [[stats-id metric-id value-key] metric-path]
+       (let [[stats-id metric-id value-key] metric-path
+             extract-bounds? (and with-error-bounds
+                                  (= value-key :mean))]
          (cond-> {:type :criterium/domain-comparison
                   :axis axis-key
                   :metric metric-path
+                  :with-error-bounds (boolean extract-bounds?)
                   :data (into {}
                               (map (fn [[axis-val sub-domain]]
                                      [axis-val
                                       (mapv (fn [{:keys [coord data]}]
-                                              {:coord coord
-                                               :value (util/stats-value
-                                                       data stats-id
-                                                       metric-id value-key)})
+                                              (let [value (util/stats-value
+                                                           data stats-id
+                                                           metric-id value-key)]
+                                                {:coord coord
+                                                 :value (if extract-bounds?
+                                                          (let [lower (util/stats-value
+                                                                       data stats-id
+                                                                       metric-id
+                                                                       :mean-minus-3sigma)
+                                                                upper (util/stats-value
+                                                                       data stats-id
+                                                                       metric-id
+                                                                       :mean-plus-3sigma)]
+                                                            (when value
+                                                              {:value value
+                                                               :lower lower
+                                                               :upper upper}))
+                                                          value)}))
                                             (types/runs sub-domain))]))
                               grouped)}
            impls (assoc :implementations impls)))
@@ -326,13 +364,15 @@
 
   Parameters:
     opts - Map with keys:
-      :id          - Key for result in output (default: :comparison)
-      :domain-id   - Key for source domain in input (default: :domain)
-      :axis-key    - Dimension key to compare across
-      :metric-path - Vector path to metric, e.g. [:stats :elapsed-time :mean].
-                     When nil, extracts all quantitative metrics.
-      :metric-ids  - When metric-path is nil, filter to these metric-ids.
-                     E.g., [:elapsed-time :thread-allocation].
+      :id               - Key for result in output (default: :comparison)
+      :domain-id        - Key for source domain in input (default: :domain)
+      :axis-key         - Dimension key to compare across
+      :metric-path      - Vector path to metric, e.g. [:stats :elapsed-time :mean].
+                          When nil, extracts all quantitative metrics.
+      :metric-ids       - When metric-path is nil, filter to these metric-ids.
+                          E.g., [:elapsed-time :thread-allocation].
+      :with-error-bounds - When true and extracting :mean values, also
+                           extracts error bounds (±3σ) for each value.
 
   The returned function:
   - Takes a data-map containing a domain under :domain-id
@@ -349,7 +389,7 @@
       ((domain-compare-fn {:id :impl-comparison
                            :axis-key :impl})))"
   ([] (domain-compare-fn {}))
-  ([{:keys [id domain-id axis-key metric-path metric-ids]}]
+  ([{:keys [id domain-id axis-key metric-path metric-ids with-error-bounds]}]
    (fn [data-map]
      (let [domain-id (or domain-id :domain)
            id (or id :comparison)
@@ -358,7 +398,8 @@
                    domain
                    axis-key
                    metric-path
-                   {:metric-ids metric-ids})]
+                   {:metric-ids metric-ids
+                    :with-error-bounds with-error-bounds})]
        (assoc data-map id result)))))
 
 ;;; Regression Analysis

--- a/bases/criterium/src/criterium/domain_plans.clj
+++ b/bases/criterium/src/criterium/domain_plans.clj
@@ -32,13 +32,15 @@
   Groups runs by :impl axis and compares all quantitative metrics.
   Requires map coordinates with an :impl key distinguishing implementations.
 
+  Includes error bounds (±3σ) for each data point when viewed with portal or kindly.
+
   In the output, the baseline implementation (first in :implementations) shows
   absolute values with SI units, while other implementations show factors
   relative to the baseline.
 
   Example:
     (analyse-domain implementation-comparison my-domain)"
-  {:analyse [[:domain-compare-fn {:axis-key :impl}]]
+  {:analyse [[:domain-compare-fn {:axis-key :impl :with-error-bounds true}]]
    :view [[:domain-comparison {}]]})
 
 (def extract-metrics

--- a/bases/criterium/src/criterium/domain_plans.clj
+++ b/bases/criterium/src/criterium/domain_plans.clj
@@ -47,9 +47,11 @@
   Discovers available metrics automatically (elapsed-time, thread-allocation, etc.)
   and extracts mean values for each.
 
+  Includes error bounds (±3σ) for each data point when viewed with portal or kindly.
+
   Example:
     (analyse-domain extract-metrics my-domain)"
-  {:analyse [[:domain-extract-fn {}]]
+  {:analyse [[:domain-extract-fn {:with-error-bounds true}]]
    :view [[:domain-extract {}]]})
 
 (def extract-elapsed-time

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -1133,12 +1133,15 @@
            (fn [row-key]
              (into {coord-header (format-row-key-value row-key single-key-info)}
                    (map (fn [{:keys [type impl]} header]
-                          (let [value (double
-                                       (get-in lookup [impl row-key]))
-                                baseline-value (double
-                                                (get-in
-                                                 lookup
-                                                 [baseline-impl row-key]))]
+                          (let [raw-value (get-numeric-value
+                                           (get-in lookup [impl row-key]))
+                                value (when raw-value (double raw-value))
+                                raw-baseline (get-numeric-value
+                                              (get-in
+                                               lookup
+                                               [baseline-impl row-key]))
+                                baseline-value (when raw-baseline
+                                                 (double raw-baseline))]
                             [header
                              (case type
                                :baseline (format-value-with-unit value metric)
@@ -1215,12 +1218,14 @@
             {coord-header (format-row-key-value row-key single-key-info)}
             (map
              (fn [{:keys [type metric-id metric-path impl]} header]
-               (let [value (double
-                            (get-in lookup [metric-id impl row-key]))
-                     baseline-value (double
-                                     (get-in
-                                      lookup
-                                      [metric-id baseline-impl row-key]))]
+               (let [raw-value (get-numeric-value
+                                (get-in lookup [metric-id impl row-key]))
+                     value (when raw-value (double raw-value))
+                     raw-baseline (get-numeric-value
+                                   (get-in
+                                    lookup
+                                    [metric-id baseline-impl row-key]))
+                     baseline-value (when raw-baseline (double raw-baseline))]
                  [header
                   (case type
                     :baseline (format-value-with-unit value metric-path)

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -843,7 +843,9 @@
     :metric-path - the metric path vector
     :x-title - x-axis title (the axis name)
     :y-title - y-axis title with SI unit
-    :data - vector of {\"x\" number \"y\" number \"impl\" string} maps"
+    :has-error-bounds? - true if error bounds data is present
+    :data - vector of {\"x\" number \"y\" number \"impl\" string} maps
+            (yLower/yUpper only present when error bounds exist)"
   [extract]
   (let [impl-axis-key (:impl-axis extract)
         metrics (:metrics extract)
@@ -857,14 +859,22 @@
      (fn [[metric-id {:keys [metric data]}]]
        (let [;; Get all raw values for error detection and SI scaling
              all-raw-values (keep (fn [[_coord value]] value) data)
-             has-error-bounds (some error-bound-value? all-raw-values)
+             ;; Check if any values have error bounds (with :lower/:upper)
+             has-error-bounds? (boolean
+                                (some (fn [v]
+                                        (and (map? v)
+                                             (contains? v :lower)
+                                             (contains? v :upper)))
+                                      all-raw-values))
+             ;; Also check for error-bound-value? (with :value key) for y-title
+             has-error-bound-format (some error-bound-value? all-raw-values)
              all-values (map get-numeric-value all-raw-values)
              {:keys [^double total-scale unit]}
              (compute-si-scaling metric all-values)
              ;; Build axis titles
              x-title (name axis-key)
              metric-name (name metric-id)
-             base-title (if has-error-bounds
+             base-title (if (or has-error-bounds? has-error-bound-format)
                           (str "mean " metric-name)
                           metric-name)
              y-title (if (seq unit)
@@ -873,21 +883,27 @@
              ;; Build chart data points
              chart-data (mapv
                          (fn [[coord value]]
-                           (let [raw-value (if (and (map? value)
-                                                    (contains? value :value))
-                                             (:value value)
-                                             value)
+                           (let [raw-value (get-numeric-value value)
                                  x-val (get coord axis-key)
                                  impl-val (get coord impl-axis-key)]
-                             {"x" x-val
-                              "y" (when raw-value
-                                    (* (double raw-value) total-scale))
-                              "impl" (name impl-val)}))
+                             (cond-> {"x" x-val
+                                      "y" (when raw-value
+                                            (* (double raw-value) total-scale))
+                                      "impl" (name impl-val)}
+                               (and has-error-bounds?
+                                    (map? value)
+                                    (contains? value :lower))
+                               (assoc "yLower" (* (double (:lower value)) total-scale))
+                               (and has-error-bounds?
+                                    (map? value)
+                                    (contains? value :upper))
+                               (assoc "yUpper" (* (double (:upper value)) total-scale)))))
                          data)]
          {:metric-id metric-id
           :metric-path metric
           :x-title x-title
           :y-title y-title
+          :has-error-bounds? has-error-bounds?
           :data chart-data}))
      (sort-by key metrics))))
 
@@ -911,7 +927,9 @@
     :metric-path - the metric path vector
     :x-title - x-axis title (the non-axis coordinate name)
     :y-title - y-axis title with SI unit
+    :has-error-bounds? - true if error bounds data is present
     :data - vector of {\"x\" number \"y\" number \"impl\" string} maps
+            (yLower/yUpper only present when error bounds exist)
 
   When the comparison axis is the implementation axis (i.e., implementations
   are present), uses the non-axis coordinate key for the x-axis."
@@ -931,13 +949,21 @@
                                    vals
                                    (mapcat (fn [entries]
                                              (keep :value entries))))
-               has-error-bounds (some error-bound-value? all-raw-values)
+               ;; Check if any values have error bounds (with :lower/:upper)
+               has-error-bounds? (boolean
+                                  (some (fn [v]
+                                          (and (map? v)
+                                               (contains? v :lower)
+                                               (contains? v :upper)))
+                                        all-raw-values))
+               ;; Also check for error-bound-value? (with :value key) for y-title
+               has-error-bound-format (some error-bound-value? all-raw-values)
                all-values (map get-numeric-value all-raw-values)
                {:keys [^double total-scale unit]}
                (compute-si-scaling metric all-values)
                ;; Build y-axis title
                metric-name (name metric-id)
-               base-title (if has-error-bounds
+               base-title (if (or has-error-bounds? has-error-bound-format)
                             (str "mean " metric-name)
                             metric-name)
                y-title (if (seq unit)
@@ -947,19 +973,25 @@
                chart-data (vec
                            (for [[impl-val entries] data
                                  {:keys [coord value]} entries
-                                 :let [raw-value (if (and (map? value)
-                                                          (contains? value :value))
-                                                   (:value value)
-                                                   value)
+                                 :let [raw-value (get-numeric-value value)
                                        x-val (get coord x-key)]
                                  :when (some? raw-value)]
-                             {"x" x-val
-                              "y" (* (double raw-value) total-scale)
-                              "impl" (name impl-val)}))]
+                             (cond-> {"x" x-val
+                                      "y" (* (double raw-value) total-scale)
+                                      "impl" (name impl-val)}
+                               (and has-error-bounds?
+                                    (map? value)
+                                    (contains? value :lower))
+                               (assoc "yLower" (* (double (:lower value)) total-scale))
+                               (and has-error-bounds?
+                                    (map? value)
+                                    (contains? value :upper))
+                               (assoc "yUpper" (* (double (:upper value)) total-scale)))))]
            {:metric-id metric-id
             :metric-path metric
             :x-title x-title
             :y-title y-title
+            :has-error-bounds? has-error-bounds?
             :data chart-data}))
        (sort-by key metrics))
       ;; Single-metric mode
@@ -968,12 +1000,20 @@
                                 vals
                                 (mapcat (fn [entries]
                                           (keep :value entries))))
-            has-error-bounds (some error-bound-value? all-raw-values)
+            ;; Check if any values have error bounds (with :lower/:upper)
+            has-error-bounds? (boolean
+                               (some (fn [v]
+                                       (and (map? v)
+                                            (contains? v :lower)
+                                            (contains? v :upper)))
+                                     all-raw-values))
+            ;; Also check for error-bound-value? (with :value key) for y-title
+            has-error-bound-format (some error-bound-value? all-raw-values)
             all-values (map get-numeric-value all-raw-values)
             {:keys [^double total-scale unit]}
             (compute-si-scaling metric all-values)
             ;; Build y-axis title
-            base-title (if has-error-bounds
+            base-title (if (or has-error-bounds? has-error-bound-format)
                          (str "mean " (pr-str metric))
                          (pr-str metric))
             y-title (if (seq unit)
@@ -983,19 +1023,25 @@
             chart-data (vec
                         (for [[impl-val entries] data
                               {:keys [coord value]} entries
-                              :let [raw-value (if (and (map? value)
-                                                       (contains? value :value))
-                                                (:value value)
-                                                value)
+                              :let [raw-value (get-numeric-value value)
                                     x-val (get coord x-key)]
                               :when (some? raw-value)]
-                          {"x" x-val
-                           "y" (* (double raw-value) total-scale)
-                           "impl" (name impl-val)}))]
+                          (cond-> {"x" x-val
+                                   "y" (* (double raw-value) total-scale)
+                                   "impl" (name impl-val)}
+                            (and has-error-bounds?
+                                 (map? value)
+                                 (contains? value :lower))
+                            (assoc "yLower" (* (double (:lower value)) total-scale))
+                            (and has-error-bounds?
+                                 (map? value)
+                                 (contains? value :upper))
+                            (assoc "yUpper" (* (double (:upper value)) total-scale)))))]
         [{:metric-id nil
           :metric-path metric
           :x-title x-title
           :y-title y-title
+          :has-error-bounds? has-error-bounds?
           :data chart-data}]))))
 
 (defn- extract-row-key

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -449,7 +449,7 @@
     (name (:key single-key-info))
     "coordinate"))
 
-(defn- get-numeric-value
+(defn get-numeric-value
   "Extract numeric value from plain value or error-bound format {:value v}."
   [v]
   (if (and (map? v) (contains? v :value))

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -461,6 +461,16 @@
   [v]
   (and (map? v) (contains? v :value)))
 
+(defn values-have-error-bounds?
+  "Returns true if any value in coll has :lower and :upper keys for error bounds."
+  [coll]
+  (boolean
+   (some (fn [v]
+           (and (map? v)
+                (contains? v :lower)
+                (contains? v :upper)))
+         coll)))
+
 (defn detect-uniform-axes
   "Find coordinate axes where all values are identical.
   Returns a set of keys that have uniform values across all coords."
@@ -732,20 +742,16 @@
                           entries))
                        {}
                        data)
+               ;; Get all values from lookup for error bounds check and SI scaling
+               all-raw-values (keep #(get lookup %) implementations)
                ;; Check if any values have error bounds
-               has-error-bounds? (boolean
-                                  (some (fn [impl]
-                                          (let [v (get lookup impl)]
-                                            (and (map? v)
-                                                 (contains? v :lower)
-                                                 (contains? v :upper))))
-                                        implementations))
+               has-error-bounds? (values-have-error-bounds? all-raw-values)
                ;; Get numeric values for SI scaling
                get-numeric (fn [v]
                              (if (and (map? v) (contains? v :value))
                                (:value v)
                                v))
-               all-values (keep #(get-numeric (get lookup %)) implementations)
+               all-values (map get-numeric all-raw-values)
                {:keys [^double total-scale unit]}
                (compute-si-scaling metric all-values)
                ;; Build y-axis title with unit
@@ -790,20 +796,16 @@
                        entries))
                     {}
                     data)
+            ;; Get all values from lookup for error bounds check and SI scaling
+            all-raw-values (keep #(get lookup %) implementations)
             ;; Check if any values have error bounds
-            has-error-bounds? (boolean
-                               (some (fn [impl]
-                                       (let [v (get lookup impl)]
-                                         (and (map? v)
-                                              (contains? v :lower)
-                                              (contains? v :upper))))
-                                     implementations))
+            has-error-bounds? (values-have-error-bounds? all-raw-values)
             ;; Get numeric values for SI scaling
             get-numeric (fn [v]
                           (if (and (map? v) (contains? v :value))
                             (:value v)
                             v))
-            all-values (keep #(get-numeric (get lookup %)) implementations)
+            all-values (map get-numeric all-raw-values)
             {:keys [^double total-scale unit]}
             (compute-si-scaling metric all-values)
             ;; Build y-axis title with unit
@@ -860,12 +862,7 @@
        (let [;; Get all raw values for error detection and SI scaling
              all-raw-values (keep (fn [[_coord value]] value) data)
              ;; Check if any values have error bounds (with :lower/:upper)
-             has-error-bounds? (boolean
-                                (some (fn [v]
-                                        (and (map? v)
-                                             (contains? v :lower)
-                                             (contains? v :upper)))
-                                      all-raw-values))
+             has-error-bounds? (values-have-error-bounds? all-raw-values)
              ;; Also check for error-bound-value? (with :value key) for y-title
              has-error-bound-format (some error-bound-value? all-raw-values)
              all-values (map get-numeric-value all-raw-values)
@@ -950,12 +947,7 @@
                                    (mapcat (fn [entries]
                                              (keep :value entries))))
                ;; Check if any values have error bounds (with :lower/:upper)
-               has-error-bounds? (boolean
-                                  (some (fn [v]
-                                          (and (map? v)
-                                               (contains? v :lower)
-                                               (contains? v :upper)))
-                                        all-raw-values))
+               has-error-bounds? (values-have-error-bounds? all-raw-values)
                ;; Also check for error-bound-value? (with :value key) for y-title
                has-error-bound-format (some error-bound-value? all-raw-values)
                all-values (map get-numeric-value all-raw-values)
@@ -1001,12 +993,7 @@
                                 (mapcat (fn [entries]
                                           (keep :value entries))))
             ;; Check if any values have error bounds (with :lower/:upper)
-            has-error-bounds? (boolean
-                               (some (fn [v]
-                                       (and (map? v)
-                                            (contains? v :lower)
-                                            (contains? v :upper)))
-                                     all-raw-values))
+            has-error-bounds? (values-have-error-bounds? all-raw-values)
             ;; Also check for error-bound-value? (with :value key) for y-title
             has-error-bound-format (some error-bound-value? all-raw-values)
             all-values (map get-numeric-value all-raw-values)

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -713,81 +713,127 @@
     :metric-id - the metric keyword (or nil for single-metric mode)
     :metric-path - the metric path vector
     :y-title - y-axis title with SI unit
-    :data - vector of {:impl string :value number} maps"
+    :has-error-bounds? - true if error bounds data is present
+    :data - vector of {:impl string :value number :valueLower number :valueUpper number} maps
+            (valueLower/valueUpper only present when error bounds exist)"
   [comparison]
   (let [{:keys [metric metrics implementations data]} comparison]
     (if metrics
       ;; Multi-metric mode
       (mapv
        (fn [[metric-id {:keys [metric data]}]]
-         (let [;; Build lookup: impl -> raw value
+         (let [;; Build lookup: impl -> full value (may be map with :value/:lower/:upper)
                lookup (reduce
                        (fn [acc [impl-val entries]]
                          (reduce
                           (fn [acc2 {:keys [value]}]
-                            (assoc acc2 impl-val
-                                   (if (and (map? value) (contains? value :value))
-                                     (:value value)
-                                     value)))
+                            (assoc acc2 impl-val value))
                           acc
                           entries))
                        {}
                        data)
-               ;; Get all values for SI scaling
-               all-values (keep #(get lookup %) implementations)
+               ;; Check if any values have error bounds
+               has-error-bounds? (boolean
+                                  (some (fn [impl]
+                                          (let [v (get lookup impl)]
+                                            (and (map? v)
+                                                 (contains? v :lower)
+                                                 (contains? v :upper))))
+                                        implementations))
+               ;; Get numeric values for SI scaling
+               get-numeric (fn [v]
+                             (if (and (map? v) (contains? v :value))
+                               (:value v)
+                               v))
+               all-values (keep #(get-numeric (get lookup %)) implementations)
                {:keys [^double total-scale unit]}
                (compute-si-scaling metric all-values)
                ;; Build y-axis title with unit
                metric-name (name metric-id)
+               base-title (if has-error-bounds?
+                            (str "mean " metric-name)
+                            metric-name)
                y-title (if (seq unit)
-                         (str metric-name " (" unit ")")
-                         metric-name)
+                         (str base-title " (" unit ")")
+                         base-title)
                ;; Build chart data
                chart-data (mapv
                            (fn [impl]
-                             (let [raw-value (get lookup impl)]
-                               {"impl" (name impl)
-                                "value" (when raw-value
-                                          (* (double raw-value) total-scale))}))
+                             (let [v (get lookup impl)
+                                   raw-value (get-numeric v)]
+                               (cond-> {"impl" (name impl)
+                                        "value" (when raw-value
+                                                  (* (double raw-value) total-scale))}
+                                 (and has-error-bounds?
+                                      (map? v)
+                                      (contains? v :lower))
+                                 (assoc "valueLower" (* (double (:lower v)) total-scale))
+                                 (and has-error-bounds?
+                                      (map? v)
+                                      (contains? v :upper))
+                                 (assoc "valueUpper" (* (double (:upper v)) total-scale)))))
                            implementations)]
            {:metric-id metric-id
             :metric-path metric
             :y-title y-title
+            :has-error-bounds? has-error-bounds?
             :data chart-data}))
        (sort-by key metrics))
       ;; Single-metric mode
-      (let [;; Build lookup: impl -> raw value
+      (let [;; Build lookup: impl -> full value (may be map with :value/:lower/:upper)
             lookup (reduce
                     (fn [acc [impl-val entries]]
                       (reduce
                        (fn [acc2 {:keys [value]}]
-                         (assoc acc2 impl-val
-                                (if (and (map? value) (contains? value :value))
-                                  (:value value)
-                                  value)))
+                         (assoc acc2 impl-val value))
                        acc
                        entries))
                     {}
                     data)
-            ;; Get all values for SI scaling
-            all-values (keep #(get lookup %) implementations)
+            ;; Check if any values have error bounds
+            has-error-bounds? (boolean
+                               (some (fn [impl]
+                                       (let [v (get lookup impl)]
+                                         (and (map? v)
+                                              (contains? v :lower)
+                                              (contains? v :upper))))
+                                     implementations))
+            ;; Get numeric values for SI scaling
+            get-numeric (fn [v]
+                          (if (and (map? v) (contains? v :value))
+                            (:value v)
+                            v))
+            all-values (keep #(get-numeric (get lookup %)) implementations)
             {:keys [^double total-scale unit]}
             (compute-si-scaling metric all-values)
             ;; Build y-axis title with unit
+            base-title (if has-error-bounds?
+                         (str "mean " (pr-str metric))
+                         (pr-str metric))
             y-title (if (seq unit)
-                      (str (pr-str metric) " (" unit ")")
-                      (pr-str metric))
+                      (str base-title " (" unit ")")
+                      base-title)
             ;; Build chart data
             chart-data (mapv
                         (fn [impl]
-                          (let [raw-value (get lookup impl)]
-                            {"impl" (name impl)
-                             "value" (when raw-value
-                                       (* (double raw-value) total-scale))}))
+                          (let [v (get lookup impl)
+                                raw-value (get-numeric v)]
+                            (cond-> {"impl" (name impl)
+                                     "value" (when raw-value
+                                               (* (double raw-value) total-scale))}
+                              (and has-error-bounds?
+                                   (map? v)
+                                   (contains? v :lower))
+                              (assoc "valueLower" (* (double (:lower v)) total-scale))
+                              (and has-error-bounds?
+                                   (map? v)
+                                   (contains? v :upper))
+                              (assoc "valueUpper" (* (double (:upper v)) total-scale)))))
                         implementations)]
         [{:metric-id nil
           :metric-path metric
           :y-title y-title
+          :has-error-bounds? has-error-bounds?
           :data chart-data}]))))
 
 (defn prepare-line-chart-data

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -549,44 +549,67 @@
     :metric-id - the metric keyword
     :metric-path - the metric path vector
     :y-title - y-axis title with SI unit
-    :data - vector of {:impl string :value number} maps"
+    :has-error-bounds? - true if error bounds data is present
+    :data - vector of {:impl string :value number :valueLower number :valueUpper number} maps
+            (valueLower/valueUpper only present when error bounds exist)"
   [extract]
   (let [impl-axis-key (:impl-axis extract)
         implementations (:implementations extract)
         metrics (:metrics extract)]
     (mapv
      (fn [[metric-id {:keys [metric data]}]]
-       (let [;; Build lookup: impl -> raw value
+       (let [;; Build lookup: impl -> full value (may be map with :value/:lower/:upper)
              lookup (reduce
                      (fn [acc [coord value]]
-                       (let [impl-val (get coord impl-axis-key)
-                             raw-value (if (and (map? value)
-                                                (contains? value :value))
-                                         (:value value)
-                                         value)]
-                         (assoc acc impl-val raw-value)))
+                       (let [impl-val (get coord impl-axis-key)]
+                         (assoc acc impl-val value)))
                      {}
                      data)
-             ;; Get all values for SI scaling
-             all-values (keep #(get lookup %) implementations)
+             ;; Check if any values have error bounds
+             has-error-bounds? (boolean
+                                (some (fn [impl]
+                                        (let [v (get lookup impl)]
+                                          (and (map? v)
+                                               (contains? v :lower)
+                                               (contains? v :upper))))
+                                      implementations))
+             ;; Get numeric values for SI scaling
+             get-numeric (fn [v]
+                           (if (and (map? v) (contains? v :value))
+                             (:value v)
+                             v))
+             all-values (keep #(get-numeric (get lookup %)) implementations)
              {:keys [^double total-scale unit]}
              (viewer-common/compute-si-scaling metric all-values)
              ;; Build y-axis title with unit
              metric-name (name metric-id)
+             base-title (if has-error-bounds?
+                          (str "mean " metric-name)
+                          metric-name)
              y-title (if (seq unit)
-                       (str metric-name " (" unit ")")
-                       metric-name)
+                       (str base-title " (" unit ")")
+                       base-title)
              ;; Build chart data
              chart-data (mapv
                          (fn [impl]
-                           (let [raw-value (get lookup impl)]
-                             {"impl" (name impl)
-                              "value" (when raw-value
-                                        (* (double raw-value) total-scale))}))
+                           (let [v (get lookup impl)
+                                 raw-value (get-numeric v)]
+                             (cond-> {"impl" (name impl)
+                                      "value" (when raw-value
+                                                (* (double raw-value) total-scale))}
+                               (and has-error-bounds?
+                                    (map? v)
+                                    (contains? v :lower))
+                               (assoc "valueLower" (* (double (:lower v)) total-scale))
+                               (and has-error-bounds?
+                                    (map? v)
+                                    (contains? v :upper))
+                               (assoc "valueUpper" (* (double (:upper v)) total-scale)))))
                          implementations)]
          {:metric-id metric-id
           :metric-path metric
           :y-title y-title
+          :has-error-bounds? has-error-bounds?
           :data chart-data}))
      (sort-by key metrics))))
 

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -647,7 +647,25 @@
   otherwise returns a simple bar chart spec.
   Used by both single-point-bar-chart-spec and comparison-bar-chart-spec."
   [{:keys [y-title has-error-bounds? data]} chart-options]
-  (let [bar-layer (chart-layer
+  (let [base-tooltip [{:field "impl"
+                       :type "nominal"
+                       :title "Implementation"}
+                      {:field "value"
+                       :type "quantitative"
+                       :title y-title
+                       :format ".3g"}]
+        tooltip (if has-error-bounds?
+                  (into base-tooltip
+                        [{:field "valueLower"
+                          :type "quantitative"
+                          :title "Lower bound"
+                          :format ".3g"}
+                         {:field "valueUpper"
+                          :type "quantitative"
+                          :title "Upper bound"
+                          :format ".3g"}])
+                  base-tooltip)
+        bar-layer (chart-layer
                    data
                    {}
                    {:type "bar"}
@@ -662,13 +680,7 @@
                     :color {:field "impl"
                             :type "nominal"
                             :legend nil}
-                    :tooltip [{:field "impl"
-                               :type "nominal"
-                               :title "Implementation"}
-                              {:field "value"
-                               :type "quantitative"
-                               :title y-title
-                               :format ".3g"}]})]
+                    :tooltip tooltip})]
     (if has-error-bounds?
       (merge chart-options
              {:layer [bar-layer (bar-error-layer data)]})

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -565,20 +565,17 @@
                          (assoc acc impl-val value)))
                      {}
                      data)
+             ;; Get all values from lookup for error bounds check and SI scaling
+             all-raw-values (keep #(get lookup %) implementations)
              ;; Check if any values have error bounds
-             has-error-bounds? (boolean
-                                (some (fn [impl]
-                                        (let [v (get lookup impl)]
-                                          (and (map? v)
-                                               (contains? v :lower)
-                                               (contains? v :upper))))
-                                      implementations))
+             has-error-bounds? (viewer-common/values-have-error-bounds?
+                                all-raw-values)
              ;; Get numeric values for SI scaling
              get-numeric (fn [v]
                            (if (and (map? v) (contains? v :value))
                              (:value v)
                              v))
-             all-values (keep #(get-numeric (get lookup %)) implementations)
+             all-values (map get-numeric all-raw-values)
              {:keys [^double total-scale unit]}
              (viewer-common/compute-si-scaling metric all-values)
              ;; Build y-axis title with unit

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -623,32 +623,50 @@
     :mark mark
     :encoding encoding}))
 
+(defn- bar-error-layer
+  "Build error bar layer for bar charts with error bounds.
+  Uses rule marks positioned at bar centers with y/y2 for bounds."
+  [data]
+  {:data {:values data}
+   :mark {:type "rule" :strokeWidth 1.5}
+   :encoding {:x {:field "impl" :type "nominal"}
+              :y {:field "valueLower" :type "quantitative"}
+              :y2 {:field "valueUpper"}
+              :color {:field "impl" :type "nominal" :legend nil}
+              :opacity {:value 0.5}}})
+
 (defn- bar-chart-layer
-  "Build a single bar chart layer from prepared bar data.
+  "Build a bar chart from prepared bar data.
+  Returns a layered spec with error bars when has-error-bounds? is true,
+  otherwise returns a simple bar chart spec.
   Used by both single-point-bar-chart-spec and comparison-bar-chart-spec."
-  [{:keys [y-title data]} chart-options]
-  (chart-layer
-   data
-   chart-options
-   {:type "bar"}
-   {:x {:field "impl"
-        :type "nominal"
-        :title "Implementation"
-        :sort nil
-        :axis {:labelAngle 0}}
-    :y {:field "value"
-        :type "quantitative"
-        :title y-title}
-    :color {:field "impl"
-            :type "nominal"
-            :legend nil}
-    :tooltip [{:field "impl"
-               :type "nominal"
-               :title "Implementation"}
-              {:field "value"
-               :type "quantitative"
-               :title y-title
-               :format ".3g"}]}))
+  [{:keys [y-title has-error-bounds? data]} chart-options]
+  (let [bar-layer (chart-layer
+                   data
+                   {}
+                   {:type "bar"}
+                   {:x {:field "impl"
+                        :type "nominal"
+                        :title "Implementation"
+                        :sort nil
+                        :axis {:labelAngle 0}}
+                    :y {:field "value"
+                        :type "quantitative"
+                        :title y-title}
+                    :color {:field "impl"
+                            :type "nominal"
+                            :legend nil}
+                    :tooltip [{:field "impl"
+                               :type "nominal"
+                               :title "Implementation"}
+                              {:field "value"
+                               :type "quantitative"
+                               :title y-title
+                               :format ".3g"}]})]
+    (if has-error-bounds?
+      (merge chart-options
+             {:layer [bar-layer (bar-error-layer data)]})
+      (merge chart-options bar-layer))))
 
 (defn single-point-bar-chart-spec
   "Build a Vega-Lite bar chart spec for single-point multi-impl comparison.

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -571,11 +571,7 @@
              has-error-bounds? (viewer-common/values-have-error-bounds?
                                 all-raw-values)
              ;; Get numeric values for SI scaling
-             get-numeric (fn [v]
-                           (if (and (map? v) (contains? v :value))
-                             (:value v)
-                             v))
-             all-values (map get-numeric all-raw-values)
+             all-values (map viewer-common/get-numeric-value all-raw-values)
              {:keys [^double total-scale unit]}
              (viewer-common/compute-si-scaling metric all-values)
              ;; Build y-axis title with unit
@@ -590,7 +586,7 @@
              chart-data (mapv
                          (fn [impl]
                            (let [v (get lookup impl)
-                                 raw-value (get-numeric v)]
+                                 raw-value (viewer-common/get-numeric-value v)]
                              (cond-> {"impl" (name impl)
                                       "value" (when raw-value
                                                 (* (double raw-value) total-scale))}

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -702,34 +702,52 @@
 
 ;;; Multi-point line charts
 
+(defn- line-confidence-band-layer
+  "Build confidence band layer for line charts with error bounds.
+  Uses area marks with y/y2 encoding for yLower/yUpper bounds.
+  Color matches line color per implementation."
+  [data]
+  {:data {:values data}
+   :mark {:type "area" :opacity 0.2}
+   :encoding {:x {:field "x" :type "quantitative"}
+              :y {:field "yLower" :type "quantitative"}
+              :y2 {:field "yUpper"}
+              :color {:field "impl" :type "nominal" :legend nil}}})
+
 (defn- line-chart-layer
   "Build a single line chart layer from prepared line data.
+  Returns a layered spec with confidence bands when has-error-bounds? is true,
+  otherwise returns a simple line chart spec.
   Used by both domain-line-chart-spec and comparison-line-chart-spec."
-  [{:keys [x-title y-title data]} chart-options]
-  (chart-layer
-   data
-   chart-options
-   {:type "line" :point true}
-   {:x {:field "x"
-        :type "quantitative"
-        :title x-title
-        :scale {:zero false}}
-    :y {:field "y"
-        :type "quantitative"
-        :title y-title}
-    :color {:field "impl"
-            :type "nominal"
-            :title "Implementation"}
-    :tooltip [{:field "impl"
-               :type "nominal"
-               :title "Implementation"}
-              {:field "x"
-               :type "quantitative"
-               :title x-title}
-              {:field "y"
-               :type "quantitative"
-               :title y-title
-               :format ".3g"}]}))
+  [{:keys [x-title y-title has-error-bounds? data]} chart-options]
+  (let [line-layer (chart-layer
+                    data
+                    {}
+                    {:type "line" :point true}
+                    {:x {:field "x"
+                         :type "quantitative"
+                         :title x-title
+                         :scale {:zero false}}
+                     :y {:field "y"
+                         :type "quantitative"
+                         :title y-title}
+                     :color {:field "impl"
+                             :type "nominal"
+                             :title "Implementation"}
+                     :tooltip [{:field "impl"
+                                :type "nominal"
+                                :title "Implementation"}
+                               {:field "x"
+                                :type "quantitative"
+                                :title x-title}
+                               {:field "y"
+                                :type "quantitative"
+                                :title y-title
+                                :format ".3g"}]})]
+    (if has-error-bounds?
+      (merge chart-options
+             {:layer [(line-confidence-band-layer data) line-layer]})
+      (merge chart-options line-layer))))
 
 (defn domain-line-chart-spec
   "Build a Vega-Lite line chart spec for single-axis multi-point domain extract.

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -618,15 +618,28 @@
 
 (defn- bar-error-layer
   "Build error bar layer for bar charts with error bounds.
-  Uses rule marks positioned at bar centers with y/y2 for bounds."
+  Returns a layered spec with vertical rule and horizontal tick caps."
   [data]
-  {:data {:values data}
-   :mark {:type "rule" :strokeWidth 1.5}
-   :encoding {:x {:field "impl" :type "nominal"}
-              :y {:field "valueLower" :type "quantitative"}
-              :y2 {:field "valueUpper"}
-              :color {:field "impl" :type "nominal" :legend nil}
-              :opacity {:value 0.5}}})
+  {:layer
+   [;; Vertical rule (error bar stem)
+    {:data {:values data}
+     :mark {:type "rule" :strokeWidth 1.5}
+     :encoding {:x {:field "impl" :type "nominal"}
+                :y {:field "valueLower" :type "quantitative"}
+                :y2 {:field "valueUpper"}
+                :color {:value "#333"}}}
+    ;; Lower tick cap
+    {:data {:values data}
+     :mark {:type "tick" :thickness 1.5 :size 8}
+     :encoding {:x {:field "impl" :type "nominal"}
+                :y {:field "valueLower" :type "quantitative"}
+                :color {:value "#333"}}}
+    ;; Upper tick cap
+    {:data {:values data}
+     :mark {:type "tick" :thickness 1.5 :size 8}
+     :encoding {:x {:field "impl" :type "nominal"}
+                :y {:field "valueUpper" :type "quantitative"}
+                :color {:value "#333"}}}]})
 
 (defn- bar-chart-layer
   "Build a bar chart from prepared bar data.

--- a/bases/criterium/test/criterium/domain_plans_test.clj
+++ b/bases/criterium/test/criterium/domain_plans_test.clj
@@ -69,4 +69,33 @@
                   :viewer :none)
             result (analysis/analyse-domain plan d)]
         (is (contains? result :extract))
-        (is (= :criterium/domain-extract (:type (:extract result))))))))
+        (is (= :criterium/domain-extract (:type (:extract result))))))
+    (testing "extract-metrics includes error bounds"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-bench-result-with-defs
+                       {:elapsed-time {:mean 1.0
+                                       :mean-plus-3sigma 1.2
+                                       :mean-minus-3sigma 0.8}})}
+               {:coord {:n 200}
+                :data (mock-bench-result-with-defs
+                       {:elapsed-time {:mean 2.0
+                                       :mean-plus-3sigma 2.5
+                                       :mean-minus-3sigma 1.5}})})
+            plan (analysis/options->domain-plan
+                  domain-plans/extract-metrics
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            extract (:extract result)
+            et-data (get-in extract [:metrics :elapsed-time])]
+        (is (contains? result :extract))
+        (is (= :criterium/domain-extract (:type extract)))
+        ;; Verify error bounds flag is set
+        (is (true? (:with-error-bounds et-data))
+            "extract-metrics plan should enable :with-error-bounds")
+        ;; Verify data includes error bounds
+        (let [[_coord value] (first (:data et-data))]
+          (is (map? value))
+          (is (contains? value :value))
+          (is (contains? value :lower))
+          (is (contains? value :upper)))))))

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -254,7 +254,65 @@
             result (charts/prepare-single-point-bar-data multi-metric-extract)]
         (is (= 2 (count result)))
         (is (= #{:elapsed-time :thread-allocation}
-               (set (map :metric-id result))))))))
+               (set (map :metric-id result))))))
+
+    (testing "returns has-error-bounds? false for plain values"
+      (let [result (charts/prepare-single-point-bar-data single-point-extract)
+            first-metric (first result)]
+        (is (false? (:has-error-bounds? first-metric)))
+        ;; Data should not have valueLower/valueUpper
+        (is (every? #(not (contains? % "valueLower")) (:data first-metric)))
+        (is (every? #(not (contains? % "valueUpper")) (:data first-metric)))))
+
+    (testing "extracts error bounds when present"
+      (let [extract-with-bounds
+            {:type :criterium/domain-extract
+             :impl-axis :impl
+             :implementations [:foo :bar]
+             :metrics {:elapsed-time
+                       {:metric [:stats :elapsed-time :mean]
+                        :data [[{:n 100 :impl :foo}
+                                {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                               [{:n 100 :impl :bar}
+                                {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]]}}}
+            result (charts/prepare-single-point-bar-data extract-with-bounds)
+            first-metric (first result)]
+        ;; Check has-error-bounds? flag
+        (is (true? (:has-error-bounds? first-metric)))
+        ;; Check that y-title includes "mean" prefix
+        (is (re-find #"mean" (:y-title first-metric)))
+        ;; Check that data includes error bound fields
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "valueLower") data))
+          (is (every? #(contains? % "valueUpper") data))
+          ;; Verify order: lower < value < upper
+          (doseq [d data]
+            (is (< (get d "valueLower") (get d "value")))
+            (is (< (get d "value") (get d "valueUpper")))))))
+
+    (testing "graceful degradation for mixed values"
+      ;; When some values have bounds and some don't
+      (let [extract-mixed
+            {:type :criterium/domain-extract
+             :impl-axis :impl
+             :implementations [:foo :bar]
+             :metrics {:elapsed-time
+                       {:metric [:stats :elapsed-time :mean]
+                        :data [[{:n 100 :impl :foo}
+                                {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                               [{:n 100 :impl :bar} 2.0e-6]]}}}
+            result (charts/prepare-single-point-bar-data extract-mixed)
+            first-metric (first result)
+            data (:data first-metric)]
+        ;; has-error-bounds? true because some have bounds
+        (is (true? (:has-error-bounds? first-metric)))
+        ;; foo has bounds, bar does not
+        (let [foo-data (first (filter #(= "foo" (get % "impl")) data))
+              bar-data (first (filter #(= "bar" (get % "impl")) data))]
+          (is (contains? foo-data "valueLower"))
+          (is (contains? foo-data "valueUpper"))
+          (is (not (contains? bar-data "valueLower")))
+          (is (not (contains? bar-data "valueUpper"))))))))
 
 (deftest single-point-bar-chart-spec-test
   ;; Tests bar chart spec generation for single-point multi-impl comparisons.

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -786,6 +786,185 @@
             (str "comparison-line-chart-spec validation failed: "
                  (pr-str (:errors result))))))))
 
+;;; Line chart confidence band tests.
+;;; Verifies confidence band generation for line charts with error bounds.
+
+(def multi-point-extract-with-bounds
+  "Sample multi-point extract with error bounds for line chart testing."
+  {:type :criterium/domain-extract
+   :impl-axis :impl
+   :implementations [:foo :bar]
+   :metrics {:elapsed-time
+             {:metric [:stats :elapsed-time :mean]
+              :data [[{:n 100 :impl :foo}
+                      {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                     [{:n 100 :impl :bar}
+                      {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]
+                     [{:n 200 :impl :foo}
+                      {:value 1.5e-6 :lower 1.3e-6 :upper 1.7e-6}]
+                     [{:n 200 :impl :bar}
+                      {:value 2.5e-6 :lower 2.3e-6 :upper 2.7e-6}]
+                     [{:n 400 :impl :foo}
+                      {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]
+                     [{:n 400 :impl :bar}
+                      {:value 3.5e-6 :lower 3.2e-6 :upper 3.8e-6}]]}}})
+
+(deftest domain-line-chart-with-confidence-bands-test
+  ;; Tests line chart spec generation when error bounds are present.
+  ;; Verifies layered spec structure with confidence band layer + line layer.
+  (testing "domain-line-chart-spec with error bounds"
+    (testing "produces layered structure"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (contains? chart :layer))
+        (is (= 2 (count (:layer chart))))))
+
+    (testing "includes confidence band layer with area mark"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            band-layer (first (:layer chart))]
+        (is (= "area" (get-in band-layer [:mark :type])))
+        (is (= 0.2 (get-in band-layer [:mark :opacity])))))
+
+    (testing "confidence band layer encodes y/y2 for bounds"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            band-layer (first (:layer chart))
+            encoding (:encoding band-layer)]
+        (is (= "yLower" (get-in encoding [:y :field])))
+        (is (= "yUpper" (get-in encoding [:y2 :field])))))
+
+    (testing "includes line layer with line mark"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            line-layer (second (:layer chart))]
+        (is (= "line" (get-in line-layer [:mark :type])))
+        (is (true? (get-in line-layer [:mark :point])))))
+
+    (testing "confidence band data includes bounds"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            band-layer (first (:layer chart))
+            data (get-in band-layer [:data :values])]
+        (is (every? #(contains? % "yLower") data))
+        (is (every? #(contains? % "yUpper") data))))
+
+    (testing "respects chart dimensions"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 500 :height 250})
+            chart (first (:vconcat spec))]
+        (is (= 500 (:width chart)))
+        (is (= 250 (:height chart)))))))
+
+(deftest domain-line-chart-graceful-degradation-test
+  ;; Tests that line charts without error bounds render normally.
+  ;; Verifies graceful degradation - no layered structure when no bounds.
+  (testing "domain-line-chart-spec without error bounds"
+    (testing "produces simple structure without layer"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (not (contains? chart :layer)))
+        (is (= {:type "line" :point true} (:mark chart)))))
+
+    (testing "still includes line mark and encodings"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (= "x" (get-in chart [:encoding :x :field])))
+        (is (= "y" (get-in chart [:encoding :y :field])))
+        (is (= "impl" (get-in chart [:encoding :color :field])))))))
+
+(deftest domain-line-chart-with-confidence-bands-schema-validation-test
+  ;; Validates line chart with confidence bands against Vega-Lite v6 schema.
+  (testing "domain-line-chart-spec with error bounds"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/domain-line-chart-spec
+                  multi-point-extract-with-bounds
+                  {:width 400 :height 300})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "line chart with confidence bands failed: "
+                 (pr-str (:errors result))))))))
+
+;;; Comparison line chart confidence band tests.
+
+(def multi-point-comparison-with-bounds
+  "Sample comparison with error bounds for line chart testing."
+  {:type :criterium/domain-comparison
+   :axis :n
+   :metric [:stats :elapsed-time :mean]
+   :implementations [:foo :bar]
+   :data {:foo [{:coord {:n 100}
+                 :value {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}}
+                {:coord {:n 200}
+                 :value {:value 1.5e-6 :lower 1.3e-6 :upper 1.7e-6}}
+                {:coord {:n 400}
+                 :value {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}}]
+          :bar [{:coord {:n 100}
+                 :value {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}}
+                {:coord {:n 200}
+                 :value {:value 2.5e-6 :lower 2.3e-6 :upper 2.7e-6}}
+                {:coord {:n 400}
+                 :value {:value 3.5e-6 :lower 3.2e-6 :upper 3.8e-6}}]}})
+
+(deftest comparison-line-chart-with-confidence-bands-test
+  ;; Tests comparison line chart spec when error bounds are present.
+  ;; Verifies layered spec structure with confidence band layer + line layer.
+  (testing "comparison-line-chart-spec with error bounds"
+    (testing "produces layered structure"
+      (let [spec (charts/comparison-line-chart-spec
+                  multi-point-comparison-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (contains? chart :layer))
+        (is (= 2 (count (:layer chart))))))
+
+    (testing "includes confidence band layer with area mark"
+      (let [spec (charts/comparison-line-chart-spec
+                  multi-point-comparison-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            band-layer (first (:layer chart))]
+        (is (= "area" (get-in band-layer [:mark :type])))
+        (is (= 0.2 (get-in band-layer [:mark :opacity])))))))
+
+(deftest comparison-line-chart-graceful-degradation-test
+  ;; Tests that comparison line charts without error bounds render normally.
+  (testing "comparison-line-chart-spec without error bounds"
+    (testing "produces simple structure without layer"
+      (let [spec (charts/comparison-line-chart-spec
+                  multi-point-comparison
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (not (contains? chart :layer)))
+        (is (= {:type "line" :point true} (:mark chart)))))))
+
+(deftest comparison-line-chart-with-confidence-bands-schema-validation-test
+  ;; Validates comparison line chart with confidence bands against Vega-Lite schema.
+  (testing "comparison-line-chart-spec with error bounds"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/comparison-line-chart-spec
+                  multi-point-comparison-with-bounds
+                  {:width 400 :height 300})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "comparison line chart with confidence bands failed: "
+                 (pr-str (:errors result))))))))
+
 (deftest treemap-vega-spec-schema-validation-test
   ;; Validates treemap-vega-spec output against Vega v5 schema.
   ;; Tests treemap visualization for allocation data.

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -392,6 +392,112 @@
             (str "single-point-bar-chart-spec validation failed: "
                  (pr-str (:errors result))))))))
 
+;;; Bar chart error bars tests.
+;;; Verifies error bar generation for bar charts with error bounds.
+
+(def single-point-extract-with-bounds
+  "Sample single-point extract with error bounds for testing."
+  {:type :criterium/domain-extract
+   :impl-axis :impl
+   :implementations [:foo :bar :baz]
+   :metrics {:elapsed-time
+             {:metric [:stats :elapsed-time :mean]
+              :data [[{:n 100 :impl :foo}
+                      {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                     [{:n 100 :impl :bar}
+                      {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]
+                     [{:n 100 :impl :baz}
+                      {:value 1.5e-6 :lower 1.3e-6 :upper 1.7e-6}]]}}})
+
+(deftest single-point-bar-chart-with-error-bars-test
+  ;; Tests bar chart spec generation when error bounds are present.
+  ;; Verifies layered spec structure with bar layer + error layer.
+  (testing "single-point-bar-chart-spec with error bounds"
+    (testing "produces layered structure"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (contains? chart :layer))
+        (is (= 2 (count (:layer chart))))))
+
+    (testing "includes bar layer with bar mark"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            bar-layer (first (:layer chart))]
+        (is (= {:type "bar"} (:mark bar-layer)))))
+
+    (testing "includes error layer with rule mark"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            error-layer (second (:layer chart))]
+        (is (= "rule" (get-in error-layer [:mark :type])))
+        (is (= 1.5 (get-in error-layer [:mark :strokeWidth])))))
+
+    (testing "error layer encodes y/y2 for bounds"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            error-layer (second (:layer chart))
+            encoding (:encoding error-layer)]
+        (is (= "valueLower" (get-in encoding [:y :field])))
+        (is (= "valueUpper" (get-in encoding [:y2 :field])))))
+
+    (testing "error layer data includes bounds"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            error-layer (second (:layer chart))
+            data (get-in error-layer [:data :values])]
+        (is (every? #(contains? % "valueLower") data))
+        (is (every? #(contains? % "valueUpper") data))))
+
+    (testing "respects chart dimensions"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 500 :height 250})
+            chart (first (:vconcat spec))]
+        (is (= 500 (:width chart)))
+        (is (= 250 (:height chart)))))))
+
+(deftest single-point-bar-chart-graceful-degradation-test
+  ;; Tests that bar charts without error bounds render normally.
+  ;; Verifies graceful degradation - no layered structure when no bounds.
+  (testing "single-point-bar-chart-spec without error bounds"
+    (testing "produces simple structure without layer"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (not (contains? chart :layer)))
+        (is (= {:type "bar"} (:mark chart)))))
+
+    (testing "still includes bar mark and encodings"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (= "impl" (get-in chart [:encoding :x :field])))
+        (is (= "value" (get-in chart [:encoding :y :field])))))))
+
+(deftest single-point-bar-chart-with-error-bars-schema-validation-test
+  ;; Validates bar chart with error bars against Vega-Lite v6 schema.
+  (testing "single-point-bar-chart-spec with error bounds"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/single-point-bar-chart-spec
+                  single-point-extract-with-bounds
+                  {:width 400 :height 300})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "bar chart with error bars validation failed: "
+                 (pr-str (:errors result))))))))
+
 ;;; Comparison bar chart tests.
 ;;; Verifies bar chart generation from domain-comparison data.
 
@@ -455,6 +561,64 @@
             result (schema/validate-vega-lite-spec spec)]
         (is (:valid? result)
             (str "comparison-bar-chart-spec validation failed: "
+                 (pr-str (:errors result))))))))
+
+;;; Comparison bar chart error bars tests.
+
+(def single-point-comparison-with-bounds
+  "Sample comparison with error bounds for testing."
+  {:type :criterium/domain-comparison
+   :axis :n
+   :metric [:stats :elapsed-time :mean]
+   :implementations [:foo :bar :baz]
+   :data {:foo [{:coord {:n 100}
+                 :value {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}}]
+          :bar [{:coord {:n 100}
+                 :value {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}}]
+          :baz [{:coord {:n 100}
+                 :value {:value 1.5e-6 :lower 1.3e-6 :upper 1.7e-6}}]}})
+
+(deftest comparison-bar-chart-with-error-bars-test
+  ;; Tests comparison bar chart spec when error bounds are present.
+  ;; Verifies layered spec structure with bar layer + error layer.
+  (testing "comparison-bar-chart-spec with error bounds"
+    (testing "produces layered structure"
+      (let [spec (charts/comparison-bar-chart-spec
+                  single-point-comparison-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (contains? chart :layer))
+        (is (= 2 (count (:layer chart))))))
+
+    (testing "includes error layer with rule mark"
+      (let [spec (charts/comparison-bar-chart-spec
+                  single-point-comparison-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            error-layer (second (:layer chart))]
+        (is (= "rule" (get-in error-layer [:mark :type])))))))
+
+(deftest comparison-bar-chart-graceful-degradation-test
+  ;; Tests that comparison bar charts without error bounds render normally.
+  (testing "comparison-bar-chart-spec without error bounds"
+    (testing "produces simple structure without layer"
+      (let [spec (charts/comparison-bar-chart-spec
+                  single-point-comparison
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (not (contains? chart :layer)))
+        (is (= {:type "bar"} (:mark chart)))))))
+
+(deftest comparison-bar-chart-with-error-bars-schema-validation-test
+  ;; Validates comparison bar chart with error bars against Vega-Lite schema.
+  (testing "comparison-bar-chart-spec with error bounds"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/comparison-bar-chart-spec
+                  single-point-comparison-with-bounds
+                  {:width 400 :height 300})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "comparison bar chart with error bars failed: "
                  (pr-str (:errors result))))))))
 
 ;;; Multi-point line chart tests.

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -429,22 +429,26 @@
             bar-layer (first (:layer chart))]
         (is (= {:type "bar"} (:mark bar-layer)))))
 
-    (testing "includes error layer with rule mark"
+    (testing "includes error layer with rule and tick marks"
       (let [spec (charts/single-point-bar-chart-spec
                   single-point-extract-with-bounds
                   {:width 400 :height 300})
             chart (first (:vconcat spec))
-            error-layer (second (:layer chart))]
-        (is (= "rule" (get-in error-layer [:mark :type])))
-        (is (= 1.5 (get-in error-layer [:mark :strokeWidth])))))
+            error-composite (second (:layer chart))
+            rule-layer (first (:layer error-composite))]
+        (is (contains? error-composite :layer) "error layer is a composite")
+        (is (= 3 (count (:layer error-composite))) "rule + 2 tick caps")
+        (is (= "rule" (get-in rule-layer [:mark :type])))
+        (is (= 1.5 (get-in rule-layer [:mark :strokeWidth])))))
 
-    (testing "error layer encodes y/y2 for bounds"
+    (testing "error rule layer encodes y/y2 for bounds"
       (let [spec (charts/single-point-bar-chart-spec
                   single-point-extract-with-bounds
                   {:width 400 :height 300})
             chart (first (:vconcat spec))
-            error-layer (second (:layer chart))
-            encoding (:encoding error-layer)]
+            error-composite (second (:layer chart))
+            rule-layer (first (:layer error-composite))
+            encoding (:encoding rule-layer)]
         (is (= "valueLower" (get-in encoding [:y :field])))
         (is (= "valueUpper" (get-in encoding [:y2 :field])))))
 
@@ -453,8 +457,9 @@
                   single-point-extract-with-bounds
                   {:width 400 :height 300})
             chart (first (:vconcat spec))
-            error-layer (second (:layer chart))
-            data (get-in error-layer [:data :values])]
+            error-composite (second (:layer chart))
+            rule-layer (first (:layer error-composite))
+            data (get-in rule-layer [:data :values])]
         (is (every? #(contains? % "valueLower") data))
         (is (every? #(contains? % "valueUpper") data))))
 
@@ -590,13 +595,16 @@
         (is (contains? chart :layer))
         (is (= 2 (count (:layer chart))))))
 
-    (testing "includes error layer with rule mark"
+    (testing "includes error layer with rule and tick marks"
       (let [spec (charts/comparison-bar-chart-spec
                   single-point-comparison-with-bounds
                   {:width 400 :height 300})
             chart (first (:vconcat spec))
-            error-layer (second (:layer chart))]
-        (is (= "rule" (get-in error-layer [:mark :type])))))))
+            error-composite (second (:layer chart))
+            rule-layer (first (:layer error-composite))]
+        (is (contains? error-composite :layer) "error layer is a composite")
+        (is (= 3 (count (:layer error-composite))) "rule + 2 tick caps")
+        (is (= "rule" (get-in rule-layer [:mark :type])))))))
 
 (deftest comparison-bar-chart-graceful-degradation-test
   ;; Tests that comparison bar charts without error bounds render normally.

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -408,7 +408,87 @@
             result (common/prepare-comparison-bar-data comparison)]
         (is (= 2 (count result)))
         (is (= #{:elapsed-time :thread-allocation}
-               (set (map :metric-id result))))))))
+               (set (map :metric-id result))))))
+
+    (testing "returns has-error-bounds? false for plain values"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100} :value 1.0e-6}]
+                               :bar [{:coord {:n 100} :value 2.0e-6}]}}
+            result (common/prepare-comparison-bar-data comparison)
+            first-metric (first result)]
+        (is (false? (:has-error-bounds? first-metric)))
+        (is (every? #(not (contains? % "valueLower")) (:data first-metric)))
+        (is (every? #(not (contains? % "valueUpper")) (:data first-metric)))))
+
+    (testing "extracts error bounds for single-metric comparison"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100}
+                                      :value {:value 1.0e-6
+                                              :lower 0.9e-6
+                                              :upper 1.1e-6}}]
+                               :bar [{:coord {:n 100}
+                                      :value {:value 2.0e-6
+                                              :lower 1.8e-6
+                                              :upper 2.2e-6}}]}}
+            result (common/prepare-comparison-bar-data comparison)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (re-find #"mean" (:y-title first-metric)))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "valueLower") data))
+          (is (every? #(contains? % "valueUpper") data))
+          (doseq [d data]
+            (is (< (get d "valueLower") (get d "value")))
+            (is (< (get d "value") (get d "valueUpper")))))))
+
+    (testing "extracts error bounds for multi-metric comparison"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:n 100}
+                                                 :value {:value 1.0e-6
+                                                         :lower 0.9e-6
+                                                         :upper 1.1e-6}}]
+                                          :bar [{:coord {:n 100}
+                                                 :value {:value 2.0e-6
+                                                         :lower 1.8e-6
+                                                         :upper 2.2e-6}}]}}}}
+            result (common/prepare-comparison-bar-data comparison)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (re-find #"mean" (:y-title first-metric)))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "valueLower") data))
+          (is (every? #(contains? % "valueUpper") data)))))
+
+    (testing "graceful degradation for mixed values"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100}
+                                      :value {:value 1.0e-6
+                                              :lower 0.9e-6
+                                              :upper 1.1e-6}}]
+                               :bar [{:coord {:n 100} :value 2.0e-6}]}}
+            result (common/prepare-comparison-bar-data comparison)
+            first-metric (first result)
+            data (:data first-metric)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (let [foo-data (first (filter #(= "foo" (get % "impl")) data))
+              bar-data (first (filter #(= "bar" (get % "impl")) data))]
+          (is (contains? foo-data "valueLower"))
+          (is (contains? foo-data "valueUpper"))
+          (is (not (contains? bar-data "valueLower")))
+          (is (not (contains? bar-data "valueUpper"))))))))
 
 ;;; Tests for single-axis-multi-point-comparison? helper.
 ;;; Verifies detection of multi-point line chart scenarios in domain-comparison data.

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -704,7 +704,75 @@
                                        [{:n 200 :impl :bar} 2.5e-6]]}}}
             result (common/prepare-line-chart-data extract)
             {:keys [y-title]} (first result)]
-        (is (not (str/starts-with? y-title "mean ")))))))
+        (is (not (str/starts-with? y-title "mean ")))))
+
+    (testing "returns has-error-bounds? false for plain values"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:foo :bar]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :impl :foo} 1.0e-6]
+                                       [{:n 100 :impl :bar} 2.0e-6]
+                                       [{:n 200 :impl :foo} 1.5e-6]
+                                       [{:n 200 :impl :bar} 2.5e-6]]}}}
+            result (common/prepare-line-chart-data extract)
+            first-metric (first result)]
+        (is (false? (:has-error-bounds? first-metric)))
+        (is (every? #(not (contains? % "yLower")) (:data first-metric)))
+        (is (every? #(not (contains? % "yUpper")) (:data first-metric)))))
+
+    (testing "extracts error bounds when :lower/:upper present"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:foo :bar]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :impl :foo}
+                                        {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                                       [{:n 100 :impl :bar}
+                                        {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]
+                                       [{:n 200 :impl :foo}
+                                        {:value 1.5e-6 :lower 1.4e-6 :upper 1.6e-6}]
+                                       [{:n 200 :impl :bar}
+                                        {:value 2.5e-6 :lower 2.3e-6 :upper 2.7e-6}]]}}}
+            result (common/prepare-line-chart-data extract)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (re-find #"mean" (:y-title first-metric)))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "yLower") data))
+          (is (every? #(contains? % "yUpper") data))
+          (doseq [d data]
+            (is (< (get d "yLower") (get d "y")))
+            (is (< (get d "y") (get d "yUpper")))))))
+
+    (testing "graceful degradation for mixed values with bounds"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:foo :bar]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :impl :foo}
+                                        {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                                       [{:n 100 :impl :bar} 2.0e-6]
+                                       [{:n 200 :impl :foo} 1.5e-6]
+                                       [{:n 200 :impl :bar}
+                                        {:value 2.5e-6 :lower 2.3e-6 :upper 2.7e-6}]]}}}
+            result (common/prepare-line-chart-data extract)
+            first-metric (first result)
+            data (:data first-metric)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (let [foo-100 (first (filter #(and (= "foo" (get % "impl"))
+                                           (= 100 (get % "x")))
+                                     data))
+              bar-100 (first (filter #(and (= "bar" (get % "impl"))
+                                           (= 100 (get % "x")))
+                                     data))]
+          (is (contains? foo-100 "yLower"))
+          (is (contains? foo-100 "yUpper"))
+          (is (not (contains? bar-100 "yLower")))
+          (is (not (contains? bar-100 "yUpper"))))))))
 
 ;;; Edge case tests for empty data and degenerate inputs.
 ;;; Verifies that detection helpers and preparation functions handle edge cases
@@ -947,7 +1015,114 @@
                                      {:coord {:n 200} :value 2.5e-6}]}}
             result (common/prepare-comparison-line-data comparison)
             {:keys [y-title]} (first result)]
-        (is (not (str/starts-with? y-title "mean ")))))))
+        (is (not (str/starts-with? y-title "mean ")))))
+
+    (testing "returns has-error-bounds? false for plain values"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100} :value 1.0e-6}
+                                     {:coord {:n 200} :value 1.5e-6}]
+                               :bar [{:coord {:n 100} :value 2.0e-6}
+                                     {:coord {:n 200} :value 2.5e-6}]}}
+            result (common/prepare-comparison-line-data comparison)
+            first-metric (first result)]
+        (is (false? (:has-error-bounds? first-metric)))
+        (is (every? #(not (contains? % "yLower")) (:data first-metric)))
+        (is (every? #(not (contains? % "yUpper")) (:data first-metric)))))
+
+    (testing "extracts error bounds for single-metric comparison"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100}
+                                      :value {:value 1.0e-6
+                                              :lower 0.9e-6
+                                              :upper 1.1e-6}}
+                                     {:coord {:n 200}
+                                      :value {:value 1.5e-6
+                                              :lower 1.4e-6
+                                              :upper 1.6e-6}}]
+                               :bar [{:coord {:n 100}
+                                      :value {:value 2.0e-6
+                                              :lower 1.8e-6
+                                              :upper 2.2e-6}}
+                                     {:coord {:n 200}
+                                      :value {:value 2.5e-6
+                                              :lower 2.3e-6
+                                              :upper 2.7e-6}}]}}
+            result (common/prepare-comparison-line-data comparison)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (re-find #"mean" (:y-title first-metric)))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "yLower") data))
+          (is (every? #(contains? % "yUpper") data))
+          (doseq [d data]
+            (is (< (get d "yLower") (get d "y")))
+            (is (< (get d "y") (get d "yUpper")))))))
+
+    (testing "extracts error bounds for multi-metric comparison"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:n 100}
+                                                 :value {:value 1.0e-6
+                                                         :lower 0.9e-6
+                                                         :upper 1.1e-6}}
+                                                {:coord {:n 200}
+                                                 :value {:value 1.5e-6
+                                                         :lower 1.4e-6
+                                                         :upper 1.6e-6}}]
+                                          :bar [{:coord {:n 100}
+                                                 :value {:value 2.0e-6
+                                                         :lower 1.8e-6
+                                                         :upper 2.2e-6}}
+                                                {:coord {:n 200}
+                                                 :value {:value 2.5e-6
+                                                         :lower 2.3e-6
+                                                         :upper 2.7e-6}}]}}}}
+            result (common/prepare-comparison-line-data comparison)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (re-find #"mean" (:y-title first-metric)))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "yLower") data))
+          (is (every? #(contains? % "yUpper") data)))))
+
+    (testing "graceful degradation for mixed values"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100}
+                                      :value {:value 1.0e-6
+                                              :lower 0.9e-6
+                                              :upper 1.1e-6}}
+                                     {:coord {:n 200} :value 1.5e-6}]
+                               :bar [{:coord {:n 100} :value 2.0e-6}
+                                     {:coord {:n 200}
+                                      :value {:value 2.5e-6
+                                              :lower 2.3e-6
+                                              :upper 2.7e-6}}]}}
+            result (common/prepare-comparison-line-data comparison)
+            first-metric (first result)
+            data (:data first-metric)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (let [foo-100 (first (filter #(and (= "foo" (get % "impl"))
+                                           (= 100 (get % "x")))
+                                     data))
+              foo-200 (first (filter #(and (= "foo" (get % "impl"))
+                                           (= 200 (get % "x")))
+                                     data))]
+          (is (contains? foo-100 "yLower"))
+          (is (contains? foo-100 "yUpper"))
+          (is (not (contains? foo-200 "yLower")))
+          (is (not (contains? foo-200 "yUpper"))))))))
 
 ;; Tests for ASCII treemap rendering functions.
 ;; Verifies ascii-bar generates proportional bars and render-ascii-treemap


### PR DESCRIPTION
## Summary

Add error bars to bar charts and confidence bands to line charts in domain viewers (portal and kindly) to display statistical uncertainty from benchmark data.

## Changes

- **Data Flow**: Updated `prepare-single-point-bar-data`, `prepare-comparison-bar-data`, `prepare-line-chart-data`, and `prepare-comparison-line-data` to flow error bounds (`:lower`/`:upper`) through to chart data as `valueLower`/`valueUpper` and `yLower`/`yUpper` fields
- **Bar Charts**: Added `bar-error-layer` function using Vega-Lite rule marks with tick caps for vertical error bars; `single-point-bar-chart-spec` and `comparison-bar-chart-spec` now show error bars when bounds data present
- **Line Charts**: Added `line-confidence-band-layer` function using Vega-Lite area marks for confidence bands; `domain-line-chart-spec` and `comparison-line-chart-spec` now show bands when bounds data present
- **Domain Plans**: Enabled `:with-error-bounds true` in both `extract-metrics` and `implementation-comparison` plans so charts display error bars/bands by default
- **Comparison Support**: Added `:with-error-bounds` option to `compare-by` and `domain-compare-fn` for implementation comparison error bounds
- **Factor Tables**: Updated `build-factor-table-single-metric` and `build-factor-table-multi-metric` to handle error bounds format
- **Error Bar Styling**: Dark gray (#333) color with horizontal tick caps at bounds for visibility
- **Tooltips**: Bar chart tooltips show lower/upper bounds when error data present
- **Graceful Degradation**: Charts render normally without error visualization when bounds data absent
- **Refactoring**: Extracted `values-have-error-bounds?` helper and deduplicated `get-numeric-value` function

## Commits

- feat(viewer): add error bounds to bar chart tooltip
- feat(viewer): improve bar chart error bars with dark color and tick caps
- fix(viewer): handle error bounds format in factor table functions
- feat(domain): add error bounds support to implementation-comparison plan
- refactor(viewer): deduplicate get-numeric-value function
- refactor(viewer): extract values-have-error-bounds? helper
- feat(domain-plans): enable error bounds in extract-metrics plan
- feat(viewer): add confidence bands to line charts
- feat(viewer): add error bars to bar charts
- feat(viewer): enable error bounds data flow in line chart preparation
- feat(viewer): enable error bounds data flow in bar chart preparation

## Test plan

- [x] Unit tests for bar chart data preparation with error bounds
- [x] Unit tests for line chart data preparation with error bounds
- [x] Integration test verifying error bounds flow end-to-end
- [x] Verify graceful degradation when no error bounds present
- [x] Vega-Lite schema validation for generated chart specs
- [x] Factor table functions handle error bounds format