### PR TITLE
feat: add median statistics with bootstrapped CI and percentile spread

### DIFF
--- a/bases/criterium/src/criterium/analyse.clj
+++ b/bases/criterium/src/criterium/analyse.clj
@@ -6,6 +6,7 @@
    [criterium.analyse.metrics-samples]
    [criterium.collect-plan :as collect-plan]
    [criterium.metric :as metric]
+   [criterium.util.bootstrap :as bootstrap]
    [criterium.util.debug :as debug]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]))
@@ -777,3 +778,28 @@
   ([] (allocation-treemap {}))
   ([opts]
    (allocation-analysis/treemap-fn opts)))
+
+(def bootstrap-stats
+  "Analysis function that adds bootstrap statistics to the result.
+
+  Computes bootstrap BCa confidence intervals for mean, variance, min, max,
+  and configurable quantiles (0.1, 0.25, 0.5, 0.75, 0.9 by default plus any
+  additional quantiles specified in opts).
+
+  Parameters:
+    opts - Optional map with keys:
+      :id                - Key for result in output (default: :bootstrap-stats)
+      :samples-id        - Key for source samples (default: :samples)
+      :metric-ids        - Set of metric ids to analyze (default: all quantitative)
+      :quantiles         - Additional quantiles beyond defaults (e.g., [0.99])
+      :estimate-quantiles - Confidence interval bounds (e.g., [0.025 0.975])
+      :bootstrap-size    - Number of bootstrap resamples (default: 80% of sample size)
+
+  The returned function:
+  - Takes a data map containing samples
+  - Returns the map with bootstrap statistics added under :id key
+  - For each metric, calculates bootstrapped estimates with BCa CIs for:
+    - mean, variance, min-val, max-val
+    - mean-plus-3sigma, mean-minus-3sigma
+    - quantiles (0.1, 0.25, 0.5, 0.75, 0.9 plus configured)"
+  bootstrap/bootstrap-stats)

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -54,6 +54,8 @@
              :outliers
              [:stats {}]
              [:stats {:samples-id :log-samples :id :log-stats}]
+             [:bootstrap-stats {:quantiles [0.99]
+                                :estimate-quantiles [0.025 0.975]}]
              :histogram
              :event-stats
              :allocation-summary
@@ -62,6 +64,7 @@
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
           [:stats {:stats-id :log-stats}]
+          :bootstrap-stats
           :quantiles
           :event-stats
           :outlier-counts

--- a/bases/criterium/src/criterium/util/bootstrap.clj
+++ b/bases/criterium/src/criterium/util/bootstrap.clj
@@ -84,7 +84,7 @@
   {:pre [(:quantiles opts)
          (:estimate-quantiles opts)]}
   (let [vs        (mapv double samples)
-        quantiles (into [0.25 0.5 0.75] (:quantiles opts))
+        quantiles (into [0.1 0.25 0.5 0.75 0.9] (:quantiles opts))
         stats-fn  (stats/stats-fn (stats/stats-fns quantiles))
         stats     (stats/bootstrap-bca
                    vs

--- a/bases/criterium/src/criterium/util/sampled_stats.clj
+++ b/bases/criterium/src/criterium/util/sampled_stats.clj
@@ -48,7 +48,6 @@
   {:pre [(have? seq path)
          (have? seq samples)
          (have? map? samples)]}
-  (have :quantiles config)
   (have (comp not :tail-quantile) config)
   (let [qs (vec (sort (into #{0.1 0.25 0.5 0.75 0.9} (:quantiles config))))
         vs (sort (samples-for-path samples path))]

--- a/bases/criterium/src/criterium/util/sampled_stats.clj
+++ b/bases/criterium/src/criterium/util/sampled_stats.clj
@@ -10,7 +10,8 @@
 (def stats-fns
   ;; called on sorted values
   (juxt
-   (pair-fn :mean  stats/mean)
+   (pair-fn :mean stats/mean)
+   (pair-fn :median (partial stats/quantile 0.5))
    (pair-fn :variance stats/variance)
    (pair-fn :min-val first)
    (pair-fn :max-val last)))
@@ -49,7 +50,7 @@
          (have? map? samples)]}
   (have :quantiles config)
   (have (comp not :tail-quantile) config)
-  (let [qs (into [0.25 0.5 0.75] (:quantiles config))
+  (let [qs (into [0.1 0.25 0.5 0.75 0.9] (:quantiles config))
         vs (sort (samples-for-path samples path))]
     (sample-quantiles qs vs)))
 

--- a/bases/criterium/src/criterium/util/sampled_stats.clj
+++ b/bases/criterium/src/criterium/util/sampled_stats.clj
@@ -50,7 +50,7 @@
          (have? map? samples)]}
   (have :quantiles config)
   (have (comp not :tail-quantile) config)
-  (let [qs (into [0.1 0.25 0.5 0.75 0.9] (:quantiles config))
+  (let [qs (vec (sort (into #{0.1 0.25 0.5 0.75 0.9} (:quantiles config))))
         vs (sort (samples-for-path samples path))]
     (sample-quantiles qs vs)))
 

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -155,6 +155,93 @@
                               :title (str "Mean " (name k))}]}
         :mark "rule"}]}]))
 
+(defn metric-bootstrap-boxplot-layer
+  "Build a boxplot-style layer showing median CI and spread percentiles.
+
+  Creates a rug-plot style annotation at the bottom of the histogram showing:
+  - Box: median confidence interval bounds
+  - Center line: median point estimate
+  - Whiskers: 10th and 90th percentiles
+
+  Returns a vector of Vega-Lite layer specs."
+  [transforms bootstrap-stats metric-config]
+  (let [quantiles (:quantiles bootstrap-stats)
+        p10 (get quantiles 0.1)
+        p50 (get quantiles 0.5)
+        p90 (get quantiles 0.9)]
+    (when (and p10 p50 p90)
+      (let [path (:path metric-config)
+            k (first path)
+            field-name (name k)
+            tform #(util/transform-sample-> % transforms)
+            ;; Extract point estimates
+            p10-val (tform (:point-estimate p10))
+            p50-val (tform (:point-estimate p50))
+            p90-val (tform (:point-estimate p90))
+            ;; Extract median CI bounds
+            median-ci (:estimate-quantiles p50)
+            ci-lower (when (seq median-ci)
+                       (tform (:value (first median-ci))))
+            ci-upper (when (seq median-ci)
+                       (tform (:value (second median-ci))))
+            ;; Fixed y position for the boxplot (below the histogram)
+            box-y 0
+            box-height -0.02]
+        [{:layer
+          (cond-> []
+            ;; Whisker from p10 to p90
+            true
+            (conj {:data {:values [{field-name p10-val
+                                    :end p90-val
+                                    :y box-y
+                                    :type "whisker"}]}
+                   :transform [{:calculate "'Spread (10th-90th)'" :as "layer"}]
+                   :encoding {:x {:field field-name
+                                  :type "quantitative"
+                                  :scale {:zero false}}
+                              :x2 {:field "end"
+                                   :type "quantitative"}
+                              :y {:datum box-y}
+                              :color {:field "layer" :type "nominal"
+                                      :legend {:orient "top-left" :offset 10}}}
+                   :mark {:type "rule"
+                          :strokeWidth 1}})
+
+            ;; Box for median CI
+            (and ci-lower ci-upper)
+            (conj {:data {:values [{field-name ci-lower
+                                    :end ci-upper
+                                    :y box-y
+                                    :y2 box-height
+                                    :type "ci-box"}]}
+                   :transform [{:calculate "'Median CI'" :as "layer"}]
+                   :encoding {:x {:field field-name
+                                  :type "quantitative"
+                                  :scale {:zero false}}
+                              :x2 {:field "end"
+                                   :type "quantitative"}
+                              :y {:datum box-y}
+                              :y2 {:datum box-height}
+                              :color {:field "layer" :type "nominal"
+                                      :legend {:orient "top-left" :offset 10}}}
+                   :mark {:type "rect"
+                          :opacity 0.6}})
+
+            ;; Median line
+            true
+            (conj {:data {:values [{field-name p50-val
+                                    :title "median"}]}
+                   :transform [{:calculate "'Median'" :as "layer"}]
+                   :encoding {:x {:field field-name
+                                  :type "quantitative"
+                                  :scale {:zero false}}
+                              :tooltip [{:field field-name
+                                         :title (str "Median " (name k))}]
+                              :color {:field "layer" :type "nominal"
+                                      :legend {:orient "top-left" :offset 10}}}
+                   :mark {:type "rule"
+                          :strokeWidth 2}}))}]))))
+
 ;;; Event markers
 
 (defn event-occurrence
@@ -269,9 +356,11 @@
   [data-map view chart-options]
   (let [histogram-id (or (:histogram-id view) :histograms)
         stats-id (or (:stats-id view) :stats)
+        bootstrap-stats-id (or (:bootstrap-stats-id view) :bootstrap-stats)
         quant-samples-id (or (:samples-id view) :samples)
         quant-samples (data-map quant-samples-id)
         stats (data-map stats-id)
+        bootstrap-stats-map (data-map bootstrap-stats-id)
         histograms-map (util/lookup-data data-map histogram-id)
         histograms (:histograms histograms-map)
         metrics-defs (-> (:metrics-defs quant-samples)
@@ -280,6 +369,10 @@
         metric-configs (metric/all-metric-configs metrics-defs)
         hist-transforms (util/get-transforms data-map histogram-id)
         stats-transforms (util/get-transforms data-map (:source-id stats))
+        bootstrap-transforms (when bootstrap-stats-map
+                               (util/get-transforms
+                                data-map
+                                (:source-id bootstrap-stats-map)))
         layer-num (volatile! 0)]
     {:data {:values []}
      :resolve {:scale {:x "independent"
@@ -299,15 +392,23 @@
                       (vswap!
                        layer-num
                        (fn [^long x] (unchecked-inc x))))]
-                    (when stats
-                      (->>
-                       (metric-sample-stats-layer
-                        stats-transforms
-                        (get-in (util/stats stats) (:path metric-config))
-                        metric-config
-                        (vswap!
-                         layer-num
-                         (fn [^long x] (unchecked-inc x)))))))}))
+                    (concat
+                     (when stats
+                       (->>
+                        (metric-sample-stats-layer
+                         stats-transforms
+                         (get-in (util/stats stats) (:path metric-config))
+                         metric-config
+                         (vswap!
+                          layer-num
+                          (fn [^long x] (unchecked-inc x))))))
+                     (when bootstrap-stats-map
+                       (->>
+                        (metric-bootstrap-boxplot-layer
+                         bootstrap-transforms
+                         (get-in (util/bootstrap bootstrap-stats-map)
+                                 (:path metric-config))
+                         metric-config)))))}))
                metric-configs)}))
 
 ;;; Percentile charts

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -180,12 +180,16 @@
             p10-val (:point-estimate p10)
             p50-val (:point-estimate p50)
             p90-val (:point-estimate p90)
-            ;; Extract median CI bounds
+            ;; Extract median CI bounds and alpha for label
             median-ci (:estimate-quantiles p50)
             ci-lower (when (seq median-ci)
                        (:value (first median-ci)))
             ci-upper (when (seq median-ci)
                        (:value (second median-ci)))
+            ci-alpha (when (seq median-ci)
+                       (:alpha (first median-ci)))
+            ci-level (when ci-alpha
+                       (long (* 100 (- 1.0 (* 2.0 (double ci-alpha))))))
             ;; Position boxplot at y=0 (histogram baseline)
             box-y 0]
         [{:layer
@@ -210,10 +214,13 @@
             ;; space. The -0.02 height creates a thin overlay that doesn't
             ;; obscure histogram bars while remaining visible.
             (and ci-lower ci-upper)
-            (conj (let [box-height -0.02]
+            (conj (let [box-height -0.02
+                        ci-label (if ci-level
+                                   (str "Median CI (" ci-level "%)")
+                                   "Median CI")]
                     {:data {:values [{field-name ci-lower
                                       :end ci-upper}]}
-                     :transform [{:calculate "'Median CI'" :as "layer"}]
+                     :transform [{:calculate (str "'" ci-label "'") :as "layer"}]
                      :encoding {:x {:field field-name
                                     :type "quantitative"
                                     :scale {:zero false}}
@@ -392,6 +399,15 @@
                        layer-num
                        (fn [^long x] (unchecked-inc x))))]
                     (concat
+                     ;; Bootstrap boxplot layers (median) first
+                     (when bootstrap-stats-map
+                       (->>
+                        (metric-bootstrap-boxplot-layer
+                         bootstrap-transforms
+                         (get-in (util/bootstrap bootstrap-stats-map)
+                                 (:path metric-config))
+                         metric-config)))
+                     ;; Stats layers (mean) last so mean line appears on top
                      (when stats
                        (->>
                         (metric-sample-stats-layer
@@ -400,14 +416,7 @@
                          metric-config
                          (vswap!
                           layer-num
-                          (fn [^long x] (unchecked-inc x))))))
-                     (when bootstrap-stats-map
-                       (->>
-                        (metric-bootstrap-boxplot-layer
-                         bootstrap-transforms
-                         (get-in (util/bootstrap bootstrap-stats-map)
-                                 (:path metric-config))
-                         metric-config)))))}))
+                          (fn [^long x] (unchecked-inc x))))))))}))
                metric-configs)}))
 
 ;;; Percentile charts

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -191,9 +191,7 @@
             ;; Whisker from p10 to p90
             true
             (conj {:data {:values [{field-name p10-val
-                                    :end p90-val
-                                    :y box-y
-                                    :type "whisker"}]}
+                                    :end p90-val}]}
                    :transform [{:calculate "'Spread (10th-90th)'" :as "layer"}]
                    :encoding {:x {:field field-name
                                   :type "quantitative"
@@ -212,10 +210,7 @@
             (and ci-lower ci-upper)
             (conj (let [box-height -0.02]
                     {:data {:values [{field-name ci-lower
-                                      :end ci-upper
-                                      :y box-y
-                                      :y2 box-height
-                                      :type "ci-box"}]}
+                                      :end ci-upper}]}
                      :transform [{:calculate "'Median CI'" :as "layer"}]
                      :encoding {:x {:field field-name
                                     :type "quantitative"

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -163,8 +163,11 @@
   - Center line: median point estimate
   - Whiskers: 10th and 90th percentiles
 
+  Bootstrap stats values are already scaled by bootstrap-stats-for, so no
+  additional transform is applied here.
+
   Returns a vector of Vega-Lite layer specs."
-  [transforms bootstrap-stats metric-config]
+  [_transforms bootstrap-stats metric-config]
   (let [quantiles (:quantiles bootstrap-stats)
         p10 (get quantiles 0.1)
         p50 (get quantiles 0.5)
@@ -173,17 +176,16 @@
       (let [path (:path metric-config)
             k (first path)
             field-name (name k)
-            tform #(util/transform-sample-> % transforms)
-            ;; Extract point estimates
-            p10-val (tform (:point-estimate p10))
-            p50-val (tform (:point-estimate p50))
-            p90-val (tform (:point-estimate p90))
+            ;; Values are already scaled by bootstrap-stats-for
+            p10-val (:point-estimate p10)
+            p50-val (:point-estimate p50)
+            p90-val (:point-estimate p90)
             ;; Extract median CI bounds
             median-ci (:estimate-quantiles p50)
             ci-lower (when (seq median-ci)
-                       (tform (:value (first median-ci))))
+                       (:value (first median-ci)))
             ci-upper (when (seq median-ci)
-                       (tform (:value (second median-ci))))
+                       (:value (second median-ci)))
             ;; Position boxplot at y=0 (histogram baseline)
             box-y 0]
         [{:layer

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -184,11 +184,8 @@
                        (tform (:value (first median-ci))))
             ci-upper (when (seq median-ci)
                        (tform (:value (second median-ci))))
-            ;; Position boxplot at y=0 (histogram baseline) extending slightly
-            ;; below into negative density space. The -0.02 height creates a thin
-            ;; overlay that doesn't obscure histogram bars while remaining visible.
-            box-y 0
-            box-height -0.02]
+            ;; Position boxplot at y=0 (histogram baseline)
+            box-y 0]
         [{:layer
           (cond-> []
             ;; Whisker from p10 to p90
@@ -209,25 +206,28 @@
                    :mark {:type "rule"
                           :strokeWidth 1}})
 
-            ;; Box for median CI
+            ;; Box for median CI - extends slightly below into negative density
+            ;; space. The -0.02 height creates a thin overlay that doesn't
+            ;; obscure histogram bars while remaining visible.
             (and ci-lower ci-upper)
-            (conj {:data {:values [{field-name ci-lower
-                                    :end ci-upper
-                                    :y box-y
-                                    :y2 box-height
-                                    :type "ci-box"}]}
-                   :transform [{:calculate "'Median CI'" :as "layer"}]
-                   :encoding {:x {:field field-name
-                                  :type "quantitative"
-                                  :scale {:zero false}}
-                              :x2 {:field "end"
-                                   :type "quantitative"}
-                              :y {:datum box-y}
-                              :y2 {:datum box-height}
-                              :color {:field "layer" :type "nominal"
-                                      :legend {:orient "top-left" :offset 10}}}
-                   :mark {:type "rect"
-                          :opacity 0.6}})
+            (conj (let [box-height -0.02]
+                    {:data {:values [{field-name ci-lower
+                                      :end ci-upper
+                                      :y box-y
+                                      :y2 box-height
+                                      :type "ci-box"}]}
+                     :transform [{:calculate "'Median CI'" :as "layer"}]
+                     :encoding {:x {:field field-name
+                                    :type "quantitative"
+                                    :scale {:zero false}}
+                                :x2 {:field "end"
+                                     :type "quantitative"}
+                                :y {:datum box-y}
+                                :y2 {:datum box-height}
+                                :color {:field "layer" :type "nominal"
+                                        :legend {:orient "top-left" :offset 10}}}
+                     :mark {:type "rect"
+                            :opacity 0.6}}))
 
             ;; Median line
             true

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -184,7 +184,9 @@
                        (tform (:value (first median-ci))))
             ci-upper (when (seq median-ci)
                        (tform (:value (second median-ci))))
-            ;; Fixed y position for the boxplot (below the histogram)
+            ;; Position boxplot at y=0 (histogram baseline) extending slightly
+            ;; below into negative density space. The -0.02 height creates a thin
+            ;; overlay that doesn't obscure histogram bars while remaining visible.
             box-y 0
             box-height -0.02]
         [{:layer

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -199,14 +199,15 @@
 (defmethod view/event-stats* :kindly
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)
-        event-stats-map (data-map event-stats-id)
-        metrics-defs (have (:metrics-defs event-stats-map))
-        stats (viewer-common/event-stats
-               metrics-defs
-               (util/event-stats event-stats-map))]
-    (when (seq stats)
-      (kindly-heading "Event stats")
-      (kindly-table stats))))
+        event-stats-map (data-map event-stats-id)]
+    (when event-stats-map
+      (let [metrics-defs (have (:metrics-defs event-stats-map))
+            stats (viewer-common/event-stats
+                   metrics-defs
+                   (util/event-stats event-stats-map))]
+        (when (seq stats)
+          (kindly-heading "Event stats")
+          (kindly-table stats))))))
 
 (defmethod view/outlier-significance* :kindly
   [_ {:keys [outlier-significance-id] :as _view} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -96,14 +96,15 @@
 (defmethod view/event-stats* :portal
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)
-        event-stats-map (data-map event-stats-id)
-        metrics-defs (have (:metrics-defs event-stats-map))
-        stats (viewer-common/event-stats
-               metrics-defs
-               (util/event-stats event-stats-map))]
-    (when (seq stats)
-      (heading "Event stats")
-      (portal-table stats))))
+        event-stats-map (data-map event-stats-id)]
+    (when event-stats-map
+      (let [metrics-defs (have (:metrics-defs event-stats-map))
+            stats (viewer-common/event-stats
+                   metrics-defs
+                   (util/event-stats event-stats-map))]
+        (when (seq stats)
+          (heading "Event stats")
+          (portal-table stats))))))
 
 (defmethod view/quantiles* :portal
   [_ {:keys [quantiles-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -56,14 +56,15 @@
 (defmethod view/event-stats* :pprint
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)
-        event-stats-map (data-map event-stats-id)
-        metrics-defs (:metrics-defs event-stats-map)
-        res (viewer-common/event-stats
-             metrics-defs
-             (util/event-stats event-stats-map))
-        ks (reduce into [] (map keys res))]
-    (when (seq res)
-      (pprint/print-table (distinct ks) res))))
+        event-stats-map (data-map event-stats-id)]
+    (when event-stats-map
+      (let [metrics-defs (:metrics-defs event-stats-map)
+            res (viewer-common/event-stats
+                 metrics-defs
+                 (util/event-stats event-stats-map))
+            ks (reduce into [] (map keys res))]
+        (when (seq res)
+          (pprint/print-table (distinct ks) res))))))
 
 (defmethod view/outlier-counts* :pprint
   [_ {:keys [outliers-id] :as _view} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.pprint :as pprint]
    [criterium.metric :as metric]
+   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
@@ -92,24 +93,28 @@
   (print-outlier-significances view data-map))
 
 (defn- format-bootstrap-estimate
-  "Format a BcaEstimate for display, returning a map with :value and :ci keys."
-  [estimate]
+  "Format a BcaEstimate for display, returning a map with :value and :ci keys.
+  Applies unit scaling based on metric-config dimension and scale."
+  [estimate metric-config]
   (when estimate
-    (let [quantiles (:estimate-quantiles estimate)
+    (let [{:keys [dimension scale]} metric-config
+          quantiles (:estimate-quantiles estimate)
           ci-lower (when (seq quantiles) (-> quantiles first :value))
-          ci-upper (when (seq quantiles) (-> quantiles second :value))]
-      {:value (:point-estimate estimate)
-       :ci-lower ci-lower
-       :ci-upper ci-upper})))
+          ci-upper (when (seq quantiles) (-> quantiles second :value))
+          point-est (:point-estimate estimate)
+          fmt-val (fn [v] (when v (format/format-value dimension (* scale v))))]
+      {:value (fmt-val point-est)
+       :ci-lower (fmt-val ci-lower)
+       :ci-upper (fmt-val ci-upper)})))
 
 (defn- bootstrap-stat-row
   "Create a row for the bootstrap stats table."
   [metric-config stat]
   (let [{:keys [mean quantiles]} stat
-        mean-fmt (format-bootstrap-estimate mean)
-        p10 (format-bootstrap-estimate (get quantiles 0.1))
-        p50 (format-bootstrap-estimate (get quantiles 0.5))
-        p90 (format-bootstrap-estimate (get quantiles 0.9))]
+        mean-fmt (format-bootstrap-estimate mean metric-config)
+        p10 (format-bootstrap-estimate (get quantiles 0.1) metric-config)
+        p50 (format-bootstrap-estimate (get quantiles 0.5) metric-config)
+        p90 (format-bootstrap-estimate (get quantiles 0.9) metric-config)]
     {:metric (:label metric-config)
      :mean (:value mean-fmt)
      :mean-ci-lower (:ci-lower mean-fmt)

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -91,6 +91,53 @@
   [_ view data-map]
   (print-outlier-significances view data-map))
 
+(defn- format-bootstrap-estimate
+  "Format a BcaEstimate for display, returning a map with :value and :ci keys."
+  [estimate]
+  (when estimate
+    (let [quantiles (:estimate-quantiles estimate)
+          ci-lower (when (seq quantiles) (-> quantiles first :value))
+          ci-upper (when (seq quantiles) (-> quantiles second :value))]
+      {:value (:point-estimate estimate)
+       :ci-lower ci-lower
+       :ci-upper ci-upper})))
+
+(defn- bootstrap-stat-row
+  "Create a row for the bootstrap stats table."
+  [metric-config stat]
+  (let [{:keys [mean quantiles]} stat
+        mean-fmt (format-bootstrap-estimate mean)
+        p10 (format-bootstrap-estimate (get quantiles 0.1))
+        p50 (format-bootstrap-estimate (get quantiles 0.5))
+        p90 (format-bootstrap-estimate (get quantiles 0.9))]
+    {:metric (:label metric-config)
+     :mean (:value mean-fmt)
+     :mean-ci-lower (:ci-lower mean-fmt)
+     :mean-ci-upper (:ci-upper mean-fmt)
+     :median (:value p50)
+     :median-ci-lower (:ci-lower p50)
+     :median-ci-upper (:ci-upper p50)
+     :p10 (:value p10)
+     :p90 (:value p90)}))
+
+(defmethod view/bootstrap-stats* :pprint
+  [_ {:keys [bootstrap-stats-id]} data-map]
+  (let [bootstrap-stats-id (or bootstrap-stats-id :bootstrap-stats)
+        bootstrap-map (data-map bootstrap-stats-id)
+        metrics-defs (:metrics-defs bootstrap-map)
+        metric-configs (metric/all-metric-configs metrics-defs)
+        bootstrap (util/bootstrap bootstrap-map)]
+    (when (seq metric-configs)
+      (println "\nBootstrap Statistics:")
+      (pprint/print-table
+       [:metric :mean :mean-ci-lower :mean-ci-upper
+        :median :median-ci-lower :median-ci-upper
+        :p10 :p90]
+       (for [m metric-configs
+             :let [stat (get-in bootstrap (:path m))]
+             :when stat]
+         (bootstrap-stat-row m stat))))))
+
 (defn- flatten-events [sample metrics-defs index]
   (reduce-kv
    (fn [res k metric-group]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -151,7 +151,7 @@
                (-> median-ci first :alpha)
                (-> median-ci second :alpha))))
     (println
-     (format "%36s: [%.3g %.3g] %s "
+     (format "%36s: [%.3g %.3g] %s"
              (str label " 3σ")
              (* scale (:point-estimate mean-minus-3sigma))
              (* scale (:point-estimate mean-plus-3sigma))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -140,7 +140,7 @@
              (* scale (-> mean-ci second :value))
              (-> mean-ci first :alpha)
              (-> mean-ci second :alpha)))
-    (when median-est
+    (when (and median-est (seq median-ci))
       (println
        (format "%36s: %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
                (str label " median")

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -106,7 +106,8 @@
   [metric
    {:keys [mean
            mean-minus-3sigma
-           mean-plus-3sigma]
+           mean-plus-3sigma
+           quantiles]
     minval :min-val
     :as stat}]
   (assert minval stat)
@@ -115,7 +116,11 @@
                        dimension
                        (* (:scale metric) (:point-estimate mean)))
         min-quantiles (:estimate-quantiles minval)
-        quantiles (:estimate-quantiles mean)
+        mean-ci (:estimate-quantiles mean)
+        median-est (get quantiles 0.5)
+        median-ci (:estimate-quantiles median-est)
+        p10-est (get quantiles 0.1)
+        p90-est (get quantiles 0.9)
         scale (* (:scale metric) scale)]
     (println
      (format "%36s: %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
@@ -131,16 +136,33 @@
              (str label " mean")
              (* scale (:point-estimate mean))
              units
-             (* scale (-> quantiles first :value))
-             (* scale (-> quantiles second :value))
-             (-> quantiles first :alpha)
-             (-> quantiles second :alpha)))
+             (* scale (-> mean-ci first :value))
+             (* scale (-> mean-ci second :value))
+             (-> mean-ci first :alpha)
+             (-> mean-ci second :alpha)))
+    (when median-est
+      (println
+       (format "%36s: %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
+               (str label " median")
+               (* scale (:point-estimate median-est))
+               units
+               (* scale (-> median-ci first :value))
+               (* scale (-> median-ci second :value))
+               (-> median-ci first :alpha)
+               (-> median-ci second :alpha))))
     (println
      (format "%36s: [%.3g %.3g] %s "
              (str label " 3σ")
              (* scale (:point-estimate mean-minus-3sigma))
              (* scale (:point-estimate mean-plus-3sigma))
-             units))))
+             units))
+    (when (and p10-est p90-est)
+      (println
+       (format "%36s: [%.3g %.3g] %s (10th-90th percentile)"
+               (str label " spread")
+               (* scale (:point-estimate p10-est))
+               (* scale (:point-estimate p90-est))
+               units)))))
 
 (defn print-bootstrap-stats
   [{:keys [bootstrap-stats-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -95,12 +95,13 @@
 (defmethod view/event-stats* :print
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)
-        event-stats-map (data-map event-stats-id)
-        metrics-defs (-> (:metrics-defs event-stats-map)
-                         (metric/filter-metrics
-                          (metric/type-pred :event)))
-        event-stats (util/event-stats event-stats-map)]
-    (print-event-stats metrics-defs event-stats)))
+        event-stats-map (data-map event-stats-id)]
+    (when event-stats-map
+      (let [metrics-defs (-> (:metrics-defs event-stats-map)
+                             (metric/filter-metrics
+                              (metric/type-pred :event)))
+            event-stats (util/event-stats event-stats-map)]
+        (print-event-stats metrics-defs event-stats)))))
 
 (defn print-bootstrap-stat
   [metric

--- a/bases/criterium/test/criterium/analyse_test.clj
+++ b/bases/criterium/test/criterium/analyse_test.clj
@@ -339,6 +339,7 @@
         (is (= {:min-val 1.0,
                 :max-val 3.0,
                 :mean 2.0,
+                :median 2.0,
                 :mean-plus-3sigma 5.0,
                 :variance 1.0,
                 :mean-minus-3sigma -1.0

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -22,6 +22,7 @@
     {:type         :criterium/stats
      :stats        {:elapsed-time
                     {:mean              100.0
+                     :median            100.0
                      :variance          16.0
                      :mean-plus-3sigma  112.0
                      :mean-minus-3sigma 88.0

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -244,6 +244,36 @@
          stats
          histogram)))
 
+(defn histogram-with-bootstrap-data-map
+  "Create a data-map suitable for histogram-vega-spec with boxplot overlay.
+
+  Includes bootstrap-stats with median (0.5) and spread (0.1, 0.9) quantiles
+  to exercise the boxplot overlay code path."
+  []
+  (let [base-map (histogram-data-map)
+        metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+    (assoc base-map
+           :bootstrap-stats
+           {:type :criterium/bootstrap
+            :bootstrap
+            {:elapsed-time
+             {:quantiles
+              {0.1 {:point-estimate 9.2
+                    :estimate-quantiles []}
+               0.25 {:point-estimate 9.5
+                     :estimate-quantiles []}
+               0.5 {:point-estimate 9.75
+                    :estimate-quantiles [{:quantile 0.025 :value 9.3}
+                                         {:quantile 0.975 :value 10.2}]}
+               0.75 {:point-estimate 10.0
+                     :estimate-quantiles []}
+               0.9 {:point-estimate 10.5
+                    :estimate-quantiles []}}}}
+            :metrics-defs metrics-defs
+            :transform collect-plan/identity-transforms
+            :batch-size 1
+            :source-id :samples})))
+
 (defn kde-data-map
   "Create a data-map suitable for kde-vega-spec testing."
   []

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -247,8 +247,10 @@
 (defn histogram-with-bootstrap-data-map
   "Create a data-map suitable for histogram-vega-spec with boxplot overlay.
 
-  Includes bootstrap-stats with median (0.5) and spread (0.1, 0.9) quantiles
-  to exercise the boxplot overlay code path."
+  Includes bootstrap-stats with complete bootstrap structure matching real
+  bootstrap output: mean, variance, min-val, mean-plus-3sigma, mean-minus-3sigma,
+  and quantiles (0.1, 0.25, 0.5, 0.75, 0.9). Exercises the boxplot overlay code
+  path with median CI and spread percentiles."
   []
   (let [base-map (histogram-data-map)
         metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
@@ -257,14 +259,29 @@
            {:type :criterium/bootstrap
             :bootstrap
             {:elapsed-time
-             {:quantiles
+             {:mean {:point-estimate 9.8
+                     :estimate-quantiles [{:value 9.5 :alpha 0.025}
+                                          {:value 10.1 :alpha 0.975}]}
+              :variance {:point-estimate 0.5
+                         :estimate-quantiles [{:value 0.3 :alpha 0.025}
+                                              {:value 0.8 :alpha 0.975}]}
+              :min-val {:point-estimate 9.0
+                        :estimate-quantiles [{:value 8.8 :alpha 0.025}
+                                             {:value 9.2 :alpha 0.975}]}
+              :mean-plus-3sigma {:point-estimate 11.9
+                                 :estimate-quantiles [{:value 11.1 :alpha 0.025}
+                                                      {:value 12.7 :alpha 0.975}]}
+              :mean-minus-3sigma {:point-estimate 7.7
+                                  :estimate-quantiles [{:value 6.9 :alpha 0.025}
+                                                       {:value 8.5 :alpha 0.975}]}
+              :quantiles
               {0.1 {:point-estimate 9.2
                     :estimate-quantiles []}
                0.25 {:point-estimate 9.5
                      :estimate-quantiles []}
                0.5 {:point-estimate 9.75
-                    :estimate-quantiles [{:quantile 0.025 :value 9.3}
-                                         {:quantile 0.975 :value 10.2}]}
+                    :estimate-quantiles [{:value 9.3 :alpha 0.025}
+                                         {:value 10.2 :alpha 0.975}]}
                0.75 {:point-estimate 10.0
                      :estimate-quantiles []}
                0.9 {:point-estimate 10.5

--- a/bases/criterium/test/criterium/util/bootstrap_test.clj
+++ b/bases/criterium/test/criterium/util/bootstrap_test.clj
@@ -8,7 +8,8 @@
    [criterium.util.invariant :refer [have]]
    [criterium.util.sampled-stats-test :as sampled-stats-test]
    [criterium.util.stats :as stats]
-   [criterium.util.well :as well]))
+   [criterium.util.well :as well]
+   [stats.interface :as stats-interface]))
 
 (deftest bootstrap-estimate-test
   (is (= [1.0 0.0 [1.0 1.0]]
@@ -187,3 +188,42 @@
                             :point-estimate))]
     (is (test-max-error 10.0 point 0.1 "mean")
         (str "Value: " point))))
+
+;; Verifies that all quantiles computed by bootstrap-stats-for share the same
+;; bootstrap resamples. This is critical for statistical validity - if quantiles
+;; were bootstrapped separately, they would use different resamples and lose
+;; the correlation structure of the data.
+(deftest bootstrap-quantiles-share-resamples-test
+  (testing "bootstrap-stats-for"
+    (testing "computes all quantiles from the same resamples"
+      ;; Track how many times stats-fn is invoked during bootstrap-sample.
+      ;; If all quantiles share resamples, the combined stats-fn should be
+      ;; called exactly bootstrap-size times (once per resample).
+      (let [invocation-count  (atom 0)
+            bootstrap-size    50
+            samples           (mapv double (range 101))
+            ;; Wrap stats-fn to track invocations
+            original-stats-fn stats-interface/stats-fn
+            tracking-stats-fn (fn [fs]
+                                (let [combined (original-stats-fn fs)]
+                                  (fn [vs]
+                                    (swap! invocation-count inc)
+                                    (combined vs))))]
+        (with-redefs [stats-interface/stats-fn tracking-stats-fn]
+          (bootstrap/bootstrap-stats-for
+           samples
+           {:estimate-quantiles [0.025 0.975]
+            :quantiles          [0.99]
+            :bootstrap-size     bootstrap-size}
+           sampled-stats-test/identity-transforms))
+        ;; The combined stats-fn should be called:
+        ;; - Once for the original estimate
+        ;; - Once per bootstrap resample (bootstrap-size times)
+        ;; - Once per jackknife sample (n times, where n = sample count)
+        ;; Total = 1 + bootstrap-size + n
+        (let [expected-calls (+ 1 bootstrap-size (count samples))]
+          (is (= expected-calls @invocation-count)
+              (str "Expected " expected-calls " stats-fn calls "
+                   "(1 estimate + " bootstrap-size " bootstrap + "
+                   (count samples) " jackknife), got " @invocation-count
+                   ". If higher, quantiles may be bootstrapped separately.")))))))

--- a/bases/criterium/test/criterium/util/sampled_stats_test.clj
+++ b/bases/criterium/test/criterium/util/sampled_stats_test.clj
@@ -18,7 +18,7 @@
          (sampled-stats/sample-quantiles [0.01 0.99] (range 101)))))
 
 (deftest stats-fns-test
-  (is (= [[:mean 50.0] [:variance 858.5] [:min-val 0] [:max-val 100]]
+  (is (= [[:mean 50.0] [:median 50] [:variance 858.5] [:min-val 0] [:max-val 100]]
          (sampled-stats/stats-fns (range 101)))))
 
 (defn batch-transforms [^long batch-size]
@@ -34,6 +34,7 @@
         stats (sampled-stats/stats-for
                samples {:quantiles [0.05 0.95]})]
     (is (= 1.0 (-> stats :mean)))
+    (is (= 1.0 (-> stats :median)))
     (is (= 0.0 (-> stats :variance))))
 
   (testing "stats on [0..100]"
@@ -41,6 +42,7 @@
           stats (sampled-stats/stats-for
                  samples {:quantiles [0.05 0.95]})]
       (is (= 50.0 (-> stats :mean)))
+      (is (= 50.0 (-> stats :median)))
       (is (= 858.5 (-> stats :variance)))
       (is (= 0.0 (-> stats :min-val)))
       (is (= 100.0 (-> stats :max-val)))))
@@ -50,6 +52,7 @@
           stats (sampled-stats/stats-for
                  samples {:quantiles [0.05 0.95]})]
       (is (= 50.0 (-> stats :mean)))
+      (is (= 50.0 (-> stats :median)))
       (is (= 858.5 (-> stats :variance)))
       (is (= 0.0 (-> stats :min-val)))
       (is (= 100.0 (-> stats :max-val)))))
@@ -59,6 +62,7 @@
           stats (sampled-stats/stats-for
                  samples {:quantiles [0.05 0.95]})]
       (is (= 9.5 (-> stats :mean)))
+      (is (= 9.5 (-> stats :median)))
       (test-max-error 0.3 (-> stats :variance) 1e-5)
       (is (= 9.0 (-> stats :min-val)))
       (is (= 10.0 (-> stats :max-val))))))
@@ -67,19 +71,23 @@
   (let [samples {[:v] (repeat 100 1)}
         quantiles (sampled-stats/quantiles-for
                    [:v] samples {:quantiles [0.05 0.95]})]
-    (is (= {0.25 1.0, 0.5 1.0, 0.75 1.0, 0.05 1.0, 0.95 1.0} quantiles)))
+    (is (= {0.1 1.0, 0.25 1.0, 0.5 1.0, 0.75 1.0, 0.9 1.0, 0.05 1.0, 0.95 1.0}
+           quantiles)))
 
   (testing "quantiles on [0..100]"
     (let [samples {[:v] (range 101)}
           quantiles (sampled-stats/quantiles-for
                      [:v] samples {:quantiles [0.05 0.95]})]
-      (is (= {0.25 25.0, 0.5 50.0, 0.75 75.0, 0.05 5.0, 0.95 95.0} quantiles))))
+      (is (= {0.1 10.0, 0.25 25.0, 0.5 50.0, 0.75 75.0, 0.9 90.0,
+              0.05 5.0, 0.95 95.0}
+             quantiles))))
 
   (testing "quantiles on (reverse [0..100])"
     (let [samples {[:v] (range 101)}
           quantiles (sampled-stats/quantiles-for
                      [:v] samples {:quantiles [0.05 0.95]})]
-      (is (= {0.25 25.0, 0.5 50.0, 0.75 75.0, 0.05 5.0, 0.95 95.0}
+      (is (= {0.1 10.0, 0.25 25.0, 0.5 50.0, 0.75 75.0, 0.9 90.0,
+              0.05 5.0, 0.95 95.0}
              quantiles)))))
 
 (deftest stats-for-test-property-1

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -973,6 +973,131 @@
             (str "comparison line chart with confidence bands failed: "
                  (pr-str (:errors result))))))))
 
+;;; Boxplot layer tests.
+;;; Verifies boxplot layer generation for histogram median/spread overlays.
+
+(def identity-transforms
+  "Identity transforms for testing - `:sample->` must be a list of functions."
+  {:sample-> (list identity)
+   :->sample [identity]})
+
+(def sample-bootstrap-stats
+  "Sample bootstrap stats with median (0.5) and spread (0.1, 0.9) quantiles."
+  {:quantiles
+   {0.1 {:point-estimate 90.0
+         :estimate-quantiles []}
+    0.5 {:point-estimate 100.0
+         :estimate-quantiles [{:quantile 0.025 :value 95.0}
+                              {:quantile 0.975 :value 105.0}]}
+    0.9 {:point-estimate 110.0
+         :estimate-quantiles []}}})
+
+(def sample-metric-config
+  "Sample metric config for elapsed-time."
+  {:path [:elapsed-time]
+   :label "Elapsed Time"
+   :type :quantitative})
+
+(deftest metric-bootstrap-boxplot-layer-test
+  ;; Tests boxplot layer generation for histogram overlays showing
+  ;; median CI and 10th/90th percentile spread.
+  (testing "metric-bootstrap-boxplot-layer"
+    (testing "returns vector of layers when quantiles present"
+      (let [result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms sample-bootstrap-stats sample-metric-config)]
+        (is (vector? result))
+        (is (= 1 (count result)))
+        (is (map? (first result)))
+        (is (contains? (first result) :layer))))
+
+    (testing "contains whisker, CI box, and median line layers"
+      (let [result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms sample-bootstrap-stats sample-metric-config)
+            inner-layers (get-in result [0 :layer])]
+        (is (= 3 (count inner-layers)))
+        ;; Whisker layer (p10 to p90)
+        (let [whisker (first inner-layers)]
+          (is (= "rule" (get-in whisker [:mark :type])))
+          (is (= 1 (get-in whisker [:mark :strokeWidth]))))
+        ;; CI box layer
+        (let [ci-box (second inner-layers)]
+          (is (= "rect" (get-in ci-box [:mark :type])))
+          (is (= 0.6 (get-in ci-box [:mark :opacity]))))
+        ;; Median line layer
+        (let [median-line (nth inner-layers 2)]
+          (is (= "rule" (get-in median-line [:mark :type])))
+          (is (= 2 (get-in median-line [:mark :strokeWidth]))))))
+
+    (testing "whisker spans from p10 to p90"
+      (let [result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms sample-bootstrap-stats sample-metric-config)
+            whisker (get-in result [0 :layer 0])
+            data (get-in whisker [:data :values 0])]
+        ;; Vega-Lite data uses string keys
+        (is (= 90.0 (get data "elapsed-time")))
+        (is (= 110.0 (get data :end)))))
+
+    (testing "CI box spans median confidence interval"
+      (let [result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms sample-bootstrap-stats sample-metric-config)
+            ci-box (get-in result [0 :layer 1])
+            data (get-in ci-box [:data :values 0])]
+        ;; Vega-Lite data uses string keys for field names
+        (is (= 95.0 (get data "elapsed-time")))
+        (is (= 105.0 (get data :end)))))
+
+    (testing "median line at point estimate"
+      (let [result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms sample-bootstrap-stats sample-metric-config)
+            median-line (get-in result [0 :layer 2])
+            data (get-in median-line [:data :values 0])]
+        ;; Vega-Lite data uses string keys for field names
+        (is (= 100.0 (get data "elapsed-time")))))
+
+    (testing "applies transforms to values"
+      (let [scale-transforms {:sample-> (list (fn [^double v] (/ v 1e9)))
+                              :->sample [identity]}
+            result (charts/metric-bootstrap-boxplot-layer
+                    scale-transforms sample-bootstrap-stats sample-metric-config)
+            whisker (get-in result [0 :layer 0])
+            whisker-data (get-in whisker [:data :values 0])]
+        ;; Values should be scaled by 1e-9
+        (is (< (double (get whisker-data "elapsed-time")) 1e-6))))
+
+    (testing "returns nil when quantiles missing"
+      (let [missing-quantiles {:quantiles {}}
+            result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms missing-quantiles sample-metric-config)]
+        (is (nil? result))))
+
+    (testing "returns nil when p50 missing"
+      (let [missing-p50 {:quantiles {0.1 {:point-estimate 90.0}
+                                     0.9 {:point-estimate 110.0}}}
+            result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms missing-p50 sample-metric-config)]
+        (is (nil? result))))
+
+    (testing "omits CI box when median CI empty"
+      (let [no-ci {:quantiles
+                   {0.1 {:point-estimate 90.0}
+                    0.5 {:point-estimate 100.0
+                         :estimate-quantiles []}
+                    0.9 {:point-estimate 110.0}}}
+            result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms no-ci sample-metric-config)
+            inner-layers (get-in result [0 :layer])]
+        ;; Only whisker and median line (no CI box)
+        (is (= 2 (count inner-layers)))
+        (is (= "rule" (get-in (first inner-layers) [:mark :type])))
+        (is (= "rule" (get-in (second inner-layers) [:mark :type])))))
+
+    (testing "includes layer transforms for legend"
+      (let [result (charts/metric-bootstrap-boxplot-layer
+                    identity-transforms sample-bootstrap-stats sample-metric-config)
+            whisker (get-in result [0 :layer 0])]
+        (is (some? (get-in whisker [:transform])))
+        (is (some #(contains? % :calculate) (get-in whisker [:transform])))))))
+
 (deftest treemap-vega-spec-schema-validation-test
   ;; Validates treemap-vega-spec output against Vega v5 schema.
   ;; Tests treemap visualization for allocation data.

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -1068,15 +1068,15 @@
         ;; Vega-Lite data uses string keys for field names
         (is (= 100.0 (get data "elapsed-time")))))
 
-    (testing "applies transforms to values"
+    (testing "ignores transforms (values are pre-scaled by bootstrap-stats-for)"
       (let [scale-transforms {:sample-> (list (fn [^double v] (/ v 1e9)))
                               :->sample [identity]}
             result (charts/metric-bootstrap-boxplot-layer
                     scale-transforms sample-bootstrap-stats sample-metric-config)
             whisker (get-in result [0 :layer 0])
             whisker-data (get-in whisker [:data :values 0])]
-        ;; Values should be scaled by 1e-9
-        (is (< (double (get whisker-data "elapsed-time")) 1e-6))))
+        ;; Values remain unchanged - transforms not applied
+        (is (= 90.0 (double (get whisker-data "elapsed-time"))))))
 
     (testing "returns nil when quantiles missing"
       (let [missing-quantiles {:quantiles {}}

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -145,6 +145,20 @@
             (str "histogram-vega-spec validation failed: "
                  (pr-str (:errors result))))))))
 
+(deftest histogram-with-boxplot-schema-validation-test
+  ;; Validates histogram-vega-spec with boxplot overlay against Vega-Lite v6 schema.
+  ;; Tests histogram with bootstrap-stats for median CI and spread percentiles.
+  (testing "histogram-vega-spec"
+    (testing "produces valid Vega-Lite spec with boxplot overlay"
+      (let [data-map (test-data/histogram-with-bootstrap-data-map)
+            view {}
+            chart-options {:width 400 :height 300}
+            spec (charts/histogram-vega-spec data-map view chart-options)
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "histogram-vega-spec with boxplot validation failed: "
+                 (pr-str (:errors result))))))))
+
 (deftest kde-vega-spec-schema-validation-test
   ;; Validates kde-vega-spec output against Vega-Lite v6 schema.
   ;; Tests KDE density curve visualization.

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -3,9 +3,11 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
+   [criterium.collect-plan :as collect-plan]
    [criterium.collector.metrics]
    [criterium.test-data :as test-data]
    [criterium.test-utils :refer [trimmed-lines]]
+   [criterium.util.bootstrap :as bootstrap]
    [criterium.view :as view]
    [criterium.viewer.pprint]))
 
@@ -513,3 +515,35 @@
                                                {:my-modes modes-data}))]
         (is (str/includes? output "Mode count"))
         (is (str/includes? output "2"))))))
+
+(deftest pprint-bootstrap-stats-test
+  ;; Tests view/bootstrap-stats* pprint multimethod for table output format.
+  ;; Verifies: column headers for mean/median/spread, CI bounds, percentiles.
+  (testing "bootstrap-stats*"
+    (testing "displays table with mean, median, CI bounds, and percentiles"
+      (is (= [""
+              "Bootstrap Statistics:"
+              ""
+              "|      :metric | :mean | :mean-ci-lower | :mean-ci-upper | :median | :median-ci-lower | :median-ci-upper | :p10 | :p90 |"
+              "|--------------+-------+----------------+----------------+---------+------------------+------------------+------+------|"
+              "| Elapsed Time |   1.0 |            1.0 |            1.0 |     1.0 |              1.0 |              1.0 |  1.0 |  1.0 |"]
+             (let [data-map
+                   {:samples
+                    {:type :criterium/metrics-samples
+                     :metric->values {[:elapsed-time] [1 1 1]}
+                     :metrics-defs (select-keys
+                                    (criterium.collector.metrics/metrics)
+                                    [:elapsed-time])
+                     :transform collect-plan/identity-transforms
+                     :batch-size 1
+                     :eval-count 1
+                     :elapsed-time 1}}
+                   bootstrap-fn (bootstrap/bootstrap-stats
+                                 {:quantiles [0.025 0.975]
+                                  :estimate-quantiles [0.025 0.975]})
+                   view-fn (view/bootstrap-stats {})]
+               (trimmed-lines
+                (with-out-str
+                  (->> data-map
+                       bootstrap-fn
+                       (view-fn :pprint))))))))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -518,15 +518,16 @@
 
 (deftest pprint-bootstrap-stats-test
   ;; Tests view/bootstrap-stats* pprint multimethod for table output format.
-  ;; Verifies: column headers for mean/median/spread, CI bounds, percentiles.
+  ;; Verifies: column headers for mean/median/spread, CI bounds, percentiles,
+  ;; and that values are displayed with SI unit scaling.
   (testing "bootstrap-stats*"
     (testing "displays table with mean, median, CI bounds, and percentiles"
       (is (= [""
               "Bootstrap Statistics:"
               ""
-              "|      :metric | :mean | :mean-ci-lower | :mean-ci-upper | :median | :median-ci-lower | :median-ci-upper | :p10 | :p90 |"
-              "|--------------+-------+----------------+----------------+---------+------------------+------------------+------+------|"
-              "| Elapsed Time |   1.0 |            1.0 |            1.0 |     1.0 |              1.0 |              1.0 |  1.0 |  1.0 |"]
+              "|      :metric |   :mean | :mean-ci-lower | :mean-ci-upper | :median | :median-ci-lower | :median-ci-upper |    :p10 |    :p90 |"
+              "|--------------+---------+----------------+----------------+---------+------------------+------------------+---------+---------|"
+              "| Elapsed Time | 1.00 ns |        1.00 ns |        1.00 ns | 1.00 ns |          1.00 ns |          1.00 ns | 1.00 ns | 1.00 ns |"]
              (let [data-map
                    {:samples
                     {:type :criterium/metrics-samples

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -110,60 +110,108 @@
                        (view-stats :print))))))))))
 
 (deftest print-booststrap-stat-test
+  ;; Tests print-bootstrap-stat function for bootstrap statistics display.
+  ;; Covers: min, mean, median with CIs, 3σ range, and spread (10th-90th percentile).
   (testing "print-bootstrap-stat"
-    (is (= ["Elapsed Time min: 16.0 ns CI [9.00 25.0] (0.050 0.950)"
-            "Elapsed Time mean: 100 ns CI [95.0 105] (0.050 0.950)"
-            "Elapsed Time 3σ: [76.0 124] ns"]
-           (trimmed-lines
-            (with-out-str
-              (print/print-bootstrap-stat
-               {:scale 1e-9 :dimension :time :path [:elapsed-time]
-                :label "Elapsed Time"}
-               {:mean {:point-estimate 100.0
-                       :estimate-quantiles
-                       [{:value 95.0 :alpha 0.05}
-                        {:value 105.0 :alpha 0.95}]}
-                :variance {:point-estimate 16.0
-                           :estimate-quantiles
-                           [{:value 9.0 :alpha 0.05}
-                            {:value 25.0 :alpha 0.95}]}
-                :min-val {:point-estimate 16.0
-                          :estimate-quantiles
-                          [{:value 9.0 :alpha 0.05}
-                           {:value 25.0 :alpha 0.95}]}
-                :mean-plus-3sigma {:point-estimate 124.0
-                                   :estimate-quantiles
-                                   [{:value 9.0 :alpha 0.05}
-                                    {:value 25.0 :alpha 0.95}]}
-                :mean-minus-3sigma {:point-estimate 76.0
-                                    :estimate-quantiles
-                                    [{:value 9.0 :alpha 0.05}
-                                     {:value 25.0 :alpha 0.95}]}})))))
-    (is (= ["Elapsed Time min: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
-            "Elapsed Time mean: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
-            "Elapsed Time median: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
-            "Elapsed Time 3σ: [1.00 1.00] ns"
-            "Elapsed Time spread: [1.00 1.00] ns (10th-90th percentile)"]
-           (let [data-map
-                 {:samples
-                  {:type :criterium/collected-metrics-samples
-                   :metric->values {[:elapsed-time] [1 1 1]}
-                   :metrics-defs (select-keys
-                                  (metrics/metrics)
-                                  [:elapsed-time])
-                   :transform collect-plan/identity-transforms
-                   :batch-size 1
-                   :eval-count 1
-                   :elapsed-time 1}}
-                 bootstrap (bootstrap/bootstrap-stats
-                            {:quantiles [0.025 0.975]
-                             :estimate-quantiles [0.025 0.975]})
-                 view (view/bootstrap-stats {})]
+    (testing "without quantiles only prints min, mean, and 3σ"
+      (is (= ["Elapsed Time min: 16.0 ns CI [9.00 25.0] (0.050 0.950)"
+              "Elapsed Time mean: 100 ns CI [95.0 105] (0.050 0.950)"
+              "Elapsed Time 3σ: [76.0 124] ns"]
              (trimmed-lines
               (with-out-str
-                (->> data-map
-                     bootstrap
-                     (view :print)))))))))
+                (print/print-bootstrap-stat
+                 {:scale 1e-9 :dimension :time :path [:elapsed-time]
+                  :label "Elapsed Time"}
+                 {:mean {:point-estimate 100.0
+                         :estimate-quantiles
+                         [{:value 95.0 :alpha 0.05}
+                          {:value 105.0 :alpha 0.95}]}
+                  :variance {:point-estimate 16.0
+                             :estimate-quantiles
+                             [{:value 9.0 :alpha 0.05}
+                              {:value 25.0 :alpha 0.95}]}
+                  :min-val {:point-estimate 16.0
+                            :estimate-quantiles
+                            [{:value 9.0 :alpha 0.05}
+                             {:value 25.0 :alpha 0.95}]}
+                  :mean-plus-3sigma {:point-estimate 124.0
+                                     :estimate-quantiles
+                                     [{:value 9.0 :alpha 0.05}
+                                      {:value 25.0 :alpha 0.95}]}
+                  :mean-minus-3sigma {:point-estimate 76.0
+                                      :estimate-quantiles
+                                      [{:value 9.0 :alpha 0.05}
+                                       {:value 25.0 :alpha 0.95}]}}))))))
+    (testing "with quantiles prints median and spread"
+      (is (= ["Elapsed Time min: 80.0 ns CI [75.0 85.0] (0.025 0.975)"
+              "Elapsed Time mean: 100 ns CI [95.0 105] (0.025 0.975)"
+              "Elapsed Time median: 98.0 ns CI [93.0 103] (0.025 0.975)"
+              "Elapsed Time 3σ: [76.0 124] ns"
+              "Elapsed Time spread: [85.0 115] ns (10th-90th percentile)"]
+             (trimmed-lines
+              (with-out-str
+                (print/print-bootstrap-stat
+                 {:scale 1e-9 :dimension :time :path [:elapsed-time]
+                  :label "Elapsed Time"}
+                 {:mean {:point-estimate 100.0
+                         :estimate-quantiles
+                         [{:value 95.0 :alpha 0.025}
+                          {:value 105.0 :alpha 0.975}]}
+                  :variance {:point-estimate 16.0
+                             :estimate-quantiles
+                             [{:value 9.0 :alpha 0.025}
+                              {:value 25.0 :alpha 0.975}]}
+                  :min-val {:point-estimate 80.0
+                            :estimate-quantiles
+                            [{:value 75.0 :alpha 0.025}
+                             {:value 85.0 :alpha 0.975}]}
+                  :mean-plus-3sigma {:point-estimate 124.0
+                                     :estimate-quantiles
+                                     [{:value 9.0 :alpha 0.025}
+                                      {:value 25.0 :alpha 0.975}]}
+                  :mean-minus-3sigma {:point-estimate 76.0
+                                      :estimate-quantiles
+                                      [{:value 9.0 :alpha 0.025}
+                                       {:value 25.0 :alpha 0.975}]}
+                  :quantiles
+                  {0.1 {:point-estimate 85.0
+                        :estimate-quantiles
+                        [{:value 80.0 :alpha 0.025}
+                         {:value 90.0 :alpha 0.975}]}
+                   0.5 {:point-estimate 98.0
+                        :estimate-quantiles
+                        [{:value 93.0 :alpha 0.025}
+                         {:value 103.0 :alpha 0.975}]}
+                   0.9 {:point-estimate 115.0
+                        :estimate-quantiles
+                        [{:value 110.0 :alpha 0.025}
+                         {:value 120.0 :alpha 0.975}]}}}))))))
+    (testing "via bootstrap pipeline with degenerate data"
+      (is (= ["Elapsed Time min: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
+              "Elapsed Time mean: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
+              "Elapsed Time median: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
+              "Elapsed Time 3σ: [1.00 1.00] ns"
+              "Elapsed Time spread: [1.00 1.00] ns (10th-90th percentile)"]
+             (let [data-map
+                   {:samples
+                    {:type :criterium/collected-metrics-samples
+                     :metric->values {[:elapsed-time] [1 1 1]}
+                     :metrics-defs (select-keys
+                                    (metrics/metrics)
+                                    [:elapsed-time])
+                     :transform collect-plan/identity-transforms
+                     :batch-size 1
+                     :eval-count 1
+                     :elapsed-time 1}}
+                   bootstrap (bootstrap/bootstrap-stats
+                              {:quantiles [0.025 0.975]
+                               :estimate-quantiles [0.025 0.975]})
+                   view (view/bootstrap-stats {})]
+               (trimmed-lines
+                (with-out-str
+                  (->> data-map
+                       bootstrap
+                       (view :print))))))))))
 
 (deftest print-samples-test
   (testing "print-samples"

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -141,7 +141,9 @@
                                      {:value 25.0 :alpha 0.95}]}})))))
     (is (= ["Elapsed Time min: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
             "Elapsed Time mean: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
-            "Elapsed Time 3σ: [1.00 1.00] ns"]
+            "Elapsed Time median: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
+            "Elapsed Time 3σ: [1.00 1.00] ns"
+            "Elapsed Time spread: [1.00 1.00] ns (10th-90th percentile)"]
            (let [data-map
                  {:samples
                   {:type :criterium/collected-metrics-samples

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -281,7 +281,9 @@ bench-plans/knuth-histogram
 ^:kindly/hide-code
 (bench-display
  (bench/bench (reduce + (range 1000))
-              :viewer [:print {:show-medcouple true}]
+              :viewer :print
+              :view (conj (:view bench-plans/log-histogram)
+                          [:outlier-counts {:show-medcouple true}])
               :bench-plan bench-plans/log-histogram))
 
 ;; Medcouple interpretation:


### PR DESCRIPTION
## Summary

Add median statistics with bootstrapped confidence interval and 10th/90th percentile spread indicators to criterium's analysis and viewing pipeline.

### Changes

**Statistics:**
- Add median calculation to non-bootstrap `sampled-stats/stats-for`
- Extend default bootstrap quantiles to include 0.1 and 0.9 (10th/90th percentiles)
- Preserve single-pass bootstrap resampling so all quantiles share the same samples

**Viewers:**
- Print viewer: display median with CI and percentile spread range
- PPrint viewer: include median and spread in structured output with unit scaling
- Portal/Kindly histogram: add boxplot whisker overlay showing median CI and percentile spread

**Tests:**
- Add test verifying all quantiles share bootstrap resamples
- Add schema validation for histogram with boxplot overlay Vega spec
- Add viewer output tests for median/spread display

## Commits

- feat(stats): add median statistics with bootstrapped CI and 10th/90th percentiles
- feat(viewer): add unit scaling to pprint bootstrap-stats output
- fix(viewer): improve histogram overlay and handle missing event-stats
- fix(sampled-stats): allow empty quantiles config
- Various test and refactoring improvements