### PR TITLE
refactor(agent): make agent.cpp testable with GoogleTest + GMock

### DIFF
--- a/.github/workflows/agent-cpp.yml
+++ b/.github/workflows/agent-cpp.yml
@@ -50,6 +50,10 @@ jobs:
       working-directory: agent-cpp
       run: cmake --build build
 
+    - name: Run C++ tests
+      working-directory: agent-cpp
+      run: ctest --test-dir build --output-on-failure
+
     - name: Copy library to expected location
       working-directory: agent-cpp
       run: cp build/libcriterium.so .
@@ -97,6 +101,10 @@ jobs:
       working-directory: agent-cpp
       run: cmake --build build
 
+    - name: Run C++ tests (ARM64)
+      working-directory: agent-cpp
+      run: ctest --test-dir build --output-on-failure
+
     - name: Copy ARM64 library to expected location
       working-directory: agent-cpp
       run: cp build/libcriterium.dylib .
@@ -132,6 +140,10 @@ jobs:
     - name: Build agent-cpp (x86_64)
       working-directory: agent-cpp
       run: cmake --build build
+
+    - name: Run C++ tests (x86_64)
+      working-directory: agent-cpp
+      run: ctest --test-dir build --output-on-failure
 
     - name: Copy x86_64 library to expected location
       working-directory: agent-cpp

--- a/agent-cpp/CMakeLists.txt
+++ b/agent-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -7,23 +7,23 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #   cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64
 #   cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64
 
+project(criterium)
+
+# Find clang-tidy for use on our targets only (not dependencies)
 find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
-if(CLANG_TIDY_EXE)
-    set(CMAKE_CXX_CLANG_TIDY
-        ${CLANG_TIDY_EXE}
-    )
-else()
+if(NOT CLANG_TIDY_EXE)
     # On mac, this can be installed with `brew install llvm`
     message(WARNING "clang-tidy not found")
 endif()
-
-project(criterium)
 
 # Debug configuration
 option(DEBUG "Enable debug mode" OFF)
 if(DEBUG)
     add_definitions(-DDEBUG)
 endif()
+
+# Testing option
+option(BUILD_TESTS "Build tests" ON)
 
 # Warning flags - treat warnings as errors in Release builds
 set(WARNING_FLAGS -Wall -Wextra -Wpedantic)
@@ -43,3 +43,22 @@ include_directories(${JNI_INCLUDE_DIRS})
 
 add_library(criterium SHARED ${sources})
 target_compile_options(criterium PRIVATE ${WARNING_FLAGS})
+if(CLANG_TIDY_EXE)
+    set_target_properties(criterium PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+endif()
+
+# Testing with GoogleTest
+if(BUILD_TESTS)
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+    )
+    # Prevent GoogleTest from overriding compiler/linker options
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,5 +1,6 @@
 #include "jni.h"
 #include "include/alloc_rec.h"
+#include "include/jvmti_operations.h"
 #include "include/message_queue.h"
 #include "include/utils.h"
 #include <algorithm>
@@ -363,10 +364,16 @@ class AgentContext {
 
 private:
   jvmtiEnv* jvmti = nullptr;
+  std::unique_ptr<criterium::IJvmtiOperations> jvmti_ops_;
 
   static jvmtiEnv* get_jvmti() { return getInstance().jvmti; }
+  static criterium::IJvmtiOperations& get_jvmti_ops() {
+    return *getInstance().jvmti_ops_;
+  }
 
 public:
+  criterium::IJvmtiOperations& jvmti_ops() { return *jvmti_ops_; }
+
   template <typename T>
   class allocated  {
     T _ptr;
@@ -377,7 +384,10 @@ public:
     allocated &operator=(allocated &&) = delete;
     allocated(allocated<T> &&other) noexcept
         : _ptr(std::exchange(other._ptr, static_cast<T>(0))) {}
-    ~allocated() { get_jvmti()->Deallocate((unsigned char*)_ptr);}
+    ~allocated() {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      get_jvmti_ops().deallocate(reinterpret_cast<unsigned char*>(_ptr));
+    }
     operator T& () { return _ptr; }
     T* operator & () { return &_ptr; }
   };
@@ -441,6 +451,8 @@ public:
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     jvm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION_1_0);
+
+    jvmti_ops_ = std::make_unique<criterium::JvmtiOperations>(jvmti);
 
     jvmti->CreateRawMonitor("tag_lock", &tag_lock);
 
@@ -509,24 +521,17 @@ public:
     message_queue.push(Command{sync_state});
   }
 
-  void sampled_object_alloc(jvmtiEnv* jvmti, JNIEnv* env,
-			    jthread thread, jobject object,
-			    jclass object_klass, jlong size) {
+  void sampled_object_alloc([[maybe_unused]] jvmtiEnv* jvmti_env, JNIEnv* env,
+                            jthread thread, jobject object,
+                            jclass object_klass, jlong size) {
     auto tag = next_tag();
-    auto err = jvmti->SetTag(object, tag);
-    if (err != JVMTI_ERROR_NONE) {
-      std::cout << "Failed to tag object: " << err << '\n';
-      debug_print_jvmti_err(err);
-    }
+    jvmti_ops_->set_tag(object, tag);
 
     // Capture stack trace synchronously while still on the allocating thread
     std::array<jvmtiFrameInfo, MAX_FRAMES> frames = {};
     jint frame_count = 0;
-    auto stack_err = jvmti->GetStackTrace(thread, 0, MAX_FRAMES,
-                                          frames.data(), &frame_count);
-    if (stack_err != JVMTI_ERROR_NONE) {
-      DEBUG_PRINTLN("Failed to get stack trace: " << stack_err);
-      debug_print_jvmti_err(stack_err);
+    if (!jvmti_ops_->get_stack_trace(thread, 0, MAX_FRAMES,
+                                     frames.data(), &frame_count)) {
       frame_count = 0;
     }
 
@@ -561,89 +566,38 @@ public:
   }
 
   bool get_class_signature(jclass klass, char** class_sig) {
-    auto err = jvmti->GetClassSignature(klass, class_sig, NULL);
-    if ( err != 0) {
-      std::cout << "Failed to get class name\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+    return jvmti_ops_->get_class_signature(klass, class_sig);
   }
 
   bool get_source_file_name(jclass klass, char** source_name) {
-    auto err = jvmti->GetSourceFileName(klass, source_name);
-    if (err != 0) {
-      std::cout << "Failed to get source file name\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+    return jvmti_ops_->get_source_file_name(klass, source_name);
   }
 
-  bool get_method_declaring_class(jmethodID method,
-                                         jclass* declaring_class) {
-    auto err = jvmti->GetMethodDeclaringClass(method, declaring_class);
-    if (err != 0) {
-      std::cout << "Failed to get method declaring class\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+  bool get_method_declaring_class(jmethodID method, jclass* declaring_class) {
+    return jvmti_ops_->get_method_declaring_class(method, declaring_class);
   }
 
   bool get_method_name(jmethodID method, char** method_name) {
-    auto err = (jvmti)->GetMethodName(method, method_name, NULL, NULL);
-    if (err != 0) {
-      std::cout << "Failed to get method name\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+    return jvmti_ops_->get_method_name(method, method_name);
   }
 
-  bool get_stack_trace(jthread thread, jvmtiFrameInfo *frames,
-                              jint* count) {
-    auto err = jvmti->GetStackTrace(thread, 0, MAX_FRAMES, frames, count);
-    if (err != 0) {
-      std::cout << "Failed to get stack\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+  bool get_stack_trace(jthread thread, jvmtiFrameInfo *frames, jint* count) {
+    return jvmti_ops_->get_stack_trace(thread, 0, MAX_FRAMES, frames, count);
   }
 
   bool get_line_number_table(jmethodID method, jint *entry_count,
-                                    jvmtiLineNumberEntry** line_table) {
-    auto err = jvmti->GetLineNumberTable(method, entry_count, line_table);
-    if (err != 0) {
-      if (err != JVMTI_ERROR_NATIVE_METHOD) {
-	std::cout << "Failed to get line number table\n";
-	debug_print_jvmti_err(err);
-      }
-      return false;
-    }
-    return true;
+                             jvmtiLineNumberEntry** line_table) {
+    return jvmti_ops_->get_line_number_table(method, entry_count, line_table);
   }
 
-  bool set_tag(jobject object, [[maybe_unused]] jlong tag) {
-    auto err = jvmti->SetTag(object, 0);
-    if (err != 0) {
-      std::cout << "Failed to set tag\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+  bool set_tag(jobject object, jlong tag) {
+    return jvmti_ops_->set_tag(object, tag);
   }
 
   bool get_objects_with_tags(jint ntags, jlong *tag_data, jint *count,
-                                    jobject** objects, jlong** tags) {
-    auto err = jvmti->GetObjectsWithTags(ntags, tag_data, count, objects, tags);
-    if (err != 0) {
-      std::cout << "Failed to get objects with tags\n";
-      debug_print_jvmti_err(err);
-      return false;
-    }
-    return true;
+                             jobject** objects, jlong** tags) {
+    return jvmti_ops_->get_objects_with_tags(ntags, tag_data, count, objects,
+                                             tags);
   }
 
   static void call_static_void_method(JNIEnv *env, jclass klass,
@@ -660,62 +614,35 @@ public:
   }
 
   void set_sampling_interval(jint n) {
-    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-    auto err = jvmti->SetHeapSamplingInterval(n);
-    if (err != JVMTI_ERROR_NONE) {
-      std::cout << "Failed to set the sampling interval: " << err << '\n';
-      debug_print_jvmti_err(err);
-    }
+    jvmti_ops_->set_heap_sampling_interval(n);
   }
 
   void enable_sampled_object_alloc() {
     DEBUG_PRINT("Enabling JVMTI_EVENT_SAMPLED_OBJECT_ALLOC\n");
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    auto err = jvmti->SetEventNotificationMode(JVMTI_ENABLE,
-					       JVMTI_EVENT_SAMPLED_OBJECT_ALLOC,
-					       nullptr);
-    if (err != JVMTI_ERROR_NONE) {
-      std::cout << "Failed to enable allocation sampling " << err << '\n';
-      debug_print_jvmti_err(err);
-    }
+    jvmti_ops_->set_event_notification_mode(JVMTI_ENABLE,
+                                            JVMTI_EVENT_SAMPLED_OBJECT_ALLOC,
+                                            nullptr);
   }
 
   void enable_object_free() {
     DEBUG_PRINT("Enabling JVMTI_EVENT_OBJECT_FREE\n");
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    auto err = jvmti->SetEventNotificationMode(JVMTI_ENABLE,
-					  JVMTI_EVENT_OBJECT_FREE,
-					  nullptr);
-    if (err != JVMTI_ERROR_NONE) {
-      std::cout << "Failed to enable object free notifications " << err << '\n';
-      debug_print_jvmti_err(err);
-    }
+    jvmti_ops_->set_event_notification_mode(JVMTI_ENABLE,
+                                            JVMTI_EVENT_OBJECT_FREE,
+                                            nullptr);
   }
 
   void disable_sampled_object_alloc() {
-    DEBUG_PRINT("Enabling JVMTI_EVENT_SAMPLED_OBJECT_ALLOC\n");
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    auto err = jvmti->SetEventNotificationMode(JVMTI_DISABLE,
-					       JVMTI_EVENT_SAMPLED_OBJECT_ALLOC,
-					       nullptr);
-    if (err != JVMTI_ERROR_NONE) {
-      std::cout << "Failed to disable allocation sampling " << err << '\n';
-      debug_print_jvmti_err(err);
-    }
+    DEBUG_PRINT("Disabling JVMTI_EVENT_SAMPLED_OBJECT_ALLOC\n");
+    jvmti_ops_->set_event_notification_mode(JVMTI_DISABLE,
+                                            JVMTI_EVENT_SAMPLED_OBJECT_ALLOC,
+                                            nullptr);
   }
 
   void disable_object_free() {
-    DEBUG_PRINT("Enabling JVMTI_EVENT_OBJECT_FREE\n");
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    auto err = jvmti->SetEventNotificationMode(JVMTI_DISABLE,
-					  JVMTI_EVENT_OBJECT_FREE,
-					  nullptr);
-    if (err != JVMTI_ERROR_NONE) {
-      std::cout << "Failed to disable object free notifications "
-                << err
-		<< '\n';
-      debug_print_jvmti_err(err);
-    }
+    DEBUG_PRINT("Disabling JVMTI_EVENT_OBJECT_FREE\n");
+    jvmti_ops_->set_event_notification_mode(JVMTI_DISABLE,
+                                            JVMTI_EVENT_OBJECT_FREE,
+                                            nullptr);
   }
 
 };

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,4 +1,5 @@
 #include "jni.h"
+#include "include/utils.h"
 #include <algorithm>
 #include <array>
 #include <condition_variable>
@@ -824,26 +825,7 @@ void JNICALL Agent_command(JNIEnv* env, jclass klass, jlong cmd) {
   context.agent_command(env, klass, cmd);
 }
 
-struct PrefixEntry {
-    const char* prefix;
-    size_t length;
-};
-
-constexpr std::array<PrefixEntry, 6> SYSTEM_PREFIXES{{
-    {"Ljava/", 6},
-    {"Lcom/sun/", 9},
-    {"Ljdk/", 5},
-    {"Ljavax/", 7},
-    {"Lsun/management", 15},
-    {"Lclojure/", 9}
-}};
-
-bool is_system_class(const char* class_name) {
-    return std::any_of(SYSTEM_PREFIXES.begin(), SYSTEM_PREFIXES.end(),
-        [class_name](const PrefixEntry& entry) {
-            return strncmp(class_name, entry.prefix, entry.length) == 0;
-        });
-}
+using criterium::is_system_class;
 
 // State management class
 class AgentState {

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -567,6 +567,8 @@ public:
     return jni_ops_->call_long_method(env, thread, thread_getId_method);
   }
 
+  jmethodID get_thread_getId_method() const { return thread_getId_method; }
+
   bool get_class_signature(jclass klass, char** class_sig) {
     return jvmti_ops_->get_class_signature(klass, class_sig);
   }
@@ -720,7 +722,10 @@ private:
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   VMContext &vm_context;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  AgentContext& agent_context;
+  criterium::IJvmtiOperations& jvmti_ops_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  criterium::IJniOperations& jni_ops_;
+  jmethodID thread_getId_method_;
 
   jlong agent_state = passive;
   std::vector<std::unique_ptr<alloc_rec>> allocs;
@@ -742,8 +747,8 @@ private:
 
   void set_state(JNIEnv* env, jlong state) {
     if (agent_class) {
-      agent_context.jni_ops().set_static_long_field(env, *agent_class,
-                                                    agent_state_field, state);
+      jni_ops_.set_static_long_field(env, *agent_class, agent_state_field,
+                                     state);
     }
     set_state(state);
   }
@@ -762,9 +767,14 @@ private:
     }
 
     // here just for good measure, should already be set
-    agent_context.set_sampling_interval(0);
-    agent_context.enable_sampled_object_alloc();
-    agent_context.enable_object_free();
+    jvmti_ops_.set_heap_sampling_interval(0);
+    DEBUG_PRINT("Enabling JVMTI_EVENT_SAMPLED_OBJECT_ALLOC\n");
+    jvmti_ops_.set_event_notification_mode(JVMTI_ENABLE,
+                                           JVMTI_EVENT_SAMPLED_OBJECT_ALLOC,
+                                           nullptr);
+    DEBUG_PRINT("Enabling JVMTI_EVENT_OBJECT_FREE\n");
+    jvmti_ops_.set_event_notification_mode(JVMTI_ENABLE,
+                                           JVMTI_EVENT_OBJECT_FREE, nullptr);
   }
 
   void disable_allocation_tracing(JNIEnv* env) {
@@ -789,8 +799,12 @@ private:
 				 allocs_by_tag_t &allocs_by_tag);
 
 public:
-  AgentState(VMContext& vm_context, AgentContext& agent_context)
-      : vm_context(vm_context),	agent_context(agent_context) {}
+  AgentState(VMContext& vm_context, criterium::IJvmtiOperations& jvmti_ops,
+             criterium::IJniOperations& jni_ops, jmethodID thread_getId_method)
+      : vm_context(vm_context),
+        jvmti_ops_(jvmti_ops),
+        jni_ops_(jni_ops),
+        thread_getId_method_(thread_getId_method) {}
 
 
   void init(JNIEnv* env) {
@@ -882,30 +896,28 @@ public:
 
   void process_allocation_event(JNIEnv* env, const AllocationEvent& event) {
     auto class_sig = AgentContext::allocated<char*>();
-    if (!agent_context.get_class_signature(event.object_klass, &class_sig)) {
-        return;
+    if (!jvmti_ops_.get_class_signature(event.object_klass, &class_sig)) {
+      return;
     }
 
-    auto starting =
-      agent_state == allocation_tracing_starting
-      && 0 == std::strcmp(class_sig, allocation_start_marker);
+    auto starting = agent_state == allocation_tracing_starting &&
+                    0 == std::strcmp(class_sig, allocation_start_marker);
 
-    auto stopping =
-      agent_state == allocation_tracing_stopping
-      && 0 == std::strcmp(class_sig, allocation_finish_marker);
+    auto stopping = agent_state == allocation_tracing_stopping &&
+                    0 == std::strcmp(class_sig, allocation_finish_marker);
 
     auto internal = !(starting || stopping);
 
     // Use the pre-captured stack frames from the allocation event
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-    auto rec = (internal && event.frame_count > 0)
-                   ? allocation_record(env, class_sig, event.size,
-                                       event.thread, event.frame_count,
-                                       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-                                       const_cast<jvmtiFrameInfo*>(event.frames.data()),
-                                       event.tag)
-                   : allocation_record(env, class_sig, event.size,
-                                       event.thread, event.tag);
+    auto rec =
+        (internal && event.frame_count > 0)
+            ? allocation_record(
+                  env, class_sig, event.size, event.thread, event.frame_count,
+                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                  const_cast<jvmtiFrameInfo*>(event.frames.data()), event.tag)
+            : allocation_record(env, class_sig, event.size, event.thread,
+                                event.tag);
 
     if (starting) {
       // DEBUG_PRINT("Start marker seen\n");
@@ -913,11 +925,12 @@ public:
     }
 
     if (stopping) {
-	DEBUG_PRINT("Disabling JVMTI_EVENT_SAMPLED_OBJECT_ALLOC\n");
-	agent_context.disable_sampled_object_alloc();
-	rec->disable_marker = true;
-	set_state(env, allocation_tracing_flushing);
-      }
+      DEBUG_PRINT("Disabling JVMTI_EVENT_SAMPLED_OBJECT_ALLOC\n");
+      jvmti_ops_.set_event_notification_mode(
+          JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
+      rec->disable_marker = true;
+      set_state(env, allocation_tracing_flushing);
+    }
 
     allocs_by_tag.emplace(rec->tag, rec.get());
     allocs.push_back(std::move(rec));
@@ -931,18 +944,20 @@ public:
       // DEBUG_PRINT("Free %d %d\n", rec->start_marker, rec->disable_marker);
 
       if (rec->start_marker && agent_state == start_allocation_tracing) {
-	// set the state to allow the sampler to know that we have
-	// actually activated
-	DEBUG_PRINT("Start marker seen in Free\n");
-	set_state(env, allocation_tracing_active);
+        // set the state to allow the sampler to know that we have
+        // actually activated
+        DEBUG_PRINT("Start marker seen in Free\n");
+        set_state(env, allocation_tracing_active);
       }
       if (agent_state == allocation_tracing_flushing && rec->disable_marker) {
-	DEBUG_PRINT("Disabling JVMTI_EVENT_OBJECT_FREE\n");
-	agent_context.disable_object_free();
-	DEBUG_PRINT("Disabled\n");
-	set_state(env, allocation_tracing_flushed);
+        DEBUG_PRINT("Disabling JVMTI_EVENT_OBJECT_FREE\n");
+        jvmti_ops_.set_event_notification_mode(JVMTI_DISABLE,
+                                               JVMTI_EVENT_OBJECT_FREE,
+                                               nullptr);
+        DEBUG_PRINT("Disabled\n");
+        set_state(env, allocation_tracing_flushed);
       }
-    } catch(const std::out_of_range&) {
+    } catch (const std::out_of_range&) {
       DEBUG_PRINT("Tag not found in map\n");
     }
   }
@@ -962,9 +977,8 @@ public:
       break;
     case ping:
       if (agent_class) {
-        agent_context.call_static_void_method(
-            env, *agent_class, agent_data1_method,
-            agent_context.jni_ops().new_string_utf(env, "Alive"));
+        jni_ops_.call_static_void_method(env, *agent_class, agent_data1_method,
+                                         jni_ops_.new_string_utf(env, "Alive"));
       }
       break;
     case sync_state:
@@ -976,18 +990,17 @@ public:
   }
 };
 
-auto AgentState::calling_frame(JNIEnv* env,
-			       jvmtiFrameInfo* frames,
-			       jint num_frames) {
+auto AgentState::calling_frame(JNIEnv* env, jvmtiFrameInfo* frames,
+                               jint num_frames) {
   jint framei = 0;
   auto class_name = AgentContext::allocated<char*>();
 
   for (; framei < num_frames; framei++) {
     auto declaring_class = VMContext::local_ref<jclass>(env);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    if (agent_context.get_method_declaring_class(frames[framei].method,
-							&declaring_class)) {
-      if (agent_context.get_class_signature(declaring_class, &class_name)) {
+    if (jvmti_ops_.get_method_declaring_class(frames[framei].method,
+                                              &declaring_class)) {
+      if (jvmti_ops_.get_class_signature(declaring_class, &class_name)) {
         // printf("class : %d %s\n", framei, (char*)class_name);
         // TODO make the filters configurable
         if (is_system_class(class_name)) {
@@ -996,7 +1009,7 @@ auto AgentState::calling_frame(JNIEnv* env,
       }
     }
   }
-  if (framei>=num_frames) {
+  if (framei >= num_frames) {
     framei = 0;
   }
   return std::make_tuple(framei, std::move(class_name));
@@ -1004,25 +1017,25 @@ auto AgentState::calling_frame(JNIEnv* env,
 
 auto AgentState::frame_detail(JNIEnv* env, jvmtiFrameInfo& frame) {
   auto declaring_class = VMContext::local_ref<jclass>(env);
-  agent_context.get_method_declaring_class(frame.method, &declaring_class);
+  jvmti_ops_.get_method_declaring_class(frame.method, &declaring_class);
 
   auto class_name = AgentContext::allocated<char*>();
-  agent_context.get_class_signature(declaring_class, &class_name);
+  jvmti_ops_.get_class_signature(declaring_class, &class_name);
 
   auto method_name = AgentContext::allocated<char*>();
-  agent_context.get_method_name(frame.method, &method_name);
+  jvmti_ops_.get_method_name(frame.method, &method_name);
 
   jint entry_count = 0;
   auto line_table = AgentContext::allocated<jvmtiLineNumberEntry*>();
 
   jint line_num = -1;
 
-  if (agent_context.get_line_number_table(frame.method, &entry_count,
-                                          &line_table)) {
+  if (jvmti_ops_.get_line_number_table(frame.method, &entry_count,
+                                       &line_table)) {
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     line_num = line_table[0].line_number;
-    for ( auto i = 1 ; i < entry_count ; i++ ) {
-      if ( frame.location < line_table[i].start_location) {
+    for (auto i = 1; i < entry_count; i++) {
+      if (frame.location < line_table[i].start_location) {
         break;
       }
       line_num = line_table[i].line_number;
@@ -1030,86 +1043,59 @@ auto AgentState::frame_detail(JNIEnv* env, jvmtiFrameInfo& frame) {
     // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
 
-  auto source_name = AgentContext::allocated<char *>();
-  agent_context.get_source_file_name(declaring_class, &source_name);
+  auto source_name = AgentContext::allocated<char*>();
+  jvmti_ops_.get_source_file_name(declaring_class, &source_name);
 
-  return std::make_tuple(std::move(class_name),
-                         std::move(method_name),
-                         std::move(source_name),
-                         line_num);
+  return std::make_tuple(std::move(class_name), std::move(method_name),
+                         std::move(source_name), line_num);
 }
 
-std::unique_ptr<alloc_rec> AgentState::allocation_record(JNIEnv* env,
-							 const char* class_sig,
-							 jlong size,
-							 jthread thread,
-							 jint num_frames,
-							 jvmtiFrameInfo* frames,
-							 jlong tag) {
-  jint framei=0;
+std::unique_ptr<alloc_rec> AgentState::allocation_record(
+    JNIEnv* env, const char* class_sig, jlong size, jthread thread,
+    jint num_frames, jvmtiFrameInfo* frames, jlong tag) {
+  jint framei = 0;
 
-  auto [f0_class_name, f0_method, f0_source, f0_line]
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      = frame_detail(env, frames[0]);
+  auto [f0_class_name, f0_method, f0_source, f0_line] =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      frame_detail(env, frames[0]);
 
   auto cframe = calling_frame(env, frames, num_frames);
   framei = std::get<0>(cframe);
 
-  auto [fi_class_name, fi_method, fi_source, fi_line]
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-   = frame_detail(env, frames[framei]);
+  auto [fi_class_name, fi_method, fi_source, fi_line] =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      frame_detail(env, frames[framei]);
 
-  jlong tid = AgentContext::getInstance().thread_id(env, thread);
+  jlong tid = jni_ops_.call_long_method(env, thread, thread_getId_method_);
 
-  return std::make_unique<alloc_rec>(class_sig,
-                                     size,
-                                     fi_class_name,
-                                     fi_method,
-                                     fi_source,
-                                     static_cast<jlong>(fi_line),
-                                     f0_class_name,
-                                     f0_method,
-                                     f0_source,
-                                     static_cast<jlong>(f0_line),
-                                     tid,
-                                     tag);
+  return std::make_unique<alloc_rec>(
+      class_sig, size, fi_class_name, fi_method, fi_source,
+      static_cast<jlong>(fi_line), f0_class_name, f0_method, f0_source,
+      static_cast<jlong>(f0_line), tid, tag);
 }
 
 std::unique_ptr<alloc_rec> AgentState::allocation_record(JNIEnv* env,
-							 const char* class_sig,
-							 jlong size,
-							 jthread thread,
-							 jlong tag) {
-  jlong tid = agent_context.thread_id(env, thread);
-  return std::make_unique<alloc_rec>(class_sig,
-                                     size,
-                                     nullptr,
-                                     nullptr,
-                                     nullptr,
-                                     -1,
-                                     nullptr,
-                                     nullptr,
-                                     nullptr,
-                                     -1,
-                                     tid,
+                                                         const char* class_sig,
+                                                         jlong size,
+                                                         jthread thread,
+                                                         jlong tag) {
+  jlong tid = jni_ops_.call_long_method(env, thread, thread_getId_method_);
+  return std::make_unique<alloc_rec>(class_sig, size, nullptr, nullptr, nullptr,
+                                     -1, nullptr, nullptr, nullptr, -1, tid,
                                      tag);
 }
 
-void AgentState::untag_objects(allocs_t &allocs,
-                               allocs_by_tag_t& allocs_by_tag) {
+void AgentState::untag_objects(allocs_t& allocs, allocs_by_tag_t& allocs_by_tag) {
   auto tags = all_tags(allocs);
   if (!tags.empty()) {
     jint count = 0;
     auto objects = AgentContext::allocated<jobject*>();
     auto object_tags = AgentContext::allocated<jlong*>();
-    agent_context.get_objects_with_tags(static_cast<jint>(tags.size()),
-					tags.data(),
-					&count,
-					&objects,
-					&object_tags);
-    for (jint i=0; i< count; ++i) {
+    jvmti_ops_.get_objects_with_tags(static_cast<jint>(tags.size()), tags.data(),
+                                     &count, &objects, &object_tags);
+    for (jint i = 0; i < count; ++i) {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      agent_context.set_tag(objects[i], 0);
+      jvmti_ops_.set_tag(objects[i], 0);
     }
   }
   // DEBUG_PRINT("remove tags done\n");
@@ -1117,7 +1103,7 @@ void AgentState::untag_objects(allocs_t &allocs,
   allocs_by_tag.clear();
 }
 
-void AgentState::allocation_tracing_report(JNIEnv *env, allocs_t &allocs,
+void AgentState::allocation_tracing_report(JNIEnv* env, allocs_t& allocs,
                                            allocs_by_tag_t& allocs_by_tag) {
   if (agent_class && agent_allocation_class) {
     for (auto& alloc : allocs) {
@@ -1132,7 +1118,8 @@ void AgentState::allocation_tracing_report(JNIEnv *env, allocs_t &allocs,
       auto call_file_jstr = java::string(env, alloc->call_file);
 
       // Build jvalue array for NewObjectA
-      // Signature: (String,long,String,String,String,long,String,String,String,long,long,long)V
+      // Signature:
+      // (String,long,String,String,String,long,String,String,String,long,long,long)V
       static constexpr size_t ALLOCATION_CTOR_ARG_COUNT = 12;
       // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
       std::array<jvalue, ALLOCATION_CTOR_ARG_COUNT> args = {};
@@ -1150,15 +1137,12 @@ void AgentState::allocation_tracing_report(JNIEnv *env, allocs_t &allocs,
       args[11].j = alloc->freed;
       // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
-      auto rec = VMContext::local_ref<jobject>
-        (env, agent_context.new_object_a(env,
-                                         *agent_allocation_class,
-                                         agent_allocation_ctor,
-                                         args.data()));
+      auto rec = VMContext::local_ref<jobject>(
+          env, jni_ops_.new_object_a(env, *agent_allocation_class,
+                                     agent_allocation_ctor, args.data()));
 
-      agent_context.call_static_void_method(env, *agent_class,
-                                            agent_data1_method,
-                                            static_cast<jobject&>(rec));
+      jni_ops_.call_static_void_method(env, *agent_class, agent_data1_method,
+                                       static_cast<jobject&>(rec));
     }
   }
 
@@ -1168,13 +1152,14 @@ void AgentState::allocation_tracing_report(JNIEnv *env, allocs_t &allocs,
 
 // Queue consumer thread
 void queue_consumer_thread() {
-  JNIEnv *env = nullptr;
+  JNIEnv* env = nullptr;
   VMContext& vm_context = VMContext::getInstance();
   AgentContext& agent_context = AgentContext::getInstance();
   // Attach thread to JVM
   vm_context.attach_current_thread_as_daemon(&env);
 
-  AgentState state(vm_context, agent_context);
+  AgentState state(vm_context, agent_context.jvmti_ops(), agent_context.jni_ops(),
+                   agent_context.get_thread_getId_method());
   state.init(env);
   Message msg;
 

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,4 +1,5 @@
 #include "jni.h"
+#include "include/agent_types.h"
 #include "include/alloc_rec.h"
 #include "include/jni_operations.h"
 #include "include/jvmti_operations.h"
@@ -30,7 +31,24 @@
 #define DEBUG_PRINTLN(...)
 #endif
 
-const jint MAX_FRAMES = 1024;
+using criterium::MAX_FRAMES;
+
+// State enum values
+using criterium::passive;
+using criterium::allocation_tracing_starting;
+using criterium::allocation_tracing_active;
+using criterium::allocation_tracing_stopping;
+using criterium::allocation_tracing_flushing;
+using criterium::allocation_tracing_flushed;
+using criterium::allocation_tracing_reporting;
+using criterium::allocation_tracing_reported;
+
+// Command enum values
+using criterium::ping;
+using criterium::sync_state;
+using criterium::start_allocation_tracing;
+using criterium::stop_allocation_tracing;
+using criterium::report_allocation_tracing;
 
 // NOLINTNEXTLINE(bugprone-branch-clone)
 void debug_print_jvmti_err([[maybe_unused]] jvmtiError err) {
@@ -158,27 +176,7 @@ jmethodID class_invoke_method_id(JNIEnv* env, jclass klass) {
   return invoke;
 }
 
-// NOLINTBEGIN(performance-enum-size)
-// Using unscoped enums for implicit conversion to jlong
-enum States : jlong {  // NOLINT(cppcoreguidelines-use-enum-class)
-  passive = 0,
-  allocation_tracing_starting = 10,
-  allocation_tracing_active = 11,
-  allocation_tracing_stopping = 15,
-  allocation_tracing_flushing = 16,
-  allocation_tracing_flushed = 17,
-  allocation_tracing_reporting = 18,
-  allocation_tracing_reported = 19,
-};
-
-enum Commands : jlong {  // NOLINT(cppcoreguidelines-use-enum-class)
-  ping = 0,
-  sync_state = 1,
-  start_allocation_tracing = 10,
-  stop_allocation_tracing = 11,
-  report_allocation_tracing = 12
-};
-// NOLINTEND(performance-enum-size)
+// States and Commands enums are defined in include/agent_types.h
 
 // Event/Command structures
 struct AllocationEvent {
@@ -376,6 +374,18 @@ private:
 public:
   criterium::IJvmtiOperations& jvmti_ops() { return *jvmti_ops_; }
   criterium::IJniOperations& jni_ops() { return *jni_ops_; }
+
+  /// Set JVMTI operations for testing. Takes ownership of the pointer.
+  static void set_jvmti_ops_for_testing(
+      std::unique_ptr<criterium::IJvmtiOperations> ops) {
+    getInstance().jvmti_ops_ = std::move(ops);
+  }
+
+  /// Set JNI operations for testing. Takes ownership of the pointer.
+  static void set_jni_ops_for_testing(
+      std::unique_ptr<criterium::IJniOperations> ops) {
+    getInstance().jni_ops_ = std::move(ops);
+  }
 
   template <typename T>
   class allocated  {
@@ -988,6 +998,9 @@ public:
       std::cout << "Invalid command: " << cmd.cmd << '\n';
     }
   }
+
+  /// Returns the current agent state. Used for testing.
+  jlong get_state() const { return agent_state; }
 };
 
 auto AgentState::calling_frame(JNIEnv* env, jvmtiFrameInfo* frames,

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,5 +1,6 @@
 #include "jni.h"
 #include "include/alloc_rec.h"
+#include "include/jni_operations.h"
 #include "include/jvmti_operations.h"
 #include "include/message_queue.h"
 #include "include/utils.h"
@@ -189,10 +190,10 @@ struct AllocationEvent {
   std::array<jvmtiFrameInfo, MAX_FRAMES> frames;
   jint frame_count;
 
-  void delete_global_refs(JNIEnv* env) const {
-    env->DeleteGlobalRef(object_klass);
-    env->DeleteGlobalRef(object);
-    env->DeleteGlobalRef(thread);
+  void delete_global_refs(JNIEnv* env, criterium::IJniOperations& jni_ops) const {
+    jni_ops.delete_global_ref(env, object_klass);
+    jni_ops.delete_global_ref(env, object);
+    jni_ops.delete_global_ref(env, thread);
   }
 };
 
@@ -365,6 +366,7 @@ class AgentContext {
 private:
   jvmtiEnv* jvmti = nullptr;
   std::unique_ptr<criterium::IJvmtiOperations> jvmti_ops_;
+  std::unique_ptr<criterium::IJniOperations> jni_ops_;
 
   static jvmtiEnv* get_jvmti() { return getInstance().jvmti; }
   static criterium::IJvmtiOperations& get_jvmti_ops() {
@@ -373,6 +375,7 @@ private:
 
 public:
   criterium::IJvmtiOperations& jvmti_ops() { return *jvmti_ops_; }
+  criterium::IJniOperations& jni_ops() { return *jni_ops_; }
 
   template <typename T>
   class allocated  {
@@ -453,6 +456,7 @@ public:
     jvm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION_1_0);
 
     jvmti_ops_ = std::make_unique<criterium::JvmtiOperations>(jvmti);
+    jni_ops_ = std::make_unique<criterium::JniOperations>();
 
     jvmti->CreateRawMonitor("tag_lock", &tag_lock);
 
@@ -536,15 +540,14 @@ public:
     }
 
     message_queue.push(AllocationEvent{
-	env->NewGlobalRef(object),
-	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-	reinterpret_cast<jclass>(env->NewGlobalRef(object_klass)),
-	static_cast<jthread>(env->NewGlobalRef(thread)),
-	size,
-	tag,
-	frames,
-	frame_count
-      });
+        jni_ops_->new_global_ref(env, object),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<jclass>(jni_ops_->new_global_ref(env, object_klass)),
+        static_cast<jthread>(jni_ops_->new_global_ref(env, thread)),
+        size,
+        tag,
+        frames,
+        frame_count});
   }
 
   void object_free([[maybe_unused]] jvmtiEnv* jvmti_env, jlong tag) {
@@ -561,8 +564,7 @@ public:
   }
 
   jlong thread_id(JNIEnv *env, jthread thread) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    return env->CallLongMethod(thread, thread_getId_method);
+    return jni_ops_->call_long_method(env, thread, thread_getId_method);
   }
 
   bool get_class_signature(jclass klass, char** class_sig) {
@@ -600,17 +602,14 @@ public:
                                              tags);
   }
 
-  static void call_static_void_method(JNIEnv *env, jclass klass,
-                                      jmethodID method, jobject arg) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    env->CallStaticVoidMethod(klass, method, arg);
+  void call_static_void_method(JNIEnv *env, jclass klass,
+                               jmethodID method, jobject arg) {
+    jni_ops_->call_static_void_method(env, klass, method, arg);
   }
 
-  template <typename... Args>
-  static jobject new_object(JNIEnv *env, jclass klass, jmethodID method,
-			    Args... args) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    return env->NewObject(klass, method, args...);
+  jobject new_object_a(JNIEnv *env, jclass klass, jmethodID ctor,
+                       const jvalue* args) {
+    return jni_ops_->new_object_a(env, klass, ctor, args);
   }
 
   void set_sampling_interval(jint n) {
@@ -694,11 +693,13 @@ void AgentContext::set_callbacks(jvmtiEventCallbacks& callbacks) {
 
 namespace java {
   VMContext::local_ref<jstring> string(JNIEnv* env, const char* str) {
-    return VMContext::getInstance().mk_local_ref(env, (env)->NewStringUTF(str));
+    return VMContext::getInstance().mk_local_ref(
+        env, AgentContext::getInstance().jni_ops().new_string_utf(env, str));
   }
   VMContext::local_ref<jstring> string(JNIEnv* env, const std::string& str) {
-    return VMContext::getInstance()
-        .mk_local_ref(env, (env)->NewStringUTF(str.c_str()));
+    return VMContext::getInstance().mk_local_ref(
+        env,
+        AgentContext::getInstance().jni_ops().new_string_utf(env, str.c_str()));
   }
 }
 
@@ -741,7 +742,8 @@ private:
 
   void set_state(JNIEnv* env, jlong state) {
     if (agent_class) {
-      env->SetStaticLongField(*agent_class, agent_state_field, state);
+      agent_context.jni_ops().set_static_long_field(env, *agent_class,
+                                                    agent_state_field, state);
     }
     set_state(state);
   }
@@ -960,10 +962,9 @@ public:
       break;
     case ping:
       if (agent_class) {
-        AgentContext::call_static_void_method(env,
-                                              *agent_class,
-                                              agent_data1_method,
-                                              env->NewStringUTF("Alive"));
+        agent_context.call_static_void_method(
+            env, *agent_class, agent_data1_method,
+            agent_context.jni_ops().new_string_utf(env, "Alive"));
       }
       break;
     case sync_state:
@@ -1130,26 +1131,34 @@ void AgentState::allocation_tracing_report(JNIEnv *env, allocs_t &allocs,
       auto call_method_jstr = java::string(env, alloc->call_method);
       auto call_file_jstr = java::string(env, alloc->call_file);
 
-      auto rec = VMContext::local_ref<jobject>
-        (env, AgentContext::new_object
-         (env,
-          *agent_allocation_class,
-          agent_allocation_ctor,
-          (jstring)class_jstr,
-          alloc->obj_size,
-          (jstring)call_class_jstr,
-          (jstring)call_method_jstr,
-          (jstring)call_file_jstr,
-          alloc->call_line,
-          (jstring)alloc_class_jstr,
-          (jstring)alloc_method_jstr,
-          (jstring)alloc_file_jstr,
-          alloc->alloc_line,
-          alloc->thread_id,
-          alloc->freed));
+      // Build jvalue array for NewObjectA
+      // Signature: (String,long,String,String,String,long,String,String,String,long,long,long)V
+      static constexpr size_t ALLOCATION_CTOR_ARG_COUNT = 12;
+      // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+      std::array<jvalue, ALLOCATION_CTOR_ARG_COUNT> args = {};
+      args[0].l = static_cast<jstring>(class_jstr);
+      args[1].j = alloc->obj_size;
+      args[2].l = static_cast<jstring>(call_class_jstr);
+      args[3].l = static_cast<jstring>(call_method_jstr);
+      args[4].l = static_cast<jstring>(call_file_jstr);
+      args[5].j = alloc->call_line;
+      args[6].l = static_cast<jstring>(alloc_class_jstr);
+      args[7].l = static_cast<jstring>(alloc_method_jstr);
+      args[8].l = static_cast<jstring>(alloc_file_jstr);
+      args[9].j = alloc->alloc_line;
+      args[10].j = alloc->thread_id;
+      args[11].j = alloc->freed;
+      // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
-      AgentContext::call_static_void_method(env, *agent_class, agent_data1_method,
-                                            (jobject&)rec);
+      auto rec = VMContext::local_ref<jobject>
+        (env, agent_context.new_object_a(env,
+                                         *agent_allocation_class,
+                                         agent_allocation_ctor,
+                                         args.data()));
+
+      agent_context.call_static_void_method(env, *agent_class,
+                                            agent_data1_method,
+                                            static_cast<jobject&>(rec));
     }
   }
 
@@ -1173,9 +1182,9 @@ void queue_consumer_thread() {
     std::visit([&](auto&& arg) {
       using T = std::decay_t<decltype(arg)>;
       if constexpr (std::is_same_v<T, AllocationEvent>) {
-	// DEBUG_PRINT("Process AllocationEvent\n");
-	state.process_allocation_event(env, arg);
-	arg.delete_global_refs(env);
+        // DEBUG_PRINT("Process AllocationEvent\n");
+        state.process_allocation_event(env, arg);
+        arg.delete_global_refs(env, agent_context.jni_ops());
       }
       else if constexpr (std::is_same_v<T, ObjectFreeEvent>) {
 	// DEBUG_PRINT("Process ObjectFreeEvent\n");

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,4 +1,5 @@
 #include "jni.h"
+#include "include/alloc_rec.h"
 #include "include/message_queue.h"
 #include "include/utils.h"
 #include <algorithm>
@@ -260,18 +261,8 @@ struct alloc_rec {
 
 typedef std::vector<std::unique_ptr<alloc_rec>> allocs_t;
 typedef std::map<jlong, alloc_rec*> allocs_by_tag_t;
-/* static allocs_t allocs; */
-/* static auto allocs_by_tag = allocs_by_tag_t(); */
 
-
-auto all_tags(allocs_t& allocs) {
-  auto tags=std::vector<jlong>(allocs.size());
-  std::transform(allocs.begin(),
-                   allocs.end(),
-                   std::back_inserter(tags),
-                   std::mem_fn(&alloc_rec::tag));
-  return tags;
-}
+using criterium::all_tags;
 
 
 class VMContext {

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,4 +1,5 @@
 #include "jni.h"
+#include "include/message_queue.h"
 #include "include/utils.h"
 #include <algorithm>
 #include <array>
@@ -203,40 +204,7 @@ struct Command {
 
 // Queue message type
 using Message = std::variant<AllocationEvent, ObjectFreeEvent, Command>;
-
-// Thread-safe queue
-class MessageQueue {
-    std::queue<Message> queue;
-    std::mutex mutex;
-    std::condition_variable cond;
-    bool stopped = false;
-
-public:
-    void push(Message msg) {
-        std::lock_guard<std::mutex> lock(mutex);
-        queue.push(msg);
-        cond.notify_one();
-    }
-
-    bool pop(Message& msg) {
-        std::unique_lock<std::mutex> lock(mutex);
-        while (queue.empty() && !stopped) {
-            cond.wait(lock);
-        }
-        if (stopped && queue.empty()) {
-            return false;
-        }
-        msg = queue.front();
-        queue.pop();
-        return true;
-    }
-
-    void stop() {
-        std::lock_guard<std::mutex> lock(mutex);
-        stopped = true;
-        cond.notify_all();
-    }
-};
+using MessageQueue = criterium::MessageQueue<Message>;
 
 // Structure used to record allocations
 struct alloc_rec {

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -5,6 +5,7 @@
 #include "include/jni_operations.h"
 #include "include/jvmti_operations.h"
 #include "include/message_queue.h"
+#include "include/state_transitions.h"
 #include "include/utils.h"
 #include <algorithm>
 #include <array>
@@ -834,17 +835,15 @@ public:
   }
 
   void process_allocation_event(JNIEnv* env, const AllocationEvent& event) {
+    using namespace criterium::state_transitions;
+
     auto class_sig = AgentContext::allocated<char*>();
     if (!jvmti_ops_.get_class_signature(event.object_klass, &class_sig)) {
       return;
     }
 
-    auto starting = agent_state == allocation_tracing_starting &&
-                    0 == std::strcmp(class_sig, allocation_start_marker);
-
-    auto stopping = agent_state == allocation_tracing_stopping &&
-                    0 == std::strcmp(class_sig, allocation_finish_marker);
-
+    auto starting = is_start_marker_allocation(agent_state, class_sig);
+    auto stopping = is_finish_marker_allocation(agent_state, class_sig);
     auto internal = !(starting || stopping);
 
     // Use the pre-captured stack frames from the allocation event
@@ -859,7 +858,6 @@ public:
                                 event.tag);
 
     if (starting) {
-      // DEBUG_PRINT("Start marker seen\n");
       rec->start_marker = true;
     }
 
@@ -868,7 +866,8 @@ public:
       jvmti_ops_.set_event_notification_mode(
           JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
       rec->disable_marker = true;
-      set_state(env, allocation_tracing_flushing);
+      auto new_state = next_state_after_allocation(agent_state, class_sig);
+      set_state(env, new_state);
     }
 
     allocs_by_tag.emplace(rec->tag, rec.get());
@@ -876,25 +875,27 @@ public:
   }  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
   void process_object_free_event(JNIEnv* env, const ObjectFreeEvent& event) {
-    // DEBUG_PRINT("Free\n");
+    using namespace criterium::state_transitions;
+
     try {
       AllocRec* rec = allocs_by_tag.at(event.tag);
       rec->freed = 1;
-      // DEBUG_PRINT("Free %d %d\n", rec->start_marker, rec->disable_marker);
 
-      if (rec->start_marker && agent_state == start_allocation_tracing) {
-        // set the state to allow the sampler to know that we have
-        // actually activated
-        DEBUG_PRINT("Start marker seen in Free\n");
-        set_state(env, allocation_tracing_active);
-      }
-      if (agent_state == allocation_tracing_flushing && rec->disable_marker) {
-        DEBUG_PRINT("Disabling JVMTI_EVENT_OBJECT_FREE\n");
-        jvmti_ops_.set_event_notification_mode(JVMTI_DISABLE,
-                                               JVMTI_EVENT_OBJECT_FREE,
-                                               nullptr);
-        DEBUG_PRINT("Disabled\n");
-        set_state(env, allocation_tracing_flushed);
+      auto new_state =
+          next_state_after_object_free(agent_state, rec->start_marker,
+                                       rec->disable_marker);
+      if (new_state != agent_state) {
+        if (rec->start_marker) {
+          DEBUG_PRINT("Start marker freed, transitioning to active\n");
+        }
+        if (rec->disable_marker) {
+          DEBUG_PRINT("Disabling JVMTI_EVENT_OBJECT_FREE\n");
+          jvmti_ops_.set_event_notification_mode(JVMTI_DISABLE,
+                                                 JVMTI_EVENT_OBJECT_FREE,
+                                                 nullptr);
+          DEBUG_PRINT("Disabled\n");
+        }
+        set_state(env, new_state);
       }
     } catch (const std::out_of_range&) {
       DEBUG_PRINT("Tag not found in map\n");

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -1,4 +1,5 @@
 #include "jni.h"
+#include "include/agent_state.h"
 #include "include/agent_types.h"
 #include "include/alloc_rec.h"
 #include "include/jni_operations.h"
@@ -177,31 +178,11 @@ jmethodID class_invoke_method_id(JNIEnv* env, jclass klass) {
 }
 
 // States and Commands enums are defined in include/agent_types.h
+// Event/Command structures are defined in include/agent_state.h
 
-// Event/Command structures
-struct AllocationEvent {
-  jobject object;
-  jclass object_klass;
-  jthread thread;
-  jlong size;
-  jlong tag;
-  std::array<jvmtiFrameInfo, MAX_FRAMES> frames;
-  jint frame_count;
-
-  void delete_global_refs(JNIEnv* env, criterium::IJniOperations& jni_ops) const {
-    jni_ops.delete_global_ref(env, object_klass);
-    jni_ops.delete_global_ref(env, object);
-    jni_ops.delete_global_ref(env, thread);
-  }
-};
-
-struct ObjectFreeEvent {
-    jlong tag;
-};
-
-struct Command {
-    jlong cmd;
-};
+using criterium::AllocationEvent;
+using criterium::ObjectFreeEvent;
+using criterium::Command;
 
 // Queue message type
 using Message = std::variant<AllocationEvent, ObjectFreeEvent, Command>;

--- a/agent-cpp/agent.cpp
+++ b/agent-cpp/agent.cpp
@@ -143,7 +143,7 @@ static constexpr char const* data8_sig =
   "Ljava/lang/Object;"
   "Ljava/lang/Object;)V";
 
-static constexpr char const *no_file_name = "NO_SOURCE";
+using criterium::AllocRec;
 
 jclass ifn(JNIEnv* env) {
   auto *ifn = (env)->FindClass(IFn);
@@ -207,60 +207,8 @@ struct Command {
 using Message = std::variant<AllocationEvent, ObjectFreeEvent, Command>;
 using MessageQueue = criterium::MessageQueue<Message>;
 
-// Structure used to record allocations
-struct alloc_rec {
-  std::string obj_class;
-  jlong obj_size;
-
-  std::string call_class;
-  std::string call_method;
-  std::string call_file;
-  jlong call_line;
-
-  std::string alloc_class;
-  std::string alloc_method;
-  std::string alloc_file;
-  jlong alloc_line;
-
-  jlong thread_id;
-  jlong freed{};
-
-  jlong tag;
-  bool start_marker{};
-  bool disable_marker{};
-
-  alloc_rec(char const * obj_class,
-            jlong obj_size,
-	    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-            char const * call_class,
-            char const * call_method,
-            char const * call_file,
-            jlong call_line,
-	    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-            char const * alloc_class,
-            char const * alloc_method,
-            char const * alloc_file,
-	    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-            jlong alloc_line,
-            jlong thread_id,
-            jlong tag)
-    : obj_class(obj_class),
-      obj_size(obj_size),
-      call_class(call_class == nullptr ? "" : call_class),
-      call_method(call_method == nullptr ? "" : call_method),
-      call_file(call_file == NULL ? no_file_name : call_file),
-      call_line(call_line),
-      alloc_class(alloc_class == nullptr ? "" : alloc_class),
-      alloc_method(alloc_method == nullptr ? "" : alloc_method),
-      alloc_file(alloc_file == NULL ? no_file_name : alloc_file),
-      alloc_line(alloc_line),
-      thread_id(thread_id),
-      tag(tag)
-  { }
-};
-
-typedef std::vector<std::unique_ptr<alloc_rec>> allocs_t;
-typedef std::map<jlong, alloc_rec*> allocs_by_tag_t;
+using allocs_t = std::vector<std::unique_ptr<AllocRec>>;
+using allocs_by_tag_t = std::map<jlong, AllocRec*>;
 
 using criterium::all_tags;
 
@@ -738,8 +686,8 @@ private:
   jmethodID thread_getId_method_;
 
   jlong agent_state = passive;
-  std::vector<std::unique_ptr<alloc_rec>> allocs;
-  std::map<jlong, alloc_rec*> allocs_by_tag;
+  std::vector<std::unique_ptr<AllocRec>> allocs;
+  std::map<jlong, AllocRec*> allocs_by_tag;
 
   std::unique_ptr<VMContext::global_ref<jclass>> agent_class;
   std::unique_ptr<VMContext::global_ref<jclass>> agent_allocation_start_marker_class;
@@ -794,12 +742,12 @@ private:
   void untag_objects(allocs_t &allocs, allocs_by_tag_t &allocs_by_tag);
   auto calling_frame(JNIEnv *env, jvmtiFrameInfo *frames, jint num_frames);
   auto frame_detail(JNIEnv *env, jvmtiFrameInfo &frame);
-  std::unique_ptr<alloc_rec> allocation_record(JNIEnv* env,
+  std::unique_ptr<AllocRec> allocation_record(JNIEnv* env,
 					       const char* class_sig,
 					       jlong size,
 					       jthread thread,
 					       jlong tag);
-  std::unique_ptr<alloc_rec> allocation_record(JNIEnv *env,
+  std::unique_ptr<AllocRec> allocation_record(JNIEnv *env,
                                                const char *class_sig,
                                                jlong size,
 					       jthread thread, jint num_frames,
@@ -949,7 +897,7 @@ public:
   void process_object_free_event(JNIEnv* env, const ObjectFreeEvent& event) {
     // DEBUG_PRINT("Free\n");
     try {
-      alloc_rec* rec = allocs_by_tag.at(event.tag);
+      AllocRec* rec = allocs_by_tag.at(event.tag);
       rec->freed = 1;
       // DEBUG_PRINT("Free %d %d\n", rec->start_marker, rec->disable_marker);
 
@@ -1063,7 +1011,7 @@ auto AgentState::frame_detail(JNIEnv* env, jvmtiFrameInfo& frame) {
                          std::move(source_name), line_num);
 }
 
-std::unique_ptr<alloc_rec> AgentState::allocation_record(
+std::unique_ptr<AllocRec> AgentState::allocation_record(
     JNIEnv* env, const char* class_sig, jlong size, jthread thread,
     jint num_frames, jvmtiFrameInfo* frames, jlong tag) {
   jint framei = 0;
@@ -1081,19 +1029,19 @@ std::unique_ptr<alloc_rec> AgentState::allocation_record(
 
   jlong tid = jni_ops_.call_long_method(env, thread, thread_getId_method_);
 
-  return std::make_unique<alloc_rec>(
+  return std::make_unique<AllocRec>(
       class_sig, size, fi_class_name, fi_method, fi_source,
       static_cast<jlong>(fi_line), f0_class_name, f0_method, f0_source,
       static_cast<jlong>(f0_line), tid, tag);
 }
 
-std::unique_ptr<alloc_rec> AgentState::allocation_record(JNIEnv* env,
+std::unique_ptr<AllocRec> AgentState::allocation_record(JNIEnv* env,
                                                          const char* class_sig,
                                                          jlong size,
                                                          jthread thread,
                                                          jlong tag) {
   jlong tid = jni_ops_.call_long_method(env, thread, thread_getId_method_);
-  return std::make_unique<alloc_rec>(class_sig, size, nullptr, nullptr, nullptr,
+  return std::make_unique<AllocRec>(class_sig, size, nullptr, nullptr, nullptr,
                                      -1, nullptr, nullptr, nullptr, -1, tid,
                                      tag);
 }

--- a/agent-cpp/include/agent_state.h
+++ b/agent-cpp/include/agent_state.h
@@ -1,0 +1,89 @@
+#ifndef CRITERIUM_AGENT_STATE_H
+#define CRITERIUM_AGENT_STATE_H
+
+#include <jni.h>
+#include <jvmti.h>
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "agent_types.h"
+#include "jni_operations.h"
+#include "jvmti_operations.h"
+
+namespace criterium {
+
+/// Allocation event from JVMTI callback, queued for processing.
+struct AllocationEvent {
+  jobject object;
+  jclass object_klass;
+  jthread thread;
+  jlong size;
+  jlong tag;
+  std::array<jvmtiFrameInfo, MAX_FRAMES> frames;
+  jint frame_count;
+
+  void delete_global_refs(JNIEnv* env, IJniOperations& jni_ops) const {
+    jni_ops.delete_global_ref(env, object_klass);
+    jni_ops.delete_global_ref(env, object);
+    jni_ops.delete_global_ref(env, thread);
+  }
+};
+
+/// Object free event from JVMTI callback.
+struct ObjectFreeEvent {
+  jlong tag;
+};
+
+/// Command sent from Java to the agent.
+struct Command {
+  jlong cmd;
+};
+
+/// Allocation record for tracked objects.
+struct AllocRec {
+  std::string obj_class;
+  jlong obj_size;
+
+  std::string call_class;
+  std::string call_method;
+  std::string call_file;
+  jlong call_line;
+
+  std::string alloc_class;
+  std::string alloc_method;
+  std::string alloc_file;
+  jlong alloc_line;
+
+  jlong thread_id;
+  jlong freed{};
+
+  jlong tag;
+  bool start_marker{};
+  bool disable_marker{};
+
+  static constexpr char const* no_file_name = "NO_SOURCE";
+
+  AllocRec(char const* obj_class, jlong obj_size, char const* call_class,
+           char const* call_method, char const* call_file, jlong call_line,
+           char const* alloc_class, char const* alloc_method,
+           char const* alloc_file, jlong alloc_line, jlong thread_id, jlong tag)
+      : obj_class(obj_class),
+        obj_size(obj_size),
+        call_class(call_class == nullptr ? "" : call_class),
+        call_method(call_method == nullptr ? "" : call_method),
+        call_file(call_file == nullptr ? no_file_name : call_file),
+        call_line(call_line),
+        alloc_class(alloc_class == nullptr ? "" : alloc_class),
+        alloc_method(alloc_method == nullptr ? "" : alloc_method),
+        alloc_file(alloc_file == nullptr ? no_file_name : alloc_file),
+        alloc_line(alloc_line),
+        thread_id(thread_id),
+        tag(tag) {}
+};
+
+} // namespace criterium
+
+#endif // CRITERIUM_AGENT_STATE_H

--- a/agent-cpp/include/agent_state.h
+++ b/agent-cpp/include/agent_state.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "agent_types.h"
+#include "alloc_rec.h"
 #include "jni_operations.h"
 #include "jvmti_operations.h"
 
@@ -40,48 +41,6 @@ struct ObjectFreeEvent {
 /// Command sent from Java to the agent.
 struct Command {
   jlong cmd;
-};
-
-/// Allocation record for tracked objects.
-struct AllocRec {
-  std::string obj_class;
-  jlong obj_size;
-
-  std::string call_class;
-  std::string call_method;
-  std::string call_file;
-  jlong call_line;
-
-  std::string alloc_class;
-  std::string alloc_method;
-  std::string alloc_file;
-  jlong alloc_line;
-
-  jlong thread_id;
-  jlong freed{};
-
-  jlong tag;
-  bool start_marker{};
-  bool disable_marker{};
-
-  static constexpr char const* no_file_name = "NO_SOURCE";
-
-  AllocRec(char const* obj_class, jlong obj_size, char const* call_class,
-           char const* call_method, char const* call_file, jlong call_line,
-           char const* alloc_class, char const* alloc_method,
-           char const* alloc_file, jlong alloc_line, jlong thread_id, jlong tag)
-      : obj_class(obj_class),
-        obj_size(obj_size),
-        call_class(call_class == nullptr ? "" : call_class),
-        call_method(call_method == nullptr ? "" : call_method),
-        call_file(call_file == nullptr ? no_file_name : call_file),
-        call_line(call_line),
-        alloc_class(alloc_class == nullptr ? "" : alloc_class),
-        alloc_method(alloc_method == nullptr ? "" : alloc_method),
-        alloc_file(alloc_file == nullptr ? no_file_name : alloc_file),
-        alloc_line(alloc_line),
-        thread_id(thread_id),
-        tag(tag) {}
 };
 
 } // namespace criterium

--- a/agent-cpp/include/agent_types.h
+++ b/agent-cpp/include/agent_types.h
@@ -1,0 +1,39 @@
+#ifndef CRITERIUM_AGENT_TYPES_H
+#define CRITERIUM_AGENT_TYPES_H
+
+#include <jni.h>
+#include <jvmti.h>
+#include <array>
+
+namespace criterium {
+
+/// Agent state machine states.
+/// Using jlong for JNI compatibility when syncing state to Java.
+// NOLINTBEGIN(performance-enum-size)
+enum States : jlong {
+  passive = 0,
+  allocation_tracing_starting = 10,
+  allocation_tracing_active = 11,
+  allocation_tracing_stopping = 15,
+  allocation_tracing_flushing = 16,
+  allocation_tracing_flushed = 17,
+  allocation_tracing_reporting = 18,
+  allocation_tracing_reported = 19,
+};
+
+/// Commands sent from Java to the agent.
+enum Commands : jlong {
+  ping = 0,
+  sync_state = 1,
+  start_allocation_tracing = 10,
+  stop_allocation_tracing = 11,
+  report_allocation_tracing = 12
+};
+// NOLINTEND(performance-enum-size)
+
+/// Maximum stack frames to capture.
+inline constexpr jint MAX_FRAMES = 1024;
+
+} // namespace criterium
+
+#endif // CRITERIUM_AGENT_TYPES_H

--- a/agent-cpp/include/alloc_rec.h
+++ b/agent-cpp/include/alloc_rec.h
@@ -1,0 +1,81 @@
+#ifndef CRITERIUM_ALLOC_REC_H
+#define CRITERIUM_ALLOC_REC_H
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace criterium {
+
+// Allocation record for tracking object allocations.
+// Uses int64_t for portability (maps to jlong in JNI).
+struct AllocRec {
+  std::string obj_class;
+  int64_t obj_size;
+
+  std::string call_class;
+  std::string call_method;
+  std::string call_file;
+  int64_t call_line;
+
+  std::string alloc_class;
+  std::string alloc_method;
+  std::string alloc_file;
+  int64_t alloc_line;
+
+  int64_t thread_id;
+  int64_t freed{};
+
+  int64_t tag;
+  bool start_marker{};
+  bool disable_marker{};
+
+  AllocRec(const char* obj_class,
+           int64_t obj_size,
+           const char* call_class,
+           const char* call_method,
+           const char* call_file,
+           int64_t call_line,
+           const char* alloc_class,
+           const char* alloc_method,
+           const char* alloc_file,
+           int64_t alloc_line,
+           int64_t thread_id,
+           int64_t tag)
+    : obj_class(obj_class),
+      obj_size(obj_size),
+      call_class(call_class != nullptr ? call_class : ""),
+      call_method(call_method != nullptr ? call_method : ""),
+      call_file(call_file != nullptr ? call_file : "<no_file>"),
+      call_line(call_line),
+      alloc_class(alloc_class != nullptr ? alloc_class : ""),
+      alloc_method(alloc_method != nullptr ? alloc_method : ""),
+      alloc_file(alloc_file != nullptr ? alloc_file : "<no_file>"),
+      alloc_line(alloc_line),
+      thread_id(thread_id),
+      tag(tag) {}
+};
+
+using AllocsT = std::vector<std::unique_ptr<AllocRec>>;
+
+// Extracts all tags from a collection of allocation records.
+// Works with any container of unique_ptr<T> where T has a `tag` member.
+// Returns a vector of tag values in the same order as the input records,
+// with initial capacity reserved based on input size.
+template <typename T>
+inline auto all_tags(const std::vector<std::unique_ptr<T>>& allocs) {
+  auto tags = std::vector<decltype(std::declval<T>().tag)>();
+  tags.reserve(allocs.size());
+  std::transform(allocs.begin(),
+                 allocs.end(),
+                 std::back_inserter(tags),
+                 std::mem_fn(&T::tag));
+  return tags;
+}
+
+}  // namespace criterium
+
+#endif  // CRITERIUM_ALLOC_REC_H

--- a/agent-cpp/include/alloc_rec.h
+++ b/agent-cpp/include/alloc_rec.h
@@ -1,8 +1,8 @@
 #ifndef CRITERIUM_ALLOC_REC_H
 #define CRITERIUM_ALLOC_REC_H
 
+#include <jni.h>
 #include <algorithm>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -11,49 +11,51 @@
 namespace criterium {
 
 // Allocation record for tracking object allocations.
-// Uses int64_t for portability (maps to jlong in JNI).
 struct AllocRec {
   std::string obj_class;
-  int64_t obj_size;
+  jlong obj_size;
 
   std::string call_class;
   std::string call_method;
   std::string call_file;
-  int64_t call_line;
+  jlong call_line;
 
   std::string alloc_class;
   std::string alloc_method;
   std::string alloc_file;
-  int64_t alloc_line;
+  jlong alloc_line;
 
-  int64_t thread_id;
-  int64_t freed{};
+  jlong thread_id;
+  jlong freed{};
 
-  int64_t tag;
+  jlong tag;
   bool start_marker{};
   bool disable_marker{};
 
-  AllocRec(const char* obj_class,
-           int64_t obj_size,
-           const char* call_class,
-           const char* call_method,
-           const char* call_file,
-           int64_t call_line,
-           const char* alloc_class,
-           const char* alloc_method,
-           const char* alloc_file,
-           int64_t alloc_line,
-           int64_t thread_id,
-           int64_t tag)
+  static constexpr char const* no_file_name = "NO_SOURCE";
+
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  AllocRec(char const* obj_class,
+           jlong obj_size,
+           char const* call_class,
+           char const* call_method,
+           char const* call_file,
+           jlong call_line,
+           char const* alloc_class,
+           char const* alloc_method,
+           char const* alloc_file,
+           jlong alloc_line,
+           jlong thread_id,
+           jlong tag)
     : obj_class(obj_class),
       obj_size(obj_size),
-      call_class(call_class != nullptr ? call_class : ""),
-      call_method(call_method != nullptr ? call_method : ""),
-      call_file(call_file != nullptr ? call_file : "<no_file>"),
+      call_class(call_class == nullptr ? "" : call_class),
+      call_method(call_method == nullptr ? "" : call_method),
+      call_file(call_file == nullptr ? no_file_name : call_file),
       call_line(call_line),
-      alloc_class(alloc_class != nullptr ? alloc_class : ""),
-      alloc_method(alloc_method != nullptr ? alloc_method : ""),
-      alloc_file(alloc_file != nullptr ? alloc_file : "<no_file>"),
+      alloc_class(alloc_class == nullptr ? "" : alloc_class),
+      alloc_method(alloc_method == nullptr ? "" : alloc_method),
+      alloc_file(alloc_file == nullptr ? no_file_name : alloc_file),
       alloc_line(alloc_line),
       thread_id(thread_id),
       tag(tag) {}

--- a/agent-cpp/include/jni_operations.h
+++ b/agent-cpp/include/jni_operations.h
@@ -1,0 +1,77 @@
+#ifndef CRITERIUM_JNI_OPERATIONS_H
+#define CRITERIUM_JNI_OPERATIONS_H
+
+#include <jni.h>
+
+namespace criterium {
+
+/// Interface for JNI operations to enable unit testing with mocks.
+/// Abstracts the JNIEnv* calls used during runtime event processing.
+/// Each method takes JNIEnv* as first parameter since JNIEnv is thread-local.
+class IJniOperations {
+public:
+  virtual ~IJniOperations() = default;
+
+  // Reference management
+  virtual jobject new_global_ref(JNIEnv* env, jobject obj) = 0;
+  virtual void delete_global_ref(JNIEnv* env, jobject obj) = 0;
+
+  // String operations
+  virtual jstring new_string_utf(JNIEnv* env, const char* str) = 0;
+
+  // Method invocation
+  virtual jlong call_long_method(JNIEnv* env, jobject obj, jmethodID method) = 0;
+  virtual void call_static_void_method(JNIEnv* env, jclass klass,
+                                       jmethodID method, jobject arg) = 0;
+
+  // Object creation using jvalue array (NewObjectA)
+  virtual jobject new_object_a(JNIEnv* env, jclass klass, jmethodID ctor,
+                               const jvalue* args) = 0;
+
+  // Field access
+  virtual void set_static_long_field(JNIEnv* env, jclass klass, jfieldID field,
+                                     jlong value) = 0;
+};
+
+/// Production implementation delegating to JNIEnv*.
+class JniOperations : public IJniOperations {
+public:
+  JniOperations() = default;
+
+  jobject new_global_ref(JNIEnv* env, jobject obj) override {
+    return env->NewGlobalRef(obj);
+  }
+
+  void delete_global_ref(JNIEnv* env, jobject obj) override {
+    env->DeleteGlobalRef(obj);
+  }
+
+  jstring new_string_utf(JNIEnv* env, const char* str) override {
+    return env->NewStringUTF(str);
+  }
+
+  jlong call_long_method(JNIEnv* env, jobject obj, jmethodID method) override {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    return env->CallLongMethod(obj, method);
+  }
+
+  void call_static_void_method(JNIEnv* env, jclass klass, jmethodID method,
+                               jobject arg) override {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    env->CallStaticVoidMethod(klass, method, arg);
+  }
+
+  jobject new_object_a(JNIEnv* env, jclass klass, jmethodID ctor,
+                       const jvalue* args) override {
+    return env->NewObjectA(klass, ctor, args);
+  }
+
+  void set_static_long_field(JNIEnv* env, jclass klass, jfieldID field,
+                             jlong value) override {
+    env->SetStaticLongField(klass, field, value);
+  }
+};
+
+} // namespace criterium
+
+#endif // CRITERIUM_JNI_OPERATIONS_H

--- a/agent-cpp/include/jvmti_operations.h
+++ b/agent-cpp/include/jvmti_operations.h
@@ -1,0 +1,114 @@
+#ifndef CRITERIUM_JVMTI_OPERATIONS_H
+#define CRITERIUM_JVMTI_OPERATIONS_H
+
+#include <jvmti.h>
+
+namespace criterium {
+
+/// Interface for JVMTI operations to enable unit testing with mocks.
+/// Abstracts the jvmtiEnv* calls used during runtime event processing.
+class IJvmtiOperations {
+public:
+  virtual ~IJvmtiOperations() = default;
+
+  // Class and method introspection
+  virtual bool get_class_signature(jclass klass, char** class_sig) = 0;
+  virtual bool get_source_file_name(jclass klass, char** source_name) = 0;
+  virtual bool get_method_declaring_class(jmethodID method,
+                                          jclass* declaring_class) = 0;
+  virtual bool get_method_name(jmethodID method, char** method_name) = 0;
+
+  // Stack trace
+  virtual bool get_stack_trace(jthread thread, jint start_depth,
+                               jint max_frame_count, jvmtiFrameInfo* frames,
+                               jint* count) = 0;
+  virtual bool get_line_number_table(jmethodID method, jint* entry_count,
+                                     jvmtiLineNumberEntry** line_table) = 0;
+
+  // Object tagging
+  virtual bool set_tag(jobject object, jlong tag) = 0;
+  virtual bool get_objects_with_tags(jint tag_count, const jlong* tags,
+                                     jint* count, jobject** objects,
+                                     jlong** object_tags) = 0;
+
+  // Sampling and event control
+  virtual bool set_heap_sampling_interval(jint sampling_interval) = 0;
+  virtual bool set_event_notification_mode(jvmtiEventMode mode,
+                                           jvmtiEvent event_type,
+                                           jthread event_thread) = 0;
+
+  // Memory deallocation for JVMTI-allocated memory
+  virtual void deallocate(unsigned char* mem) = 0;
+};
+
+/// Production implementation wrapping a real jvmtiEnv*.
+class JvmtiOperations : public IJvmtiOperations {
+private:
+  jvmtiEnv* jvmti_;
+
+public:
+  explicit JvmtiOperations(jvmtiEnv* jvmti) : jvmti_(jvmti) {}
+
+  bool get_class_signature(jclass klass, char** class_sig) override {
+    auto err = jvmti_->GetClassSignature(klass, class_sig, nullptr);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool get_source_file_name(jclass klass, char** source_name) override {
+    auto err = jvmti_->GetSourceFileName(klass, source_name);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool get_method_declaring_class(jmethodID method,
+                                  jclass* declaring_class) override {
+    auto err = jvmti_->GetMethodDeclaringClass(method, declaring_class);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool get_method_name(jmethodID method, char** method_name) override {
+    auto err = jvmti_->GetMethodName(method, method_name, nullptr, nullptr);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool get_stack_trace(jthread thread, jint start_depth, jint max_frame_count,
+                       jvmtiFrameInfo* frames, jint* count) override {
+    auto err =
+        jvmti_->GetStackTrace(thread, start_depth, max_frame_count, frames, count);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool get_line_number_table(jmethodID method, jint* entry_count,
+                             jvmtiLineNumberEntry** line_table) override {
+    auto err = jvmti_->GetLineNumberTable(method, entry_count, line_table);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool set_tag(jobject object, jlong tag) override {
+    auto err = jvmti_->SetTag(object, tag);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool get_objects_with_tags(jint tag_count, const jlong* tags, jint* count,
+                             jobject** objects, jlong** object_tags) override {
+    auto err =
+        jvmti_->GetObjectsWithTags(tag_count, tags, count, objects, object_tags);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool set_heap_sampling_interval(jint sampling_interval) override {
+    auto err = jvmti_->SetHeapSamplingInterval(sampling_interval);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  bool set_event_notification_mode(jvmtiEventMode mode, jvmtiEvent event_type,
+                                   jthread event_thread) override {
+    auto err = jvmti_->SetEventNotificationMode(mode, event_type, event_thread);
+    return err == JVMTI_ERROR_NONE;
+  }
+
+  void deallocate(unsigned char* mem) override { jvmti_->Deallocate(mem); }
+};
+
+} // namespace criterium
+
+#endif // CRITERIUM_JVMTI_OPERATIONS_H

--- a/agent-cpp/include/message_queue.h
+++ b/agent-cpp/include/message_queue.h
@@ -1,0 +1,50 @@
+#ifndef CRITERIUM_MESSAGE_QUEUE_H
+#define CRITERIUM_MESSAGE_QUEUE_H
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+
+namespace criterium {
+
+// Thread-safe blocking message queue.
+// - push() adds a message and notifies one waiting consumer
+// - pop() blocks until a message is available or stop() is called
+// - stop() signals consumers to exit; pop() returns false when stopped and empty
+template<typename T>
+class MessageQueue {
+  std::queue<T> queue;
+  std::mutex mutex;
+  std::condition_variable cond;
+  bool stopped = false;
+
+public:
+  void push(T msg) {
+    std::lock_guard<std::mutex> lock(mutex);
+    queue.push(std::move(msg));
+    cond.notify_one();
+  }
+
+  bool pop(T& msg) {
+    std::unique_lock<std::mutex> lock(mutex);
+    while (queue.empty() && !stopped) {
+      cond.wait(lock);
+    }
+    if (stopped && queue.empty()) {
+      return false;
+    }
+    msg = std::move(queue.front());
+    queue.pop();
+    return true;
+  }
+
+  void stop() {
+    std::lock_guard<std::mutex> lock(mutex);
+    stopped = true;
+    cond.notify_all();
+  }
+};
+
+} // namespace criterium
+
+#endif // CRITERIUM_MESSAGE_QUEUE_H

--- a/agent-cpp/include/state_transitions.h
+++ b/agent-cpp/include/state_transitions.h
@@ -1,0 +1,79 @@
+#ifndef CRITERIUM_STATE_TRANSITIONS_H
+#define CRITERIUM_STATE_TRANSITIONS_H
+
+#include "agent_types.h"
+#include <cstring>
+
+namespace criterium {
+
+/// Marker class signatures for state transitions.
+inline constexpr char const* ALLOCATION_START_MARKER =
+    "Lcriterium/agent/Agent$AllocationStartMarker;";
+inline constexpr char const* ALLOCATION_FINISH_MARKER =
+    "Lcriterium/agent/Agent$AllocationFinishMarker;";
+
+/// Pure functions for state machine transitions.
+/// These can be tested without mocking JVMTI/JNI.
+namespace state_transitions {
+
+/// Returns true if the allocation is a start marker in the starting state.
+inline bool is_start_marker_allocation(jlong state, const char* class_sig) {
+  return state == allocation_tracing_starting &&
+         std::strcmp(class_sig, ALLOCATION_START_MARKER) == 0;
+}
+
+/// Returns true if the allocation is a finish marker in the stopping state.
+inline bool is_finish_marker_allocation(jlong state, const char* class_sig) {
+  return state == allocation_tracing_stopping &&
+         std::strcmp(class_sig, ALLOCATION_FINISH_MARKER) == 0;
+}
+
+/// Returns the next state after processing an allocation event.
+/// Returns the current state if no transition occurs.
+inline jlong next_state_after_allocation(jlong state, const char* class_sig) {
+  if (is_finish_marker_allocation(state, class_sig)) {
+    return allocation_tracing_flushing;
+  }
+  return state;
+}
+
+/// Returns the next state after processing an object free event.
+/// @param state Current agent state
+/// @param is_start_marker True if the freed object was marked as start marker
+/// @param is_disable_marker True if the freed object was marked as disable
+/// marker
+inline jlong next_state_after_object_free(jlong state, bool is_start_marker,
+                                          bool is_disable_marker) {
+  if (is_start_marker && state == allocation_tracing_starting) {
+    return allocation_tracing_active;
+  }
+  if (is_disable_marker && state == allocation_tracing_flushing) {
+    return allocation_tracing_flushed;
+  }
+  return state;
+}
+
+/// Returns the next state after processing a command.
+/// Note: Some commands (start, stop) cause immediate transitions.
+/// Report command transitions through reporting to reported.
+inline jlong next_state_for_command(jlong cmd) {
+  switch (cmd) {
+  case start_allocation_tracing:
+    return allocation_tracing_starting;
+  case stop_allocation_tracing:
+    return allocation_tracing_stopping;
+  case report_allocation_tracing:
+    // Caller should set reporting, then reported after work is done
+    return allocation_tracing_reporting;
+  case sync_state:
+  case ping:
+  default:
+    // These commands don't change state
+    return -1; // Sentinel meaning "no state change"
+  }
+}
+
+} // namespace state_transitions
+} // namespace criterium
+
+#endif // CRITERIUM_STATE_TRANSITIONS_H

--- a/agent-cpp/include/utils.h
+++ b/agent-cpp/include/utils.h
@@ -1,0 +1,33 @@
+#ifndef CRITERIUM_UTILS_H
+#define CRITERIUM_UTILS_H
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+namespace criterium {
+
+struct PrefixEntry {
+  const char* prefix;
+  size_t length;
+};
+
+constexpr std::array<PrefixEntry, 6> SYSTEM_PREFIXES{{
+  {"Ljava/", 6},
+  {"Lcom/sun/", 9},
+  {"Ljdk/", 5},
+  {"Ljavax/", 7},
+  {"Lsun/management", 15},
+  {"Lclojure/", 9}
+}};
+
+inline bool is_system_class(const char* class_name) {
+  return std::any_of(SYSTEM_PREFIXES.begin(), SYSTEM_PREFIXES.end(),
+    [class_name](const PrefixEntry& entry) {
+      return strncmp(class_name, entry.prefix, entry.length) == 0;
+    });
+}
+
+} // namespace criterium
+
+#endif // CRITERIUM_UTILS_H

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Test executable
 add_executable(criterium_tests
     test_main.cpp
+    agent_state_test.cpp
     all_tags_test.cpp
     is_system_class_test.cpp
     message_queue_test.cpp

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(criterium_tests
     test_main.cpp
     is_system_class_test.cpp
+    message_queue_test.cpp
 )
 
 target_include_directories(criterium_tests PRIVATE

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Test executable
 add_executable(criterium_tests
     test_main.cpp
+    is_system_class_test.cpp
+)
+
+target_include_directories(criterium_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}
 )
 
 target_link_libraries(criterium_tests

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(criterium_tests
     test_main.cpp
     agent_state_test.cpp
     all_tags_test.cpp
+    integration_test.cpp
     is_system_class_test.cpp
     message_queue_test.cpp
 )

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(criterium_tests
     integration_test.cpp
     is_system_class_test.cpp
     message_queue_test.cpp
+    state_transitions_test.cpp
 )
 
 target_include_directories(criterium_tests PRIVATE

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Test executable
 add_executable(criterium_tests
     test_main.cpp
+    all_tags_test.cpp
     is_system_class_test.cpp
     message_queue_test.cpp
 )

--- a/agent-cpp/test/CMakeLists.txt
+++ b/agent-cpp/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Test executable
+add_executable(criterium_tests
+    test_main.cpp
+)
+
+target_link_libraries(criterium_tests
+    GTest::gtest_main
+    GTest::gmock
+)
+
+target_compile_options(criterium_tests PRIVATE ${WARNING_FLAGS})
+
+include(GoogleTest)
+gtest_discover_tests(criterium_tests)

--- a/agent-cpp/test/agent_state_test.cpp
+++ b/agent-cpp/test/agent_state_test.cpp
@@ -124,6 +124,16 @@ public:
     }
   }
 
+  /// Returns allocation record for a given tag, or nullptr if not found.
+  /// Used by tests to verify marker flags are set correctly.
+  const AllocRec* get_alloc_by_tag(jlong tag) const {
+    auto it = allocs_by_tag_.find(tag);
+    return it != allocs_by_tag_.end() ? it->second : nullptr;
+  }
+
+  /// Returns count of tracked allocations.
+  size_t get_alloc_count() const { return allocs_.size(); }
+
 private:
   void enable_allocation_tracing() {
     state_ = allocation_tracing_starting;
@@ -583,4 +593,256 @@ TEST_F(AgentStateTest, FullStateTransitionCycle) {
 
   state_machine->process_command(Command{report_allocation_tracing});
   EXPECT_EQ(state_machine->get_state(), allocation_tracing_reported);
+}
+
+/// Marker Detection Tests
+///
+/// These tests focus specifically on the detection of start and finish markers,
+/// verifying that marker flags are set correctly and that markers are only
+/// recognized in the appropriate states.
+
+TEST_F(AgentStateTest, StartMarkerSetsStartMarkerFlag) {
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_TRUE(rec->start_marker)
+      << "start_marker flag should be true for start marker allocation";
+  EXPECT_FALSE(rec->disable_marker)
+      << "disable_marker flag should be false for start marker";
+}
+
+TEST_F(AgentStateTest, FinishMarkerSetsDisableMarkerFlag) {
+  // Reach stopping state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+
+  state_machine->process_allocation_event(FINISH_MARKER, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_TRUE(rec->disable_marker)
+      << "disable_marker flag should be true for finish marker allocation";
+  EXPECT_FALSE(rec->start_marker)
+      << "start_marker flag should be false for finish marker";
+}
+
+TEST_F(AgentStateTest, RegularAllocationHasNoMarkerFlags) {
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+
+  state_machine->process_allocation_event(REGULAR_CLASS, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->start_marker)
+      << "start_marker flag should be false for regular allocation";
+  EXPECT_FALSE(rec->disable_marker)
+      << "disable_marker flag should be false for regular allocation";
+}
+
+TEST_F(AgentStateTest, StartMarkerInActiveStateNoFlag) {
+  // Reach active state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  // Another start marker allocation in active state should not set flag
+  state_machine->process_allocation_event(START_MARKER, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->start_marker)
+      << "start_marker flag should not be set when in active state";
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active)
+      << "State should remain active";
+}
+
+TEST_F(AgentStateTest, FinishMarkerInActiveStateNoFlag) {
+  // Reach active state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  // Finish marker in active state should not set disable flag
+  state_machine->process_allocation_event(FINISH_MARKER, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->disable_marker)
+      << "disable_marker flag should not be set when in active state";
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active)
+      << "State should remain active";
+}
+
+TEST_F(AgentStateTest, StartMarkerInStoppingStateNoFlag) {
+  // Reach stopping state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_stopping);
+
+  // Start marker in stopping state should not set start flag
+  state_machine->process_allocation_event(START_MARKER, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->start_marker)
+      << "start_marker flag should not be set when in stopping state";
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_stopping)
+      << "State should remain stopping (not triggered by start marker)";
+}
+
+TEST_F(AgentStateTest, FinishMarkerInStartingStateNoFlag) {
+  state_machine->process_command(Command{start_allocation_tracing});
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_starting);
+
+  // Finish marker in starting state should not set disable flag
+  state_machine->process_allocation_event(FINISH_MARKER, 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->disable_marker)
+      << "disable_marker flag should not be set when in starting state";
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting)
+      << "State should remain starting";
+}
+
+TEST_F(AgentStateTest, MultipleStartMarkersOnlyFirstSetsFlag) {
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  // First start marker sets flag
+  state_machine->process_allocation_event(START_MARKER, 100);
+  const auto* rec1 = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec1, nullptr);
+  EXPECT_TRUE(rec1->start_marker);
+
+  // Free the first marker to transition to active
+  state_machine->process_object_free_event(100);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  // Second start marker should not set flag (now in active state)
+  state_machine->process_allocation_event(START_MARKER, 101);
+  const auto* rec2 = state_machine->get_alloc_by_tag(101);
+  ASSERT_NE(rec2, nullptr);
+  EXPECT_FALSE(rec2->start_marker)
+      << "Second start marker should not set flag after transition";
+}
+
+TEST_F(AgentStateTest, MultipleFinishMarkersOnlyFirstSetsFlag) {
+  // Reach stopping state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+
+  // First finish marker sets flag and transitions to flushing
+  state_machine->process_allocation_event(FINISH_MARKER, 100);
+  const auto* rec1 = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec1, nullptr);
+  EXPECT_TRUE(rec1->disable_marker);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_flushing);
+
+  // Second finish marker should not set flag (now in flushing state)
+  state_machine->process_allocation_event(FINISH_MARKER, 101);
+  const auto* rec2 = state_machine->get_alloc_by_tag(101);
+  ASSERT_NE(rec2, nullptr);
+  EXPECT_FALSE(rec2->disable_marker)
+      << "Second finish marker should not set flag after transition";
+}
+
+TEST_F(AgentStateTest, StartMarkerFreedButNotInStartingState) {
+  // Allocate start marker before entering starting state
+  // This is an edge case - in practice the marker is allocated after
+  // the start command, but tests the robustness of state checks
+
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  // Now allocate another start marker
+  state_machine->process_allocation_event(START_MARKER, 100);
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  // Flag not set because not in starting state
+  EXPECT_FALSE(rec->start_marker);
+
+  // Freeing it should not cause transition
+  state_machine->process_object_free_event(100);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active)
+      << "Freeing start marker in active state should not cause transition";
+}
+
+TEST_F(AgentStateTest, FinishMarkerFreedButNotInFlushingState) {
+  // Reach stopping state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_stopping);
+
+  // Allocate finish marker but don't process free yet
+  state_machine->process_allocation_event(FINISH_MARKER, 100);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_flushing);
+
+  // Allocate another finish marker (without disable flag)
+  state_machine->process_allocation_event(FINISH_MARKER, 101);
+  const auto* rec = state_machine->get_alloc_by_tag(101);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->disable_marker)
+      << "Second finish marker should not have disable flag";
+
+  // Freeing the second one should not cause flushed transition
+  state_machine->process_object_free_event(101);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushing)
+      << "Freeing non-disable marker should not cause flushed transition";
+
+  // Freeing the first (with disable flag) should cause transition
+  state_machine->process_object_free_event(100);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushed);
+}
+
+TEST_F(AgentStateTest, MarkerClassSignatureMustMatchExactly) {
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  // Similar but not exact class signature
+  state_machine->process_allocation_event(
+      "Lcriterium/agent/Agent$AllocationStartMarkerFake;", 100);
+
+  const auto* rec = state_machine->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_FALSE(rec->start_marker)
+      << "Non-matching class signature should not set marker flag";
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting)
+      << "State should remain starting";
+}
+
+TEST_F(AgentStateTest, MarkerRecordsAreTrackedLikeRegularAllocations) {
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  // Start marker is tracked
+  state_machine->process_allocation_event(START_MARKER, 1);
+  EXPECT_EQ(state_machine->get_alloc_count(), 1u);
+
+  state_machine->process_object_free_event(1);
+
+  // Regular allocations
+  state_machine->process_allocation_event(REGULAR_CLASS, 10);
+  state_machine->process_allocation_event(REGULAR_CLASS, 11);
+  EXPECT_EQ(state_machine->get_alloc_count(), 3u);
+
+  state_machine->process_command(Command{stop_allocation_tracing});
+
+  // Finish marker is tracked
+  state_machine->process_allocation_event(FINISH_MARKER, 2);
+  EXPECT_EQ(state_machine->get_alloc_count(), 4u);
 }

--- a/agent-cpp/test/agent_state_test.cpp
+++ b/agent-cpp/test/agent_state_test.cpp
@@ -1,0 +1,455 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <tuple>
+#include <vector>
+#include "include/agent_types.h"
+#include "include/agent_state.h"
+#include "mocks.h"
+
+using namespace criterium;
+using namespace criterium::test;
+using ::testing::_;
+using ::testing::Return;
+using ::testing::NiceMock;
+using ::testing::DoAll;
+using ::testing::SetArgPointee;
+
+// Tests for AgentState state machine transitions.
+// These tests validate the state transition logic using mocked JVMTI/JNI
+// operations. The state machine follows this flow:
+//
+//   passive → allocation_tracing_starting (start command)
+//           → allocation_tracing_active (start marker freed)
+//           → allocation_tracing_stopping (stop command)
+//           → allocation_tracing_flushing (finish marker seen)
+//           → allocation_tracing_flushed (finish marker freed)
+//           → allocation_tracing_reporting (report command)
+//           → allocation_tracing_reported (report complete)
+
+// Marker class signatures for state transitions
+static constexpr char const* START_MARKER =
+    "Lcriterium/agent/Agent$AllocationStartMarker;";
+static constexpr char const* FINISH_MARKER =
+    "Lcriterium/agent/Agent$AllocationFinishMarker;";
+static constexpr char const* REGULAR_CLASS = "Ljava/lang/Object;";
+
+/// Testable state machine that mirrors AgentState's transition logic.
+/// This enables unit testing of state transitions without the full
+/// agent dependencies (VMContext, AgentContext singletons).
+class TestableStateMachine {
+private:
+  NiceMock<MockJvmtiOperations>& jvmti_ops_;
+  [[maybe_unused]] NiceMock<MockJniOperations>& jni_ops_;
+  jlong state_ = passive;
+  std::vector<std::unique_ptr<AllocRec>> allocs_;
+  std::map<jlong, AllocRec*> allocs_by_tag_;
+
+public:
+  TestableStateMachine(NiceMock<MockJvmtiOperations>& jvmti_ops,
+                       NiceMock<MockJniOperations>& jni_ops)
+      : jvmti_ops_(jvmti_ops), jni_ops_(jni_ops) {}
+
+  jlong get_state() const { return state_; }
+
+  void process_command(const Command& cmd) {
+    switch (cmd.cmd) {
+    case start_allocation_tracing:
+      enable_allocation_tracing();
+      break;
+    case stop_allocation_tracing:
+      disable_allocation_tracing();
+      break;
+    case report_allocation_tracing:
+      state_ = allocation_tracing_reporting;
+      // allocation_tracing_report would be called here
+      state_ = allocation_tracing_reported;
+      break;
+    case sync_state:
+      // sync_state just reports current state to Java, no transition
+      break;
+    case ping:
+      // ping is a no-op for state
+      break;
+    default:
+      break;
+    }
+  }
+
+  void process_allocation_event(const char* class_sig, jlong tag) {
+    auto starting =
+        state_ == allocation_tracing_starting &&
+        std::strcmp(class_sig, START_MARKER) == 0;
+
+    auto stopping =
+        state_ == allocation_tracing_stopping &&
+        std::strcmp(class_sig, FINISH_MARKER) == 0;
+
+    auto rec = std::make_unique<AllocRec>(
+        class_sig, 0, nullptr, nullptr, nullptr, -1,
+        nullptr, nullptr, nullptr, -1, 0, tag);
+
+    if (starting) {
+      rec->start_marker = true;
+    }
+
+    if (stopping) {
+      // Disable allocation sampling
+      jvmti_ops_.set_event_notification_mode(
+          JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
+      rec->disable_marker = true;
+      state_ = allocation_tracing_flushing;
+    }
+
+    allocs_by_tag_.emplace(rec->tag, rec.get());
+    allocs_.push_back(std::move(rec));
+  }
+
+  void process_object_free_event(jlong tag) {
+    auto it = allocs_by_tag_.find(tag);
+    if (it == allocs_by_tag_.end()) {
+      return;
+    }
+
+    AllocRec* rec = it->second;
+    rec->freed = 1;
+
+    if (rec->start_marker && state_ == allocation_tracing_starting) {
+      state_ = allocation_tracing_active;
+    }
+
+    if (state_ == allocation_tracing_flushing && rec->disable_marker) {
+      jvmti_ops_.set_event_notification_mode(
+          JVMTI_DISABLE, JVMTI_EVENT_OBJECT_FREE, nullptr);
+      state_ = allocation_tracing_flushed;
+    }
+  }
+
+private:
+  void enable_allocation_tracing() {
+    state_ = allocation_tracing_starting;
+    allocs_.clear();
+    allocs_by_tag_.clear();
+    jvmti_ops_.set_heap_sampling_interval(0);
+    jvmti_ops_.set_event_notification_mode(
+        JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
+    jvmti_ops_.set_event_notification_mode(
+        JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, nullptr);
+  }
+
+  void disable_allocation_tracing() {
+    state_ = allocation_tracing_stopping;
+  }
+};
+
+class AgentStateTest : public ::testing::Test {
+protected:
+  NiceMock<MockJvmtiOperations> mock_jvmti;
+  NiceMock<MockJniOperations> mock_jni;
+  std::unique_ptr<TestableStateMachine> state_machine;
+
+  void SetUp() override {
+    // Configure default mock behavior
+    ON_CALL(mock_jvmti, set_heap_sampling_interval(_))
+        .WillByDefault(Return(true));
+    ON_CALL(mock_jvmti, set_event_notification_mode(_, _, _))
+        .WillByDefault(Return(true));
+
+    state_machine =
+        std::make_unique<TestableStateMachine>(mock_jvmti, mock_jni);
+  }
+};
+
+/// Test data for command-based state transitions.
+struct CommandTransitionTest {
+  const char* name;
+  jlong initial_state;
+  jlong command;
+  jlong expected_state;
+};
+
+class CommandTransitionTestSuite
+    : public AgentStateTest,
+      public ::testing::WithParamInterface<CommandTransitionTest> {};
+
+TEST_P(CommandTransitionTestSuite, TransitionsCorrectlyOnCommand) {
+  const auto& test = GetParam();
+
+  // Set initial state by processing appropriate commands
+  if (test.initial_state != passive) {
+    if (test.initial_state >= allocation_tracing_starting) {
+      state_machine->process_command(Command{start_allocation_tracing});
+    }
+    if (test.initial_state >= allocation_tracing_active) {
+      state_machine->process_allocation_event(START_MARKER, 1);
+      state_machine->process_object_free_event(1);
+    }
+    if (test.initial_state >= allocation_tracing_stopping) {
+      state_machine->process_command(Command{stop_allocation_tracing});
+    }
+    if (test.initial_state >= allocation_tracing_flushing) {
+      state_machine->process_allocation_event(FINISH_MARKER, 2);
+    }
+    if (test.initial_state >= allocation_tracing_flushed) {
+      state_machine->process_object_free_event(2);
+    }
+    if (test.initial_state >= allocation_tracing_reporting) {
+      state_machine->process_command(Command{report_allocation_tracing});
+    }
+  }
+
+  // Verify we're in the expected initial state
+  ASSERT_EQ(state_machine->get_state(), test.initial_state)
+      << "Failed to reach initial state for test: " << test.name;
+
+  // Apply the command
+  state_machine->process_command(Command{test.command});
+
+  // Verify final state
+  EXPECT_EQ(state_machine->get_state(), test.expected_state)
+      << "State transition failed for: " << test.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CommandTransitions, CommandTransitionTestSuite,
+    ::testing::Values(
+        // Start tracing from passive
+        CommandTransitionTest{"passive_to_starting_on_start_command",
+                              passive, start_allocation_tracing,
+                              allocation_tracing_starting},
+
+        // Stop tracing from active
+        CommandTransitionTest{"active_to_stopping_on_stop_command",
+                              allocation_tracing_active,
+                              stop_allocation_tracing,
+                              allocation_tracing_stopping},
+
+        // Report from flushed
+        CommandTransitionTest{"flushed_to_reported_on_report_command",
+                              allocation_tracing_flushed,
+                              report_allocation_tracing,
+                              allocation_tracing_reported},
+
+        // Sync state has no effect on state value
+        CommandTransitionTest{"starting_unchanged_on_sync_state",
+                              allocation_tracing_starting,
+                              sync_state,
+                              allocation_tracing_starting},
+
+        // Ping has no effect on state
+        CommandTransitionTest{"passive_unchanged_on_ping",
+                              passive, ping, passive}),
+    [](const ::testing::TestParamInfo<CommandTransitionTest>& info) {
+      return info.param.name;
+    });
+
+/// Test data for marker-based state transitions.
+struct MarkerTransitionTest {
+  const char* name;
+  jlong initial_state;
+  const char* marker_class;
+  bool expect_free_event;  // Whether to process object_free after allocation
+  jlong expected_state;
+};
+
+class MarkerTransitionTestSuite
+    : public AgentStateTest,
+      public ::testing::WithParamInterface<MarkerTransitionTest> {};
+
+TEST_P(MarkerTransitionTestSuite, TransitionsCorrectlyOnMarker) {
+  const auto& test = GetParam();
+  const jlong test_tag = 100;
+
+  // Set initial state
+  if (test.initial_state >= allocation_tracing_starting) {
+    state_machine->process_command(Command{start_allocation_tracing});
+  }
+  if (test.initial_state >= allocation_tracing_active) {
+    state_machine->process_allocation_event(START_MARKER, 1);
+    state_machine->process_object_free_event(1);
+  }
+  if (test.initial_state >= allocation_tracing_stopping) {
+    state_machine->process_command(Command{stop_allocation_tracing});
+  }
+  if (test.initial_state >= allocation_tracing_flushing) {
+    // Need to process finish marker allocation to reach flushing
+    state_machine->process_allocation_event(FINISH_MARKER, 2);
+  }
+  if (test.initial_state >= allocation_tracing_flushed) {
+    state_machine->process_object_free_event(2);
+  }
+
+  ASSERT_EQ(state_machine->get_state(), test.initial_state)
+      << "Failed to reach initial state for test: " << test.name;
+
+  // Process allocation event with the marker class
+  state_machine->process_allocation_event(test.marker_class, test_tag);
+
+  if (test.expect_free_event) {
+    state_machine->process_object_free_event(test_tag);
+  }
+
+  EXPECT_EQ(state_machine->get_state(), test.expected_state)
+      << "State transition failed for: " << test.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MarkerTransitions, MarkerTransitionTestSuite,
+    ::testing::Values(
+        // Start marker allocation followed by free → active
+        MarkerTransitionTest{"starting_to_active_on_start_marker_freed",
+                             allocation_tracing_starting,
+                             START_MARKER, true,
+                             allocation_tracing_active},
+
+        // Start marker allocation without free → stays starting
+        MarkerTransitionTest{"starting_unchanged_on_start_marker_not_freed",
+                             allocation_tracing_starting,
+                             START_MARKER, false,
+                             allocation_tracing_starting},
+
+        // Finish marker seen → flushing
+        MarkerTransitionTest{"stopping_to_flushing_on_finish_marker_seen",
+                             allocation_tracing_stopping,
+                             FINISH_MARKER, false,
+                             allocation_tracing_flushing},
+
+        // Regular allocation doesn't change state
+        MarkerTransitionTest{"active_unchanged_on_regular_allocation",
+                             allocation_tracing_active,
+                             REGULAR_CLASS, false,
+                             allocation_tracing_active}),
+    [](const ::testing::TestParamInfo<MarkerTransitionTest>& info) {
+      return info.param.name;
+    });
+
+// Special test for flushing → flushed transition.
+// This transition requires freeing the same finish marker that caused
+// the stopping → flushing transition, so it can't use the table-driven
+// approach which uses a new tag.
+TEST_F(AgentStateTest, FlushingToFlushedOnFinishMarkerFreed) {
+  // Reach flushing state - the finish marker is recorded with tag 2
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+  state_machine->process_allocation_event(FINISH_MARKER, 2);
+
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_flushing);
+
+  // Free the finish marker (tag 2) - should transition to flushed
+  state_machine->process_object_free_event(2);
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushed);
+}
+
+// Additional tests for edge cases and JVMTI/JNI call verification
+
+TEST_F(AgentStateTest, StartCommandEnablesAllocationTracking) {
+  EXPECT_CALL(mock_jvmti, set_heap_sampling_interval(0)).Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(AgentStateTest, FinishMarkerSeenDisablesAllocationEvents) {
+  // Set up: reach stopping state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_stopping);
+
+  EXPECT_CALL(mock_jvmti,
+              set_event_notification_mode(
+                  JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+
+  state_machine->process_allocation_event(FINISH_MARKER, 2);
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushing);
+}
+
+TEST_F(AgentStateTest, FinishMarkerFreedDisablesObjectFreeEvents) {
+  // Set up: reach flushing state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+  state_machine->process_allocation_event(FINISH_MARKER, 2);
+
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_flushing);
+
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_DISABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+
+  state_machine->process_object_free_event(2);
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushed);
+}
+
+TEST_F(AgentStateTest, StartClearsExistingAllocations) {
+  // First allocation tracing cycle
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(REGULAR_CLASS, 1);
+  state_machine->process_allocation_event(REGULAR_CLASS, 2);
+
+  // Start new cycle - should clear allocations
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  // Process object free for old tag - should not cause crash or state change
+  state_machine->process_object_free_event(1);
+  state_machine->process_object_free_event(2);
+
+  // State should still be starting (allocations were cleared)
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(AgentStateTest, UnknownTagFreeIsIgnored) {
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  // Process free for tag that was never allocated
+  state_machine->process_object_free_event(999);
+
+  // State should be unchanged
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(AgentStateTest, FullStateTransitionCycle) {
+  // Test complete state machine cycle
+  EXPECT_EQ(state_machine->get_state(), passive);
+
+  state_machine->process_command(Command{start_allocation_tracing});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+
+  state_machine->process_allocation_event(START_MARKER, 1);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+
+  state_machine->process_object_free_event(1);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  // Some regular allocations
+  state_machine->process_allocation_event(REGULAR_CLASS, 10);
+  state_machine->process_allocation_event(REGULAR_CLASS, 11);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  state_machine->process_command(Command{stop_allocation_tracing});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_stopping);
+
+  state_machine->process_allocation_event(FINISH_MARKER, 2);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushing);
+
+  state_machine->process_object_free_event(2);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_flushed);
+
+  state_machine->process_command(Command{report_allocation_tracing});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_reported);
+}

--- a/agent-cpp/test/agent_state_test.cpp
+++ b/agent-cpp/test/agent_state_test.cpp
@@ -4,20 +4,24 @@
 #include <vector>
 #include "include/agent_types.h"
 #include "include/agent_state.h"
+#include "include/state_transitions.h"
 #include "mocks.h"
 
 using namespace criterium;
 using namespace criterium::test;
+using namespace criterium::state_transitions;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::NiceMock;
 using ::testing::DoAll;
 using ::testing::SetArgPointee;
 
-// Tests for AgentState state machine transitions.
-// These tests validate the state transition logic using mocked JVMTI/JNI
-// operations. The state machine follows this flow:
+// Tests for AgentState state machine behavior using mocked JVMTI/JNI ops.
+// The pure state transition logic is tested in state_transitions_test.cpp.
+// These tests verify that TestableStateMachine (which uses the shared
+// pure functions) correctly interacts with JVMTI/JNI operations.
 //
+// State machine flow:
 //   passive → allocation_tracing_starting (start command)
 //           → allocation_tracing_active (start marker freed)
 //           → allocation_tracing_stopping (stop command)
@@ -26,14 +30,13 @@ using ::testing::SetArgPointee;
 //           → allocation_tracing_reporting (report command)
 //           → allocation_tracing_reported (report complete)
 
-// Marker class signatures for state transitions
-static constexpr char const* START_MARKER =
-    "Lcriterium/agent/Agent$AllocationStartMarker;";
-static constexpr char const* FINISH_MARKER =
-    "Lcriterium/agent/Agent$AllocationFinishMarker;";
+// Use shared marker constants from state_transitions.h
+static constexpr char const* START_MARKER = ALLOCATION_START_MARKER;
+static constexpr char const* FINISH_MARKER = ALLOCATION_FINISH_MARKER;
 static constexpr char const* REGULAR_CLASS = "Ljava/lang/Object;";
 
-/// Testable state machine that mirrors AgentState's transition logic.
+/// Testable state machine that uses the same pure transition functions
+/// as AgentState, ensuring tests and production code share the same logic.
 /// This enables unit testing of state transitions without the full
 /// agent dependencies (VMContext, AgentContext singletons).
 class TestableStateMachine {
@@ -52,37 +55,26 @@ public:
   jlong get_state() const { return state_; }
 
   void process_command(const Command& cmd) {
-    switch (cmd.cmd) {
-    case start_allocation_tracing:
+    auto new_state = next_state_for_command(cmd.cmd);
+    if (new_state == -1) {
+      // No state change for this command
+      return;
+    }
+
+    if (cmd.cmd == start_allocation_tracing) {
       enable_allocation_tracing();
-      break;
-    case stop_allocation_tracing:
-      disable_allocation_tracing();
-      break;
-    case report_allocation_tracing:
+    } else if (cmd.cmd == stop_allocation_tracing) {
+      state_ = new_state;
+    } else if (cmd.cmd == report_allocation_tracing) {
       state_ = allocation_tracing_reporting;
       // allocation_tracing_report would be called here
       state_ = allocation_tracing_reported;
-      break;
-    case sync_state:
-      // sync_state just reports current state to Java, no transition
-      break;
-    case ping:
-      // ping is a no-op for state
-      break;
-    default:
-      break;
     }
   }
 
   void process_allocation_event(const char* class_sig, jlong tag) {
-    auto starting =
-        state_ == allocation_tracing_starting &&
-        std::strcmp(class_sig, START_MARKER) == 0;
-
-    auto stopping =
-        state_ == allocation_tracing_stopping &&
-        std::strcmp(class_sig, FINISH_MARKER) == 0;
+    auto starting = is_start_marker_allocation(state_, class_sig);
+    auto stopping = is_finish_marker_allocation(state_, class_sig);
 
     auto rec = std::make_unique<AllocRec>(
         class_sig, 0, nullptr, nullptr, nullptr, -1,
@@ -97,7 +89,7 @@ public:
       jvmti_ops_.set_event_notification_mode(
           JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
       rec->disable_marker = true;
-      state_ = allocation_tracing_flushing;
+      state_ = next_state_after_allocation(state_, class_sig);
     }
 
     allocs_by_tag_.emplace(rec->tag, rec.get());
@@ -113,14 +105,14 @@ public:
     AllocRec* rec = it->second;
     rec->freed = 1;
 
-    if (rec->start_marker && state_ == allocation_tracing_starting) {
-      state_ = allocation_tracing_active;
-    }
-
-    if (state_ == allocation_tracing_flushing && rec->disable_marker) {
-      jvmti_ops_.set_event_notification_mode(
-          JVMTI_DISABLE, JVMTI_EVENT_OBJECT_FREE, nullptr);
-      state_ = allocation_tracing_flushed;
+    auto new_state = next_state_after_object_free(state_, rec->start_marker,
+                                                  rec->disable_marker);
+    if (new_state != state_) {
+      if (rec->disable_marker) {
+        jvmti_ops_.set_event_notification_mode(
+            JVMTI_DISABLE, JVMTI_EVENT_OBJECT_FREE, nullptr);
+      }
+      state_ = new_state;
     }
   }
 
@@ -144,10 +136,6 @@ private:
         JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
     jvmti_ops_.set_event_notification_mode(
         JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, nullptr);
-  }
-
-  void disable_allocation_tracing() {
-    state_ = allocation_tracing_stopping;
   }
 };
 

--- a/agent-cpp/test/agent_state_test.cpp
+++ b/agent-cpp/test/agent_state_test.cpp
@@ -423,6 +423,137 @@ TEST_F(AgentStateTest, UnknownTagFreeIsIgnored) {
   EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
 }
 
+/// Command Processing Tests
+///
+/// These tests focus on the behavior of individual commands beyond just
+/// state transitions. They verify that commands trigger the correct
+/// JVMTI/JNI operations and handle edge cases properly.
+
+TEST_F(AgentStateTest, StopCommandOnlyChangesState) {
+  // Set up: reach active state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_active);
+
+  // Stop command should NOT make any JVMTI calls - it just changes state.
+  // The actual disabling happens when the finish marker is seen.
+  EXPECT_CALL(mock_jvmti, set_heap_sampling_interval(_)).Times(0);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(_, _, _)).Times(0);
+
+  state_machine->process_command(Command{stop_allocation_tracing});
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_stopping);
+}
+
+TEST_F(AgentStateTest, ReportCommandTransitionsThroughReportingState) {
+  // Set up: reach flushed state
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  state_machine->process_command(Command{stop_allocation_tracing});
+  state_machine->process_allocation_event(FINISH_MARKER, 2);
+  state_machine->process_object_free_event(2);
+
+  ASSERT_EQ(state_machine->get_state(), allocation_tracing_flushed);
+
+  // Report command should end in reported state
+  state_machine->process_command(Command{report_allocation_tracing});
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_reported);
+}
+
+TEST_F(AgentStateTest, SyncStateDoesNotChangeState) {
+  // Test sync_state in various states
+  EXPECT_EQ(state_machine->get_state(), passive);
+  state_machine->process_command(Command{sync_state});
+  EXPECT_EQ(state_machine->get_state(), passive);
+
+  state_machine->process_command(Command{start_allocation_tracing});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+  state_machine->process_command(Command{sync_state});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active);
+  state_machine->process_command(Command{sync_state});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_active);
+}
+
+TEST_F(AgentStateTest, PingCommandDoesNotChangeState) {
+  EXPECT_EQ(state_machine->get_state(), passive);
+  state_machine->process_command(Command{ping});
+  EXPECT_EQ(state_machine->get_state(), passive);
+
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_command(Command{ping});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(AgentStateTest, InvalidCommandDoesNotChangeState) {
+  // Invalid command values should not crash and should not change state
+  const jlong INVALID_COMMAND = 99999;
+
+  EXPECT_EQ(state_machine->get_state(), passive);
+  state_machine->process_command(Command{INVALID_COMMAND});
+  EXPECT_EQ(state_machine->get_state(), passive);
+
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_command(Command{INVALID_COMMAND});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(AgentStateTest, MultipleStartCommandsResetAllocations) {
+  // First start
+  state_machine->process_command(Command{start_allocation_tracing});
+  state_machine->process_allocation_event(START_MARKER, 1);
+  state_machine->process_object_free_event(1);
+
+  // Record some allocations
+  state_machine->process_allocation_event(REGULAR_CLASS, 10);
+  state_machine->process_allocation_event(REGULAR_CLASS, 11);
+  state_machine->process_allocation_event(REGULAR_CLASS, 12);
+
+  // Second start should reset - expect fresh JVMTI calls
+  EXPECT_CALL(mock_jvmti, set_heap_sampling_interval(0)).Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+
+  state_machine->process_command(Command{start_allocation_tracing});
+
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+
+  // Old tags should be forgotten - freeing them should have no effect
+  state_machine->process_object_free_event(10);
+  state_machine->process_object_free_event(11);
+  state_machine->process_object_free_event(12);
+
+  // State should still be starting (not active, since we haven't processed
+  // a new start marker)
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(AgentStateTest, CommandsInWrongStateAreHandled) {
+  // Stop command from passive state - should still change state
+  // (real implementation may handle this differently, but state machine
+  // doesn't prevent it)
+  EXPECT_EQ(state_machine->get_state(), passive);
+  state_machine->process_command(Command{stop_allocation_tracing});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_stopping);
+}
+
+TEST_F(AgentStateTest, ReportCommandFromWrongStateStillTransitions) {
+  // Report from passive - state machine allows this transition
+  EXPECT_EQ(state_machine->get_state(), passive);
+  state_machine->process_command(Command{report_allocation_tracing});
+  EXPECT_EQ(state_machine->get_state(), allocation_tracing_reported);
+}
+
 TEST_F(AgentStateTest, FullStateTransitionCycle) {
   // Test complete state machine cycle
   EXPECT_EQ(state_machine->get_state(), passive);

--- a/agent-cpp/test/all_tags_test.cpp
+++ b/agent-cpp/test/all_tags_test.cpp
@@ -1,0 +1,153 @@
+#include <gtest/gtest.h>
+#include "include/alloc_rec.h"
+
+using criterium::AllocRec;
+using criterium::AllocsT;
+
+// Tests for all_tags() which extracts tag values from allocation records.
+// The function is used to collect tags for batch JVMTI operations.
+
+class AllTagsTest : public ::testing::Test {
+protected:
+  // Helper to create a minimal AllocRec with just a tag value
+  static std::unique_ptr<AllocRec> make_alloc(int64_t tag) {
+    return std::make_unique<AllocRec>(
+        "Ltest/Class;",  // obj_class
+        100,             // obj_size
+        "Ltest/Caller;", // call_class
+        "method",        // call_method
+        "file.java",     // call_file
+        42,              // call_line
+        "Ltest/Alloc;",  // alloc_class
+        "alloc",         // alloc_method
+        "alloc.java",    // alloc_file
+        10,              // alloc_line
+        1,               // thread_id
+        tag              // tag
+    );
+  }
+};
+
+TEST_F(AllTagsTest, ReturnsEmptyVectorForEmptyInput) {
+  AllocsT allocs;
+  auto tags = criterium::all_tags(allocs);
+  EXPECT_TRUE(tags.empty());
+}
+
+TEST_F(AllTagsTest, ExtractsSingleTag) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(42));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 1);
+  EXPECT_EQ(tags[0], 42);
+}
+
+TEST_F(AllTagsTest, ExtractsMultipleTags) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(10));
+  allocs.push_back(make_alloc(20));
+  allocs.push_back(make_alloc(30));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 3);
+  EXPECT_EQ(tags[0], 10);
+  EXPECT_EQ(tags[1], 20);
+  EXPECT_EQ(tags[2], 30);
+}
+
+TEST_F(AllTagsTest, PreservesOrderOfTags) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(300));
+  allocs.push_back(make_alloc(100));
+  allocs.push_back(make_alloc(200));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 3);
+  EXPECT_EQ(tags[0], 300);
+  EXPECT_EQ(tags[1], 100);
+  EXPECT_EQ(tags[2], 200);
+}
+
+TEST_F(AllTagsTest, HandlesDuplicateTags) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(42));
+  allocs.push_back(make_alloc(42));
+  allocs.push_back(make_alloc(42));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 3);
+  EXPECT_EQ(tags[0], 42);
+  EXPECT_EQ(tags[1], 42);
+  EXPECT_EQ(tags[2], 42);
+}
+
+TEST_F(AllTagsTest, HandlesZeroTag) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(0));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 1);
+  EXPECT_EQ(tags[0], 0);
+}
+
+TEST_F(AllTagsTest, HandlesNegativeTags) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(-1));
+  allocs.push_back(make_alloc(-100));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 2);
+  EXPECT_EQ(tags[0], -1);
+  EXPECT_EQ(tags[1], -100);
+}
+
+TEST_F(AllTagsTest, HandlesLargeTagValues) {
+  AllocsT allocs;
+  // Max int64_t value
+  allocs.push_back(make_alloc(INT64_MAX));
+  // Min int64_t value
+  allocs.push_back(make_alloc(INT64_MIN));
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), 2);
+  EXPECT_EQ(tags[0], INT64_MAX);
+  EXPECT_EQ(tags[1], INT64_MIN);
+}
+
+TEST_F(AllTagsTest, DoesNotModifyInput) {
+  AllocsT allocs;
+  allocs.push_back(make_alloc(42));
+
+  // Capture original tag
+  int64_t original_tag = allocs[0]->tag;
+
+  criterium::all_tags(allocs);
+
+  // Verify input unchanged
+  EXPECT_EQ(allocs[0]->tag, original_tag);
+  EXPECT_EQ(allocs.size(), 1);
+}
+
+TEST_F(AllTagsTest, WorksWithLargeCollection) {
+  AllocsT allocs;
+  constexpr int COUNT = 1000;
+
+  for (int i = 0; i < COUNT; i++) {
+    allocs.push_back(make_alloc(i));
+  }
+
+  auto tags = criterium::all_tags(allocs);
+
+  ASSERT_EQ(tags.size(), COUNT);
+  for (int i = 0; i < COUNT; i++) {
+    EXPECT_EQ(tags[i], i);
+  }
+}

--- a/agent-cpp/test/integration_test.cpp
+++ b/agent-cpp/test/integration_test.cpp
@@ -1,0 +1,527 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "include/agent_types.h"
+#include "include/agent_state.h"
+#include "mocks.h"
+
+using namespace criterium;
+using namespace criterium::test;
+using ::testing::_;
+using ::testing::Return;
+using ::testing::NiceMock;
+using ::testing::DoAll;
+using ::testing::Invoke;
+
+// Integration tests for the agent's event processing flow.
+// These tests verify the complete flow from allocation events through
+// to report generation, using mocked JVMTI/JNI interfaces to validate
+// that the correct operations are called with expected arguments.
+//
+// These tests exercise the full allocation tracking lifecycle:
+// - Start command enables tracing and clears previous records
+// - Start marker allocation/free triggers active state
+// - Regular allocations are tracked with class signatures
+// - Stop command transitions to stopping state
+// - Finish marker disables sampling and transitions to flushing
+// - Finish marker free disables object free events
+// - Report command generates allocation data
+
+static constexpr char const* START_MARKER =
+    "Lcriterium/agent/Agent$AllocationStartMarker;";
+static constexpr char const* FINISH_MARKER =
+    "Lcriterium/agent/Agent$AllocationFinishMarker;";
+static constexpr char const* REGULAR_CLASS = "Ljava/lang/String;";
+
+/// Testable state machine for integration flow tests.
+/// Models the state transition and allocation tracking logic of AgentState
+/// while allowing mock verification of JVMTI/JNI operations.
+class IntegrationStateMachine {
+private:
+  NiceMock<MockJvmtiOperations>& jvmti_ops_;
+  [[maybe_unused]] NiceMock<MockJniOperations>& jni_ops_;
+  jlong state_ = passive;
+  std::vector<std::unique_ptr<AllocRec>> allocs_;
+  std::map<jlong, AllocRec*> allocs_by_tag_;
+
+public:
+  IntegrationStateMachine(NiceMock<MockJvmtiOperations>& jvmti_ops,
+                          NiceMock<MockJniOperations>& jni_ops)
+      : jvmti_ops_(jvmti_ops), jni_ops_(jni_ops) {}
+
+  jlong get_state() const { return state_; }
+
+  void process_command(const Command& cmd) {
+    switch (cmd.cmd) {
+    case start_allocation_tracing:
+      enable_allocation_tracing();
+      break;
+    case stop_allocation_tracing:
+      disable_allocation_tracing();
+      break;
+    case report_allocation_tracing:
+      state_ = allocation_tracing_reporting;
+      state_ = allocation_tracing_reported;
+      break;
+    case sync_state:
+    case ping:
+    default:
+      break;
+    }
+  }
+
+  void process_allocation_event(const char* class_sig, jlong tag) {
+    auto starting = state_ == allocation_tracing_starting &&
+                    std::strcmp(class_sig, START_MARKER) == 0;
+
+    auto stopping = state_ == allocation_tracing_stopping &&
+                    std::strcmp(class_sig, FINISH_MARKER) == 0;
+
+    auto rec = std::make_unique<AllocRec>(class_sig, 0, nullptr, nullptr,
+                                          nullptr, -1, nullptr, nullptr,
+                                          nullptr, -1, 0, tag);
+
+    if (starting) {
+      rec->start_marker = true;
+    }
+
+    if (stopping) {
+      jvmti_ops_.set_event_notification_mode(
+          JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
+      rec->disable_marker = true;
+      state_ = allocation_tracing_flushing;
+    }
+
+    allocs_by_tag_.emplace(rec->tag, rec.get());
+    allocs_.push_back(std::move(rec));
+  }
+
+  void process_object_free_event(jlong tag) {
+    auto it = allocs_by_tag_.find(tag);
+    if (it == allocs_by_tag_.end()) {
+      return;
+    }
+
+    AllocRec* rec = it->second;
+    rec->freed = 1;
+
+    if (rec->start_marker && state_ == allocation_tracing_starting) {
+      state_ = allocation_tracing_active;
+    }
+
+    if (state_ == allocation_tracing_flushing && rec->disable_marker) {
+      jvmti_ops_.set_event_notification_mode(JVMTI_DISABLE,
+                                             JVMTI_EVENT_OBJECT_FREE, nullptr);
+      state_ = allocation_tracing_flushed;
+    }
+  }
+
+  const AllocRec* get_alloc_by_tag(jlong tag) const {
+    auto it = allocs_by_tag_.find(tag);
+    return it != allocs_by_tag_.end() ? it->second : nullptr;
+  }
+
+  size_t get_alloc_count() const { return allocs_.size(); }
+
+  /// Returns all tracked allocations for verification.
+  const std::vector<std::unique_ptr<AllocRec>>& get_allocs() const {
+    return allocs_;
+  }
+
+private:
+  void enable_allocation_tracing() {
+    state_ = allocation_tracing_starting;
+    allocs_.clear();
+    allocs_by_tag_.clear();
+    jvmti_ops_.set_heap_sampling_interval(0);
+    jvmti_ops_.set_event_notification_mode(
+        JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
+    jvmti_ops_.set_event_notification_mode(JVMTI_ENABLE,
+                                           JVMTI_EVENT_OBJECT_FREE, nullptr);
+  }
+
+  void disable_allocation_tracing() { state_ = allocation_tracing_stopping; }
+};
+
+class IntegrationFlowTest : public ::testing::Test {
+protected:
+  NiceMock<MockJvmtiOperations> mock_jvmti;
+  NiceMock<MockJniOperations> mock_jni;
+  std::unique_ptr<IntegrationStateMachine> sm;
+
+  void SetUp() override {
+    // Configure default mock behavior for JVMTI operations
+    ON_CALL(mock_jvmti, set_heap_sampling_interval(_))
+        .WillByDefault(Return(true));
+    ON_CALL(mock_jvmti, set_event_notification_mode(_, _, _))
+        .WillByDefault(Return(true));
+    ON_CALL(mock_jvmti, set_tag(_, _)).WillByDefault(Return(true));
+    ON_CALL(mock_jvmti, deallocate(_)).WillByDefault(Return());
+
+    // Default JNI mock behavior
+    ON_CALL(mock_jni, call_long_method(_, _, _))
+        .WillByDefault(Return(1L));
+    ON_CALL(mock_jni, new_global_ref(_, _))
+        .WillByDefault(Return(nullptr));
+    ON_CALL(mock_jni, delete_global_ref(_, _))
+        .WillByDefault(Return());
+
+    sm = std::make_unique<IntegrationStateMachine>(mock_jvmti, mock_jni);
+  }
+
+  /// Helper to reach active state quickly.
+  void reach_active_state() {
+    sm->process_command(Command{start_allocation_tracing});
+    sm->process_allocation_event(START_MARKER, 1);
+    sm->process_object_free_event(1);
+  }
+
+  /// Helper to reach flushed state quickly.
+  void reach_flushed_state() {
+    reach_active_state();
+    sm->process_command(Command{stop_allocation_tracing});
+    sm->process_allocation_event(FINISH_MARKER, 2);
+    sm->process_object_free_event(2);
+  }
+};
+
+/// Allocation Event Processing Flow Tests
+/// These tests verify the complete flow of processing allocation events,
+/// including JVMTI operations for class signature lookup and record creation.
+
+TEST_F(IntegrationFlowTest, StartCommandEnablesTracking) {
+  EXPECT_CALL(mock_jvmti, set_heap_sampling_interval(0)).Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+
+  sm->process_command(Command{start_allocation_tracing});
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(IntegrationFlowTest, AllocationEventCreatesRecord) {
+  sm->process_command(Command{start_allocation_tracing});
+  sm->process_allocation_event(START_MARKER, 1);
+  sm->process_object_free_event(1);
+
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+
+  const auto* rec = sm->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_EQ(rec->obj_class, REGULAR_CLASS);
+  EXPECT_EQ(rec->tag, 100);
+  EXPECT_EQ(rec->freed, 0);
+  EXPECT_FALSE(rec->start_marker);
+  EXPECT_FALSE(rec->disable_marker);
+}
+
+TEST_F(IntegrationFlowTest, StartMarkerSetsFlag) {
+  sm->process_command(Command{start_allocation_tracing});
+
+  sm->process_allocation_event(START_MARKER, 1);
+
+  const auto* rec = sm->get_alloc_by_tag(1);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_TRUE(rec->start_marker);
+  EXPECT_EQ(sm->get_state(), allocation_tracing_starting);
+}
+
+TEST_F(IntegrationFlowTest, StartMarkerFreeTriggersActiveState) {
+  sm->process_command(Command{start_allocation_tracing});
+  sm->process_allocation_event(START_MARKER, 1);
+
+  sm->process_object_free_event(1);
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_active);
+  const auto* rec = sm->get_alloc_by_tag(1);
+  EXPECT_EQ(rec->freed, 1);
+}
+
+TEST_F(IntegrationFlowTest, MultipleAllocationsAreTracked) {
+  reach_active_state();
+
+  sm->process_allocation_event(REGULAR_CLASS, 10);
+  sm->process_allocation_event(REGULAR_CLASS, 11);
+  sm->process_allocation_event(REGULAR_CLASS, 12);
+
+  EXPECT_EQ(sm->get_alloc_count(), 4u);  // 1 start marker + 3 regular
+
+  EXPECT_NE(sm->get_alloc_by_tag(10), nullptr);
+  EXPECT_NE(sm->get_alloc_by_tag(11), nullptr);
+  EXPECT_NE(sm->get_alloc_by_tag(12), nullptr);
+}
+
+/// Object Free Event Handling Tests
+/// These tests verify that object free events correctly update allocation
+/// records and trigger appropriate state transitions.
+
+TEST_F(IntegrationFlowTest, ObjectFreeMarksRecordAsFreed) {
+  reach_active_state();
+
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+  const auto* rec = sm->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_EQ(rec->freed, 0);
+
+  sm->process_object_free_event(100);
+
+  EXPECT_EQ(rec->freed, 1);
+}
+
+TEST_F(IntegrationFlowTest, ObjectFreeOfUnknownTagIsIgnored) {
+  reach_active_state();
+
+  // Should not crash or change state
+  sm->process_object_free_event(999);
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_active);
+}
+
+TEST_F(IntegrationFlowTest, FinishMarkerDisablesSampling) {
+  reach_active_state();
+  sm->process_command(Command{stop_allocation_tracing});
+  ASSERT_EQ(sm->get_state(), allocation_tracing_stopping);
+
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+
+  sm->process_allocation_event(FINISH_MARKER, 2);
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_flushing);
+  const auto* rec = sm->get_alloc_by_tag(2);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_TRUE(rec->disable_marker);
+}
+
+TEST_F(IntegrationFlowTest, FinishMarkerFreeDisablesObjectFreeEvents) {
+  reach_active_state();
+  sm->process_command(Command{stop_allocation_tracing});
+  sm->process_allocation_event(FINISH_MARKER, 2);
+  ASSERT_EQ(sm->get_state(), allocation_tracing_flushing);
+
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_DISABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+
+  sm->process_object_free_event(2);
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_flushed);
+}
+
+/// Report Generation Tests
+/// These tests verify the report command transitions and that allocation
+/// data is correctly structured for reporting.
+
+TEST_F(IntegrationFlowTest, ReportCommandTransitionsToReported) {
+  reach_flushed_state();
+
+  sm->process_command(Command{report_allocation_tracing});
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_reported);
+}
+
+TEST_F(IntegrationFlowTest, ReportIncludesAllTrackedAllocations) {
+  reach_active_state();
+
+  // Track several allocations with different freed states
+  sm->process_allocation_event(REGULAR_CLASS, 10);
+  sm->process_allocation_event(REGULAR_CLASS, 11);
+  sm->process_allocation_event(REGULAR_CLASS, 12);
+
+  // Free one
+  sm->process_object_free_event(11);
+
+  // Complete the tracing cycle
+  sm->process_command(Command{stop_allocation_tracing});
+  sm->process_allocation_event(FINISH_MARKER, 2);
+  sm->process_object_free_event(2);
+
+  // Before reporting, verify all allocations are tracked
+  const auto& allocs = sm->get_allocs();
+
+  // Count non-marker allocations
+  int regular_count = 0;
+  int freed_count = 0;
+  for (const auto& alloc : allocs) {
+    if (!alloc->start_marker && !alloc->disable_marker) {
+      regular_count++;
+      if (alloc->freed != 0) {
+        freed_count++;
+      }
+    }
+  }
+
+  EXPECT_EQ(regular_count, 3);
+  EXPECT_EQ(freed_count, 1);
+
+  sm->process_command(Command{report_allocation_tracing});
+  EXPECT_EQ(sm->get_state(), allocation_tracing_reported);
+}
+
+TEST_F(IntegrationFlowTest, AllocationRecordsRetainClassInfo) {
+  reach_active_state();
+
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+
+  const auto* rec = sm->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_EQ(rec->obj_class, REGULAR_CLASS);
+
+  // After freeing, class info should still be available
+  sm->process_object_free_event(100);
+  EXPECT_EQ(rec->obj_class, REGULAR_CLASS);
+  EXPECT_EQ(rec->freed, 1);
+}
+
+/// Complete Lifecycle Tests
+/// These tests verify the full allocation tracking lifecycle from start
+/// to report generation.
+
+TEST_F(IntegrationFlowTest, CompleteAllocationTrackingCycle) {
+  // 1. Start tracing
+  EXPECT_CALL(mock_jvmti, set_heap_sampling_interval(0)).Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+
+  sm->process_command(Command{start_allocation_tracing});
+  EXPECT_EQ(sm->get_state(), allocation_tracing_starting);
+
+  // 2. Start marker triggers active state
+  sm->process_allocation_event(START_MARKER, 1);
+  sm->process_object_free_event(1);
+  EXPECT_EQ(sm->get_state(), allocation_tracing_active);
+
+  // 3. Track allocations
+  sm->process_allocation_event(REGULAR_CLASS, 10);
+  sm->process_allocation_event(REGULAR_CLASS, 11);
+  sm->process_allocation_event(REGULAR_CLASS, 12);
+  sm->process_object_free_event(11);
+
+  EXPECT_EQ(sm->get_alloc_count(), 4u);
+
+  // 4. Stop tracing
+  sm->process_command(Command{stop_allocation_tracing});
+  EXPECT_EQ(sm->get_state(), allocation_tracing_stopping);
+
+  // 5. Finish marker triggers flushing
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, _))
+      .Times(1);
+  sm->process_allocation_event(FINISH_MARKER, 2);
+  EXPECT_EQ(sm->get_state(), allocation_tracing_flushing);
+
+  // 6. Finish marker free triggers flushed
+  EXPECT_CALL(mock_jvmti, set_event_notification_mode(
+                              JVMTI_DISABLE, JVMTI_EVENT_OBJECT_FREE, _))
+      .Times(1);
+  sm->process_object_free_event(2);
+  EXPECT_EQ(sm->get_state(), allocation_tracing_flushed);
+
+  // 7. Report
+  sm->process_command(Command{report_allocation_tracing});
+  EXPECT_EQ(sm->get_state(), allocation_tracing_reported);
+
+  // Verify allocation record states
+  const auto* rec10 = sm->get_alloc_by_tag(10);
+  const auto* rec11 = sm->get_alloc_by_tag(11);
+  const auto* rec12 = sm->get_alloc_by_tag(12);
+
+  ASSERT_NE(rec10, nullptr);
+  ASSERT_NE(rec11, nullptr);
+  ASSERT_NE(rec12, nullptr);
+
+  EXPECT_EQ(rec10->freed, 0);
+  EXPECT_EQ(rec11->freed, 1);
+  EXPECT_EQ(rec12->freed, 0);
+}
+
+TEST_F(IntegrationFlowTest, MultipleTracingCyclesResetAllocations) {
+  // First cycle
+  sm->process_command(Command{start_allocation_tracing});
+  sm->process_allocation_event(START_MARKER, 1);
+  sm->process_object_free_event(1);
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+  sm->process_allocation_event(REGULAR_CLASS, 101);
+
+  EXPECT_EQ(sm->get_alloc_count(), 3u);
+
+  // Second cycle - should reset
+  sm->process_command(Command{start_allocation_tracing});
+
+  // Old allocations should be cleared
+  EXPECT_EQ(sm->get_alloc_by_tag(100), nullptr);
+  EXPECT_EQ(sm->get_alloc_by_tag(101), nullptr);
+  EXPECT_EQ(sm->get_alloc_count(), 0u);
+
+  // Start fresh cycle
+  sm->process_allocation_event(START_MARKER, 2);
+  sm->process_object_free_event(2);
+  sm->process_allocation_event(REGULAR_CLASS, 200);
+
+  EXPECT_EQ(sm->get_alloc_count(), 2u);
+  EXPECT_NE(sm->get_alloc_by_tag(200), nullptr);
+}
+
+TEST_F(IntegrationFlowTest, AllocationsBeforeStartMarkerAreTracked) {
+  sm->process_command(Command{start_allocation_tracing});
+
+  // Allocations before start marker
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+  sm->process_allocation_event(REGULAR_CLASS, 101);
+
+  // Now the start marker
+  sm->process_allocation_event(START_MARKER, 1);
+  sm->process_object_free_event(1);
+
+  EXPECT_EQ(sm->get_state(), allocation_tracing_active);
+  EXPECT_EQ(sm->get_alloc_count(), 3u);
+
+  // All allocations should be present
+  EXPECT_NE(sm->get_alloc_by_tag(100), nullptr);
+  EXPECT_NE(sm->get_alloc_by_tag(101), nullptr);
+}
+
+TEST_F(IntegrationFlowTest, AllocationsInFlushingStateAreTracked) {
+  reach_active_state();
+  sm->process_command(Command{stop_allocation_tracing});
+  sm->process_allocation_event(FINISH_MARKER, 2);
+  EXPECT_EQ(sm->get_state(), allocation_tracing_flushing);
+
+  // Allocations after finish marker but before its freed
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+
+  EXPECT_NE(sm->get_alloc_by_tag(100), nullptr);
+}
+
+TEST_F(IntegrationFlowTest, FreedFlagPersistsAfterStateTransitions) {
+  reach_active_state();
+
+  sm->process_allocation_event(REGULAR_CLASS, 100);
+  sm->process_object_free_event(100);
+
+  const auto* rec = sm->get_alloc_by_tag(100);
+  ASSERT_NE(rec, nullptr);
+  EXPECT_EQ(rec->freed, 1);
+
+  // Continue through state transitions
+  sm->process_command(Command{stop_allocation_tracing});
+  sm->process_allocation_event(FINISH_MARKER, 2);
+  sm->process_object_free_event(2);
+  sm->process_command(Command{report_allocation_tracing});
+
+  // Freed flag should still be set
+  EXPECT_EQ(rec->freed, 1);
+}

--- a/agent-cpp/test/integration_test.cpp
+++ b/agent-cpp/test/integration_test.cpp
@@ -7,10 +7,12 @@
 #include <vector>
 #include "include/agent_types.h"
 #include "include/agent_state.h"
+#include "include/state_transitions.h"
 #include "mocks.h"
 
 using namespace criterium;
 using namespace criterium::test;
+using namespace criterium::state_transitions;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::NiceMock;
@@ -22,6 +24,9 @@ using ::testing::Invoke;
 // to report generation, using mocked JVMTI/JNI interfaces to validate
 // that the correct operations are called with expected arguments.
 //
+// The IntegrationStateMachine uses the same pure transition functions
+// as AgentState, ensuring tests and production code share the same logic.
+//
 // These tests exercise the full allocation tracking lifecycle:
 // - Start command enables tracing and clears previous records
 // - Start marker allocation/free triggers active state
@@ -31,15 +36,14 @@ using ::testing::Invoke;
 // - Finish marker free disables object free events
 // - Report command generates allocation data
 
-static constexpr char const* START_MARKER =
-    "Lcriterium/agent/Agent$AllocationStartMarker;";
-static constexpr char const* FINISH_MARKER =
-    "Lcriterium/agent/Agent$AllocationFinishMarker;";
+// Use shared marker constants from state_transitions.h
+static constexpr char const* START_MARKER = ALLOCATION_START_MARKER;
+static constexpr char const* FINISH_MARKER = ALLOCATION_FINISH_MARKER;
 static constexpr char const* REGULAR_CLASS = "Ljava/lang/String;";
 
 /// Testable state machine for integration flow tests.
-/// Models the state transition and allocation tracking logic of AgentState
-/// while allowing mock verification of JVMTI/JNI operations.
+/// Uses the same pure transition functions as AgentState, ensuring tests
+/// and production code share the same state machine logic.
 class IntegrationStateMachine {
 private:
   NiceMock<MockJvmtiOperations>& jvmti_ops_;
@@ -56,30 +60,24 @@ public:
   jlong get_state() const { return state_; }
 
   void process_command(const Command& cmd) {
-    switch (cmd.cmd) {
-    case start_allocation_tracing:
+    auto new_state = next_state_for_command(cmd.cmd);
+    if (new_state == -1) {
+      return;
+    }
+
+    if (cmd.cmd == start_allocation_tracing) {
       enable_allocation_tracing();
-      break;
-    case stop_allocation_tracing:
-      disable_allocation_tracing();
-      break;
-    case report_allocation_tracing:
+    } else if (cmd.cmd == stop_allocation_tracing) {
+      state_ = new_state;
+    } else if (cmd.cmd == report_allocation_tracing) {
       state_ = allocation_tracing_reporting;
       state_ = allocation_tracing_reported;
-      break;
-    case sync_state:
-    case ping:
-    default:
-      break;
     }
   }
 
   void process_allocation_event(const char* class_sig, jlong tag) {
-    auto starting = state_ == allocation_tracing_starting &&
-                    std::strcmp(class_sig, START_MARKER) == 0;
-
-    auto stopping = state_ == allocation_tracing_stopping &&
-                    std::strcmp(class_sig, FINISH_MARKER) == 0;
+    auto starting = is_start_marker_allocation(state_, class_sig);
+    auto stopping = is_finish_marker_allocation(state_, class_sig);
 
     auto rec = std::make_unique<AllocRec>(class_sig, 0, nullptr, nullptr,
                                           nullptr, -1, nullptr, nullptr,
@@ -93,7 +91,7 @@ public:
       jvmti_ops_.set_event_notification_mode(
           JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, nullptr);
       rec->disable_marker = true;
-      state_ = allocation_tracing_flushing;
+      state_ = next_state_after_allocation(state_, class_sig);
     }
 
     allocs_by_tag_.emplace(rec->tag, rec.get());
@@ -109,14 +107,14 @@ public:
     AllocRec* rec = it->second;
     rec->freed = 1;
 
-    if (rec->start_marker && state_ == allocation_tracing_starting) {
-      state_ = allocation_tracing_active;
-    }
-
-    if (state_ == allocation_tracing_flushing && rec->disable_marker) {
-      jvmti_ops_.set_event_notification_mode(JVMTI_DISABLE,
-                                             JVMTI_EVENT_OBJECT_FREE, nullptr);
-      state_ = allocation_tracing_flushed;
+    auto new_state = next_state_after_object_free(state_, rec->start_marker,
+                                                  rec->disable_marker);
+    if (new_state != state_) {
+      if (rec->disable_marker) {
+        jvmti_ops_.set_event_notification_mode(JVMTI_DISABLE,
+                                               JVMTI_EVENT_OBJECT_FREE, nullptr);
+      }
+      state_ = new_state;
     }
   }
 
@@ -143,8 +141,6 @@ private:
     jvmti_ops_.set_event_notification_mode(JVMTI_ENABLE,
                                            JVMTI_EVENT_OBJECT_FREE, nullptr);
   }
-
-  void disable_allocation_tracing() { state_ = allocation_tracing_stopping; }
 };
 
 class IntegrationFlowTest : public ::testing::Test {

--- a/agent-cpp/test/is_system_class_test.cpp
+++ b/agent-cpp/test/is_system_class_test.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+#include "include/utils.h"
+
+using criterium::is_system_class;
+
+// Tests for is_system_class() which filters out JVM system classes
+// from allocation tracking based on class name prefixes.
+
+class IsSystemClassTest : public ::testing::Test {};
+
+// System class prefixes that should be filtered
+TEST_F(IsSystemClassTest, RecognizesJavaClasses) {
+  EXPECT_TRUE(is_system_class("Ljava/lang/String;"));
+  EXPECT_TRUE(is_system_class("Ljava/util/HashMap;"));
+  EXPECT_TRUE(is_system_class("Ljava/io/File;"));
+}
+
+TEST_F(IsSystemClassTest, RecognizesComSunClasses) {
+  EXPECT_TRUE(is_system_class("Lcom/sun/proxy/$Proxy0;"));
+  EXPECT_TRUE(is_system_class("Lcom/sun/management/VMOption;"));
+}
+
+TEST_F(IsSystemClassTest, RecognizesJdkClasses) {
+  EXPECT_TRUE(is_system_class("Ljdk/internal/misc/Unsafe;"));
+  EXPECT_TRUE(is_system_class("Ljdk/nashorn/api/scripting/NashornScriptEngine;"));
+}
+
+TEST_F(IsSystemClassTest, RecognizesJavaxClasses) {
+  EXPECT_TRUE(is_system_class("Ljavax/swing/JFrame;"));
+  EXPECT_TRUE(is_system_class("Ljavax/management/MBeanServer;"));
+}
+
+TEST_F(IsSystemClassTest, RecognizesSunManagementClasses) {
+  EXPECT_TRUE(is_system_class("Lsun/management/VMManagementImpl;"));
+  EXPECT_TRUE(is_system_class("Lsun/management/ManagementFactory;"));
+}
+
+TEST_F(IsSystemClassTest, RecognizesClojureClasses) {
+  EXPECT_TRUE(is_system_class("Lclojure/lang/PersistentVector;"));
+  EXPECT_TRUE(is_system_class("Lclojure/core$map;"));
+}
+
+// Non-system classes that should NOT be filtered
+TEST_F(IsSystemClassTest, AllowsUserClasses) {
+  EXPECT_FALSE(is_system_class("Lcom/example/MyClass;"));
+  EXPECT_FALSE(is_system_class("Lorg/apache/commons/StringUtils;"));
+  EXPECT_FALSE(is_system_class("Lmyapp/Service;"));
+}
+
+TEST_F(IsSystemClassTest, AllowsOrgClasses) {
+  EXPECT_FALSE(is_system_class("Lorg/junit/Test;"));
+  EXPECT_FALSE(is_system_class("Lorg/slf4j/Logger;"));
+}
+
+TEST_F(IsSystemClassTest, AllowsNetClasses) {
+  EXPECT_FALSE(is_system_class("Lnet/sf/cglib/Enhancer;"));
+}
+
+// Edge cases
+TEST_F(IsSystemClassTest, HandlesPrefixSubstrings) {
+  // "Ljavax" starts with "Ljava" but should be handled correctly
+  EXPECT_TRUE(is_system_class("Ljavax/swing/JButton;"));
+
+  // "Ljava" prefix should not match classes starting with "Ljavax"
+  // when we're specifically testing "Ljava/" (with slash)
+  // This tests that the prefix matching includes the trailing slash
+  EXPECT_TRUE(is_system_class("Ljava/awt/Color;"));
+}
+
+TEST_F(IsSystemClassTest, RejectsPartialPrefixMatches) {
+  // "Ljavax" without the trailing slash in prefix would incorrectly match
+  // but our prefix is "Ljavax/" with the slash
+  EXPECT_FALSE(is_system_class("Ljavaxyz/Custom;"));
+}
+
+TEST_F(IsSystemClassTest, HandlesSunButNotSunManagement) {
+  // "Lsun/" is NOT a system prefix, only "Lsun/management"
+  EXPECT_FALSE(is_system_class("Lsun/misc/Unsafe;"));
+  EXPECT_FALSE(is_system_class("Lsun/nio/ch/FileChannelImpl;"));
+}
+
+TEST_F(IsSystemClassTest, HandlesEmptyString) {
+  EXPECT_FALSE(is_system_class(""));
+}
+
+TEST_F(IsSystemClassTest, HandlesMinimalValidInput) {
+  // Just the prefix without any class name
+  EXPECT_TRUE(is_system_class("Ljava/"));
+  EXPECT_TRUE(is_system_class("Lclojure/"));
+}
+
+TEST_F(IsSystemClassTest, HandlesPrimitiveArrays) {
+  // Array descriptors start with '[', not 'L'
+  EXPECT_FALSE(is_system_class("[I"));
+  EXPECT_FALSE(is_system_class("[Ljava/lang/String;"));
+}

--- a/agent-cpp/test/message_queue_test.cpp
+++ b/agent-cpp/test/message_queue_test.cpp
@@ -1,0 +1,267 @@
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include "include/message_queue.h"
+
+using criterium::MessageQueue;
+
+// Tests for MessageQueue, a thread-safe blocking queue.
+// Contracts: push adds messages, pop blocks until available,
+// stop signals termination while still draining pending messages.
+
+class MessageQueueTest : public ::testing::Test {
+protected:
+  MessageQueue<int> queue;
+};
+
+TEST_F(MessageQueueTest, PushAndPopSingleMessage) {
+  queue.push(42);
+
+  int msg;
+  bool result = queue.pop(msg);
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(msg, 42);
+}
+
+TEST_F(MessageQueueTest, PushAndPopMultipleMessages) {
+  queue.push(1);
+  queue.push(2);
+  queue.push(3);
+
+  int msg;
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg, 1);
+
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg, 2);
+
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg, 3);
+}
+
+TEST_F(MessageQueueTest, MaintainsFifoOrder) {
+  for (int i = 0; i < 100; ++i) {
+    queue.push(i);
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    int msg;
+    ASSERT_TRUE(queue.pop(msg));
+    EXPECT_EQ(msg, i);
+  }
+}
+
+TEST_F(MessageQueueTest, PopBlocksOnEmptyQueue) {
+  std::atomic<bool> pop_started{false};
+  std::atomic<bool> pop_completed{false};
+  int received_msg = -1;
+
+  std::thread consumer([&]() {
+    int msg;
+    pop_started = true;
+    bool result = queue.pop(msg);
+    if (result) {
+      received_msg = msg;
+    }
+    pop_completed = true;
+  });
+
+  // Wait for consumer to start blocking
+  while (!pop_started) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // Consumer should still be blocked
+  EXPECT_FALSE(pop_completed);
+
+  // Push a message to unblock consumer
+  queue.push(99);
+
+  consumer.join();
+
+  EXPECT_TRUE(pop_completed);
+  EXPECT_EQ(received_msg, 99);
+}
+
+TEST_F(MessageQueueTest, StopUnblocksWaitingConsumer) {
+  std::atomic<bool> pop_completed{false};
+  std::atomic<bool> pop_result{true};
+
+  std::thread consumer([&]() {
+    int msg;
+    pop_result = queue.pop(msg);
+    pop_completed = true;
+  });
+
+  // Give consumer time to start blocking
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  EXPECT_FALSE(pop_completed);
+
+  queue.stop();
+
+  consumer.join();
+
+  EXPECT_TRUE(pop_completed);
+  EXPECT_FALSE(pop_result);  // Should return false when stopped and empty
+}
+
+TEST_F(MessageQueueTest, StopDrainsPendingMessages) {
+  queue.push(1);
+  queue.push(2);
+  queue.push(3);
+
+  queue.stop();
+
+  // Should still be able to pop pending messages after stop
+  int msg;
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg, 1);
+
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg, 2);
+
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg, 3);
+
+  // Now queue is empty and stopped, should return false
+  EXPECT_FALSE(queue.pop(msg));
+}
+
+TEST_F(MessageQueueTest, StopReturnsFalseOnlyWhenEmpty) {
+  queue.push(100);
+  queue.stop();
+
+  int msg;
+  // First pop should succeed (message pending)
+  bool first_result = queue.pop(msg);
+  EXPECT_TRUE(first_result);
+  EXPECT_EQ(msg, 100);
+
+  // Second pop should fail (stopped and empty)
+  bool second_result = queue.pop(msg);
+  EXPECT_FALSE(second_result);
+}
+
+TEST_F(MessageQueueTest, MultipleProducersSingleConsumer) {
+  const int num_producers = 4;
+  const int messages_per_producer = 100;
+  std::atomic<int> total_received{0};
+
+  std::thread consumer([&]() {
+    int msg;
+    while (queue.pop(msg)) {
+      total_received++;
+    }
+  });
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < num_producers; ++p) {
+    producers.emplace_back([&, p]() {
+      for (int i = 0; i < messages_per_producer; ++i) {
+        queue.push(p * 1000 + i);
+      }
+    });
+  }
+
+  for (auto& producer : producers) {
+    producer.join();
+  }
+
+  queue.stop();
+  consumer.join();
+
+  EXPECT_EQ(total_received, num_producers * messages_per_producer);
+}
+
+TEST_F(MessageQueueTest, SingleProducerMultipleConsumers) {
+  const int num_messages = 100;
+  const int num_consumers = 4;
+  std::atomic<int> total_received{0};
+
+  std::vector<std::thread> consumers;
+  for (int c = 0; c < num_consumers; ++c) {
+    consumers.emplace_back([&]() {
+      int msg;
+      while (queue.pop(msg)) {
+        total_received++;
+      }
+    });
+  }
+
+  for (int i = 0; i < num_messages; ++i) {
+    queue.push(i);
+  }
+
+  queue.stop();
+
+  for (auto& consumer : consumers) {
+    consumer.join();
+  }
+
+  EXPECT_EQ(total_received, num_messages);
+}
+
+TEST_F(MessageQueueTest, MultipleProducersMultipleConsumers) {
+  const int num_producers = 4;
+  const int num_consumers = 4;
+  const int messages_per_producer = 50;
+  std::atomic<int> total_received{0};
+
+  std::vector<std::thread> consumers;
+  for (int c = 0; c < num_consumers; ++c) {
+    consumers.emplace_back([&]() {
+      int msg;
+      while (queue.pop(msg)) {
+        total_received++;
+      }
+    });
+  }
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < num_producers; ++p) {
+    producers.emplace_back([&, p]() {
+      for (int i = 0; i < messages_per_producer; ++i) {
+        queue.push(p * 1000 + i);
+      }
+    });
+  }
+
+  for (auto& producer : producers) {
+    producer.join();
+  }
+
+  queue.stop();
+
+  for (auto& consumer : consumers) {
+    consumer.join();
+  }
+
+  EXPECT_EQ(total_received, num_producers * messages_per_producer);
+}
+
+// Test with a more complex message type to verify move semantics
+struct ComplexMessage {
+  std::string data;
+  int id;
+};
+
+TEST(MessageQueueComplexTest, HandlesComplexTypes) {
+  MessageQueue<ComplexMessage> queue;
+
+  queue.push(ComplexMessage{"hello", 1});
+  queue.push(ComplexMessage{"world", 2});
+
+  ComplexMessage msg;
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg.data, "hello");
+  EXPECT_EQ(msg.id, 1);
+
+  ASSERT_TRUE(queue.pop(msg));
+  EXPECT_EQ(msg.data, "world");
+  EXPECT_EQ(msg.id, 2);
+}

--- a/agent-cpp/test/mocks.h
+++ b/agent-cpp/test/mocks.h
@@ -1,0 +1,84 @@
+#ifndef CRITERIUM_TEST_MOCKS_H
+#define CRITERIUM_TEST_MOCKS_H
+
+#include <gmock/gmock.h>
+#include "include/jni_operations.h"
+#include "include/jvmti_operations.h"
+
+namespace criterium {
+namespace test {
+
+/// GMock implementation of IJvmtiOperations for unit testing.
+class MockJvmtiOperations : public IJvmtiOperations {
+public:
+  // Class and method introspection
+  MOCK_METHOD(bool, get_class_signature, (jclass klass, char** class_sig),
+              (override));
+  MOCK_METHOD(bool, get_source_file_name, (jclass klass, char** source_name),
+              (override));
+  MOCK_METHOD(bool, get_method_declaring_class,
+              (jmethodID method, jclass* declaring_class), (override));
+  MOCK_METHOD(bool, get_method_name, (jmethodID method, char** method_name),
+              (override));
+
+  // Stack trace
+  MOCK_METHOD(bool, get_stack_trace,
+              (jthread thread, jint start_depth, jint max_frame_count,
+               jvmtiFrameInfo* frames, jint* count),
+              (override));
+  MOCK_METHOD(bool, get_line_number_table,
+              (jmethodID method, jint* entry_count,
+               jvmtiLineNumberEntry** line_table),
+              (override));
+
+  // Object tagging
+  MOCK_METHOD(bool, set_tag, (jobject object, jlong tag), (override));
+  MOCK_METHOD(bool, get_objects_with_tags,
+              (jint tag_count, const jlong* tags, jint* count, jobject** objects,
+               jlong** object_tags),
+              (override));
+
+  // Sampling and event control
+  MOCK_METHOD(bool, set_heap_sampling_interval, (jint sampling_interval),
+              (override));
+  MOCK_METHOD(bool, set_event_notification_mode,
+              (jvmtiEventMode mode, jvmtiEvent event_type, jthread event_thread),
+              (override));
+
+  // Memory deallocation
+  MOCK_METHOD(void, deallocate, (unsigned char* mem), (override));
+};
+
+/// GMock implementation of IJniOperations for unit testing.
+class MockJniOperations : public IJniOperations {
+public:
+  // Reference management
+  MOCK_METHOD(jobject, new_global_ref, (JNIEnv* env, jobject obj), (override));
+  MOCK_METHOD(void, delete_global_ref, (JNIEnv* env, jobject obj), (override));
+
+  // String operations
+  MOCK_METHOD(jstring, new_string_utf, (JNIEnv* env, const char* str),
+              (override));
+
+  // Method invocation
+  MOCK_METHOD(jlong, call_long_method, (JNIEnv* env, jobject obj, jmethodID method),
+              (override));
+  MOCK_METHOD(void, call_static_void_method,
+              (JNIEnv* env, jclass klass, jmethodID method, jobject arg),
+              (override));
+
+  // Object creation
+  MOCK_METHOD(jobject, new_object_a,
+              (JNIEnv* env, jclass klass, jmethodID ctor, const jvalue* args),
+              (override));
+
+  // Field access
+  MOCK_METHOD(void, set_static_long_field,
+              (JNIEnv* env, jclass klass, jfieldID field, jlong value),
+              (override));
+};
+
+} // namespace test
+} // namespace criterium
+
+#endif // CRITERIUM_TEST_MOCKS_H

--- a/agent-cpp/test/state_transitions_test.cpp
+++ b/agent-cpp/test/state_transitions_test.cpp
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+#include "include/state_transitions.h"
+#include "include/agent_types.h"
+
+using namespace criterium;
+using namespace criterium::state_transitions;
+
+// Tests for pure state transition functions.
+// These tests verify the core state machine logic without requiring any
+// mocking of JVMTI/JNI operations, since the functions are pure.
+
+/// is_start_marker_allocation tests
+
+TEST(IsStartMarkerAllocation, ReturnsTrueInStartingStateWithStartMarker) {
+  EXPECT_TRUE(is_start_marker_allocation(allocation_tracing_starting,
+                                         ALLOCATION_START_MARKER));
+}
+
+TEST(IsStartMarkerAllocation, ReturnsFalseInStartingStateWithOtherClass) {
+  EXPECT_FALSE(
+      is_start_marker_allocation(allocation_tracing_starting, "Ljava/lang/Object;"));
+}
+
+TEST(IsStartMarkerAllocation, ReturnsFalseInActiveStateWithStartMarker) {
+  EXPECT_FALSE(is_start_marker_allocation(allocation_tracing_active,
+                                          ALLOCATION_START_MARKER));
+}
+
+TEST(IsStartMarkerAllocation, ReturnsFalseInPassiveState) {
+  EXPECT_FALSE(is_start_marker_allocation(passive, ALLOCATION_START_MARKER));
+}
+
+TEST(IsStartMarkerAllocation, ReturnsFalseInStoppingState) {
+  EXPECT_FALSE(is_start_marker_allocation(allocation_tracing_stopping,
+                                          ALLOCATION_START_MARKER));
+}
+
+TEST(IsStartMarkerAllocation, ReturnsFalseWithFinishMarkerClass) {
+  EXPECT_FALSE(is_start_marker_allocation(allocation_tracing_starting,
+                                          ALLOCATION_FINISH_MARKER));
+}
+
+/// is_finish_marker_allocation tests
+
+TEST(IsFinishMarkerAllocation, ReturnsTrueInStoppingStateWithFinishMarker) {
+  EXPECT_TRUE(is_finish_marker_allocation(allocation_tracing_stopping,
+                                          ALLOCATION_FINISH_MARKER));
+}
+
+TEST(IsFinishMarkerAllocation, ReturnsFalseInStoppingStateWithOtherClass) {
+  EXPECT_FALSE(
+      is_finish_marker_allocation(allocation_tracing_stopping, "Ljava/lang/Object;"));
+}
+
+TEST(IsFinishMarkerAllocation, ReturnsFalseInActiveStateWithFinishMarker) {
+  EXPECT_FALSE(is_finish_marker_allocation(allocation_tracing_active,
+                                           ALLOCATION_FINISH_MARKER));
+}
+
+TEST(IsFinishMarkerAllocation, ReturnsFalseInFlushingState) {
+  EXPECT_FALSE(is_finish_marker_allocation(allocation_tracing_flushing,
+                                           ALLOCATION_FINISH_MARKER));
+}
+
+TEST(IsFinishMarkerAllocation, ReturnsFalseWithStartMarkerClass) {
+  EXPECT_FALSE(is_finish_marker_allocation(allocation_tracing_stopping,
+                                           ALLOCATION_START_MARKER));
+}
+
+/// next_state_after_allocation tests
+
+TEST(NextStateAfterAllocation, TransitionsToFlushingOnFinishMarker) {
+  EXPECT_EQ(next_state_after_allocation(allocation_tracing_stopping,
+                                        ALLOCATION_FINISH_MARKER),
+            allocation_tracing_flushing);
+}
+
+TEST(NextStateAfterAllocation, StaysInCurrentStateForRegularAllocation) {
+  EXPECT_EQ(next_state_after_allocation(allocation_tracing_active,
+                                        "Ljava/lang/Object;"),
+            allocation_tracing_active);
+}
+
+TEST(NextStateAfterAllocation, StaysInStartingStateForStartMarker) {
+  // Start marker allocation doesn't change state - the free event does
+  EXPECT_EQ(next_state_after_allocation(allocation_tracing_starting,
+                                        ALLOCATION_START_MARKER),
+            allocation_tracing_starting);
+}
+
+TEST(NextStateAfterAllocation, StaysInStoppingForRegularClass) {
+  EXPECT_EQ(next_state_after_allocation(allocation_tracing_stopping,
+                                        "Ljava/lang/Object;"),
+            allocation_tracing_stopping);
+}
+
+/// next_state_after_object_free tests
+
+TEST(NextStateAfterObjectFree, TransitionsToActiveOnStartMarkerFree) {
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_starting, true, false),
+      allocation_tracing_active);
+}
+
+TEST(NextStateAfterObjectFree, StaysInStartingIfNotStartMarker) {
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_starting, false, false),
+      allocation_tracing_starting);
+}
+
+TEST(NextStateAfterObjectFree, TransitionsToFlushedOnDisableMarkerFree) {
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_flushing, false, true),
+      allocation_tracing_flushed);
+}
+
+TEST(NextStateAfterObjectFree, StaysInFlushingIfNotDisableMarker) {
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_flushing, false, false),
+      allocation_tracing_flushing);
+}
+
+TEST(NextStateAfterObjectFree, StaysInActiveOnRegularFree) {
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_active, false, false),
+      allocation_tracing_active);
+}
+
+TEST(NextStateAfterObjectFree, StartMarkerInActiveStateNoTransition) {
+  // Start marker freed when already active - no effect
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_active, true, false),
+      allocation_tracing_active);
+}
+
+TEST(NextStateAfterObjectFree, DisableMarkerInActiveStateNoTransition) {
+  // Disable marker freed when in active state - no effect
+  EXPECT_EQ(
+      next_state_after_object_free(allocation_tracing_active, false, true),
+      allocation_tracing_active);
+}
+
+/// next_state_for_command tests
+
+TEST(NextStateForCommand, StartCommandReturnsStarting) {
+  EXPECT_EQ(next_state_for_command(start_allocation_tracing),
+            allocation_tracing_starting);
+}
+
+TEST(NextStateForCommand, StopCommandReturnsStopping) {
+  EXPECT_EQ(next_state_for_command(stop_allocation_tracing),
+            allocation_tracing_stopping);
+}
+
+TEST(NextStateForCommand, ReportCommandReturnsReporting) {
+  EXPECT_EQ(next_state_for_command(report_allocation_tracing),
+            allocation_tracing_reporting);
+}
+
+TEST(NextStateForCommand, PingReturnsNoChange) {
+  EXPECT_EQ(next_state_for_command(ping), -1);
+}
+
+TEST(NextStateForCommand, SyncStateReturnsNoChange) {
+  EXPECT_EQ(next_state_for_command(sync_state), -1);
+}
+
+TEST(NextStateForCommand, UnknownCommandReturnsNoChange) {
+  EXPECT_EQ(next_state_for_command(99999), -1);
+}

--- a/agent-cpp/test/test_main.cpp
+++ b/agent-cpp/test/test_main.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// Placeholder tests to verify GoogleTest and GMock setup works
+TEST(SetupTest, GoogleTestWorks) {
+    EXPECT_TRUE(true);
+}
+
+TEST(SetupTest, GMockWorks) {
+    std::vector<int> v = {1, 2, 3};
+    EXPECT_THAT(v, testing::Contains(2));
+}


### PR DESCRIPTION
## Summary

Refactors the C++ agent to improve testability by extracting interfaces and pure functions:

- Add GoogleTest/GMock test infrastructure via CMake FetchContent
- Extract pure functions (is_system_class, MessageQueue, all_tags, state transitions)
- Create IJvmtiOperations and IJniOperations interfaces for dependency injection
- Refactor AgentState to accept interfaces via constructor
- Add comprehensive test suite: 120 tests covering pure functions, state transitions, markers, and integration flows
- Integrate ctest into CI workflow for Linux and macOS

## Design

### Interface Abstraction
- `IJvmtiOperations`: Abstracts JVMTI operations (stack trace, class info, tagging)
- `IJniOperations`: Abstracts JNI operations (reference management, method calls)
- Production implementations wrap real jvmtiEnv*/JNIEnv*

### Pure Function Extraction
- `is_system_class()`: System class prefix matching
- `MessageQueue<T>`: Thread-safe queue with blocking semantics
- `all_tags()`: Tag extraction from allocation records
- State transition functions: `next_state_after_allocation()`, `next_state_for_command()`, etc.

### Test Categories
- **Pure function tests**: No mocking, direct unit tests
- **State machine tests**: GMock-based verification of transitions
- **Integration tests**: Full flow with mocked JVMTI/JNI

## Commits

- feat(agent): add GoogleTest/GMock test infrastructure
- test(agent): add tests for is_system_class() function
- test(agent): add tests for MessageQueue thread-safe queue
- test(agent): add tests for all_tags() extraction function
- feat(agent): add IJvmtiOperations interface for JVMTI abstraction
- feat(agent): add IJniOperations interface for JNI abstraction
- refactor(agent): inject interfaces into AgentState via constructor
- test(agent): add GMock implementations and state transition tests
- test(agent): add command processing tests
- test(agent): add marker detection tests
- test(agent): add integration tests for full allocation tracking flow
- ci(agent): add ctest step to agent-cpp.yml workflow
- refactor(agent): consolidate AllocRec to single definition
- refactor(agent): consolidate event structures to shared header
- refactor(agent): extract state transition logic to shared pure functions

## Test Plan

- [x] All 120 C++ tests pass via `ctest --test-dir build`
- [x] Tests run on Linux x64, macOS ARM64, and macOS x86_64 in CI
- [x] Existing Clojure tests pass with refactored agent
- [x] Agent loads and functions correctly in JVM