### PR TITLE
feat: improve domain complexity analysis

### DIFF
--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -629,7 +629,9 @@
   models (two :transforms).
 
   Returns map with :id, :label, :coefficients, :r-squared, :residuals,
-  and optionally :predict-fn (instantiated) and :equation-str."
+  :aic, :bic, and optionally :predict-fn (instantiated) and :equation-str.
+
+  AIC/BIC may be nil if there is insufficient data for the correction term."
   [model-id {:keys [transform transforms label predict-fn equation-fn]} xs ys]
   (if transforms
     ;; Composite model: y = a*f1(x) + b*f2(x) + c
@@ -641,12 +643,20 @@
           coefficients {:a a :b b :c c}
           residuals (mapv (fn [^double x1 ^double x2 ^double y]
                             (- y (+ (* a x1) (* b x2) c)))
-                          x1s x2s ys)]
+                          x1s x2s ys)
+          n (count ys)
+          k 3  ; 3 parameters for composite model
+          rss (double (reduce (fn [^double acc ^double r] (+ acc (* r r)))
+                              0.0 residuals))
+          aic (compute-aic rss n k)
+          bic (compute-bic rss n k)]
       (cond-> {:id model-id
                :label label
                :coefficients coefficients
                :r-squared r-squared
-               :residuals residuals}
+               :residuals residuals
+               :aic aic
+               :bic bic}
         predict-fn (assoc :predict-fn (predict-fn coefficients))
         equation-fn (assoc :equation-str (equation-fn coefficients))))
     ;; Simple model: y = a*f(x) + b
@@ -656,14 +666,103 @@
           coefficients {:a a :b b}
           residuals (mapv (fn [^double tx ^double y]
                             (- y (+ (* a tx) b)))
-                          transformed-xs ys)]
+                          transformed-xs ys)
+          n (count ys)
+          k 2  ; 2 parameters for simple model
+          rss (double (reduce (fn [^double acc ^double r] (+ acc (* r r)))
+                              0.0 residuals))
+          aic (compute-aic rss n k)
+          bic (compute-bic rss n k)]
       (cond-> {:id model-id
                :label label
                :coefficients coefficients
                :r-squared r-squared
-               :residuals residuals}
+               :residuals residuals
+               :aic aic
+               :bic bic}
         predict-fn (assoc :predict-fn (predict-fn coefficients))
         equation-fn (assoc :equation-str (equation-fn coefficients))))))
+
+(defn- within-threshold?
+  "Check if diff is within threshold, handling -Infinity values.
+  When both values are -Infinity (perfect fit), they are considered equal."
+  [^double best-val ^double val ^double threshold]
+  (let [diff (- val best-val)]
+    (or (Double/isNaN diff)  ; Both -Infinity → NaN diff → treat as equal
+        (< diff threshold))))
+
+(defn- select-by-r-squared
+  "Select best model by highest R², preferring simpler when close."
+  [fitted threshold]
+  (let [sorted (sort-by (juxt #(- (double (:r-squared %)))
+                              :param-count)
+                        fitted)
+        best (first sorted)
+        best-val (double (:r-squared best))
+        within-threshold (filterv #(within-threshold?
+                                    (- best-val)
+                                    (- (double (:r-squared %)))
+                                    threshold)
+                                  sorted)]
+    (:id (first (sort-by :param-count within-threshold)))))
+
+(defn- select-best-model
+  "Select best model based on selection method.
+
+  selection-method can be:
+    :aic       - select model with lowest AICc (default)
+    :bic       - select model with lowest BIC
+    :r-squared - select model with highest R²
+
+  In all cases, prefers simpler models (fewer parameters) when values
+  are essentially equal (within threshold).
+
+  When using :aic or :bic, falls back to :r-squared selection if no
+  models have valid AIC/BIC values (insufficient data for information
+  criterion computation)."
+  [fitted selection-method]
+  (when (seq fitted)
+    (let [threshold 1e-6]
+      (case selection-method
+        :r-squared
+        (select-by-r-squared fitted threshold)
+
+        :bic
+        ;; Lowest BIC, prefer simpler when close
+        ;; Filter out models with nil BIC, fall back to R² if none
+        (let [with-bic (filterv #(some? (:bic %)) fitted)]
+          (if (seq with-bic)
+            (let [sorted (sort-by (juxt #(double (:bic %))
+                                        :param-count)
+                                  with-bic)
+                  best (first sorted)
+                  best-val (double (:bic best))
+                  within-threshold (filterv #(within-threshold?
+                                              best-val
+                                              (double (:bic %))
+                                              threshold)
+                                            sorted)]
+              (:id (first (sort-by :param-count within-threshold))))
+            ;; Fall back to R² selection when no BIC values
+            (select-by-r-squared fitted threshold)))
+
+        ;; Default: :aic - lowest AICc, prefer simpler when close
+        ;; Filter out models with nil AIC, fall back to R² if none
+        (let [with-aic (filterv #(some? (:aic %)) fitted)]
+          (if (seq with-aic)
+            (let [sorted (sort-by (juxt #(double (:aic %))
+                                        :param-count)
+                                  with-aic)
+                  best (first sorted)
+                  best-val (double (:aic best))
+                  within-threshold (filterv #(within-threshold?
+                                              best-val
+                                              (double (:aic %))
+                                              threshold)
+                                            sorted)]
+              (:id (first (sort-by :param-count within-threshold))))
+            ;; Fall back to R² selection when no AIC values
+            (select-by-r-squared fitted threshold)))))))
 
 (defn fit-complexity
   "Fit complexity models to domain extract data.
@@ -673,12 +772,19 @@
 
   extract is a domain-extract result (with :metrics map).
   axis is the coordinate key to use for x-values (e.g., :n for input size).
-  models is a map of model-id to {:transform fn :label string}, or nil
-  for defaults.
+
+  Options (third argument can be a models map for backward compatibility,
+  or an options map):
+    :models           - Map of model-id to {:transform fn :label string},
+                        or nil for defaults
+    :selection-method - Method for selecting best model:
+                        :aic (default) - lowest AICc
+                        :bic           - lowest BIC
+                        :r-squared     - highest R²
 
   Filters out data points with nil values before fitting.
-  Selects best-fit model by highest R² value, preferring simpler models when
-  R² values are essentially equal (within 0.0001).
+  Selects best-fit model using the specified selection method,
+  preferring simpler models when values are essentially equal.
 
   When the extract has multiple implementations (count of :implementations > 1),
   data is grouped by implementation and models are fit separately for each.
@@ -692,6 +798,9 @@
   ;;                                  :models [{:id :linear :r-squared 0.98 ...}]
   ;;                                  :best-fit :linear}}}
 
+  Example - with selection method:
+  (fit-complexity extract :n {:selection-method :bic})
+
   Example - multiple implementations:
   (fit-complexity extract-with-impls :n)
   ;; => {:type :criterium/domain-regression
@@ -701,9 +810,20 @@
   ;;     :regressions {:elapsed-time {:metric [:stats :elapsed-time :mean]
   ;;                                  :by-impl {:vec {:models [...] :best-fit :linear}
   ;;                                            :list {:models [...] :best-fit :quadratic}}}}}"
-  ([extract axis] (fit-complexity extract axis nil))
-  ([extract axis models]
-   (let [models (or models default-complexity-models)
+  ([extract axis] (fit-complexity extract axis {}))
+  ([extract axis opts]
+   ;; Support backward compatibility: if opts looks like a models map
+   ;; (has :transform or :transforms in values), treat it as models
+   (let [is-options-map? (or (nil? opts)
+                             (empty? opts)
+                             (contains? opts :models)
+                             (contains? opts :selection-method))
+         {:keys [models selection-method]}
+         (if is-options-map?
+           opts
+           {:models opts})
+         models (or models default-complexity-models)
+         selection-method (or selection-method :aic)
          impl-axis-key (:impl-axis extract)
          impls (:implementations extract)
          multi-impl? (> (count impls) 1)
@@ -742,30 +862,7 @@
                                      :param-count
                                      param-count)))
                                 models))
-                 ;; Find best fit by R², preferring simpler models when R² is
-                 ;; close
-                 best-fit (when (seq fitted)
-                            (let [r-sq-threshold 1e-6
-                                  sorted (sort-by
-                                          (juxt
-                                           #(- (double
-                                                (:r-squared %)))
-                                           :param-count)
-                                          fitted)
-                                  best (first sorted)
-                                  within-threshold (filterv
-                                                    #(<
-                                                      (-
-                                                       (double
-                                                        (:r-squared best))
-                                                       (double
-                                                        (:r-squared %)))
-                                                      r-sq-threshold)
-                                                    sorted)]
-                              (:id (first
-                                    (sort-by
-                                     :param-count
-                                     within-threshold)))))]
+                 best-fit (select-best-model fitted selection-method)]
              {:models (or fitted [])
               :best-fit best-fit}))
 
@@ -826,10 +923,14 @@
 
   Parameters:
     opts - Map with keys:
-      :id         - Key for result in output (default: :regression)
-      :extract-id - Key for source domain-extract in input (default: :extract)
-      :axis       - Coordinate key to use for x-values (required, e.g., :n)
-      :models     - Map of model definitions, or nil for defaults
+      :id               - Key for result in output (default: :regression)
+      :extract-id       - Key for source domain-extract in input (default: :extract)
+      :axis             - Coordinate key to use for x-values (required, e.g., :n)
+      :models           - Map of model definitions, or nil for defaults
+      :selection-method - Method for selecting best model:
+                          :aic (default) - lowest AICc
+                          :bic           - lowest BIC
+                          :r-squared     - highest R²
 
   The returned function:
   - Takes a data-map containing a domain-extract under :extract-id
@@ -844,12 +945,13 @@
   ;;     :extract {:type :criterium/domain-extract ...}
   ;;     :scaling {:type :criterium/domain-regression ...}}"
   ([] (domain-regression-fn {}))
-  ([{:keys [id extract-id axis models]}]
+  ([{:keys [id extract-id axis models selection-method]}]
    (fn [data-map]
      (let [extract-id (or extract-id :extract)
            id (or id :regression)
            extract (data-map extract-id)
-           result (fit-complexity extract axis models)]
+           result (fit-complexity extract axis {:models models
+                                                :selection-method selection-method})]
        (assoc data-map id result)))))
 
 ;;; Log-Log Regression Analysis

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -408,6 +408,35 @@
 ;; Enables quantitative determination of algorithmic complexity from
 ;; benchmark measurements across varying input sizes.
 
+(defn compute-aic
+  "Compute AICc (Akaike Information Criterion with small-sample correction).
+
+  AICc = n*ln(RSS/n) + 2k + (2k(k+1))/(n-k-1)
+
+  Where n = sample size, k = number of parameters, RSS = residual sum of squares.
+
+  Returns nil if n <= k+1 (insufficient data for the correction term)."
+  [^double rss ^long n ^long k]
+  (when (> n (inc k))
+    (let [base-aic (+ (* n (Math/log (/ rss n)))
+                      (* 2.0 k))
+          correction (/ (* 2.0 k (inc k))
+                        (- n k 1))]
+      (+ base-aic correction))))
+
+(defn compute-bic
+  "Compute BIC (Bayesian Information Criterion).
+
+  BIC = n*ln(RSS/n) + k*ln(n)
+
+  Where n = sample size, k = number of parameters, RSS = residual sum of squares.
+
+  Returns nil if n = 0."
+  [^double rss ^long n ^long k]
+  (when (pos? n)
+    (+ (* n (Math/log (/ rss n)))
+       (* k (Math/log n)))))
+
 (def default-complexity-models
   "Default complexity models for regression fitting.
 

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -533,6 +533,46 @@
      :b b
      :r-squared r-sq}))
 
+(defn log-log-regression
+  "Perform linear regression on log-transformed data.
+
+  Transforms (x, y) to (log(x), log(y)) and fits a linear model:
+    log(y) = slope * log(x) + intercept
+
+  The slope directly indicates algorithmic complexity:
+    - slope ≈ 0   → O(1)
+    - slope ≈ 0.5 → O(√n)
+    - slope ≈ 1   → O(n)
+    - slope ≈ 1.5 → O(n√n)
+    - slope ≈ 2   → O(n²)
+
+  Returns:
+    {:slope      - complexity exponent
+     :intercept  - log-space intercept
+     :r-squared  - coefficient of determination in log-log space
+     :log-xs     - log-transformed x values
+     :log-ys     - log-transformed y values
+     :residuals  - residuals in log space
+     :predict-fn - (fn [x] predicted-y) in original space}"
+  [xs ys]
+  {:pre [(seq xs) (seq ys) (= (count xs) (count ys))
+         (every? pos? xs) (every? pos? ys)]}
+  (let [log-xs (mapv #(Math/log (double %)) xs)
+        log-ys (mapv #(Math/log (double %)) ys)
+        {:keys [^double a ^double b ^double r-squared]}
+        (linear-regression log-xs log-ys)
+        residuals (mapv (fn [^double lx ^double ly]
+                          (- ly (+ (* a lx) b)))
+                        log-xs log-ys)]
+    {:slope a
+     :intercept b
+     :r-squared r-squared
+     :log-xs log-xs
+     :log-ys log-ys
+     :residuals residuals
+     :predict-fn (fn [^double x]
+                   (Math/exp (+ (* a (Math/log x)) b)))}))
+
 (defn- linear-regression-2
   "Perform multiple linear regression with 2 predictors: y = a*x1 + b*x2 + c.
   Uses centered variables for numerical stability, then adjusts intercept.
@@ -810,6 +850,183 @@
            id (or id :regression)
            extract (data-map extract-id)
            result (fit-complexity extract axis models)]
+       (assoc data-map id result)))))
+
+;;; Log-Log Regression Analysis
+;;
+;; Functions for computing log-log regression on domain extract data.
+;; The log-log plot provides intuitive understanding of complexity class:
+;; the slope directly indicates the complexity exponent.
+
+(defn fit-log-log
+  "Fit log-log linear regression to domain extract data.
+
+  Returns a domain-log-log-regression result with log-transformed data
+  and regression statistics for each metric.
+
+  extract is a domain-extract result (with :metrics map).
+  axis is the coordinate key to use for x-values (e.g., :n for input size).
+
+  The log-log regression fits: log(y) = slope * log(x) + intercept
+  The slope directly indicates complexity class:
+    - slope ≈ 1   → O(n)
+    - slope ≈ 2   → O(n²)
+
+  Filters out data points with nil or non-positive values before fitting.
+
+  When the extract has multiple implementations, data is grouped by
+  implementation and regression is fit separately for each.
+
+  Example - single implementation:
+  (fit-log-log extract :n)
+  ;; => {:type :criterium/domain-log-log-regression
+  ;;     :axis :n
+  ;;     :regressions {:elapsed-time {:metric [:stats :elapsed-time :mean]
+  ;;                                  :slope 1.02
+  ;;                                  :intercept -15.3
+  ;;                                  :r-squared 0.998
+  ;;                                  :log-xs [...]
+  ;;                                  :log-ys [...]
+  ;;                                  :xs [...]
+  ;;                                  :ys [...]
+  ;;                                  :residuals [...]}}}
+
+  Example - multiple implementations:
+  (fit-log-log extract-with-impls :n)
+  ;; => {:type :criterium/domain-log-log-regression
+  ;;     :axis :n
+  ;;     :impl-axis :impl
+  ;;     :implementations [:vec :list]
+  ;;     :regressions {:elapsed-time {:metric [:stats :elapsed-time :mean]
+  ;;                                  :by-impl {:vec {:slope 1.0 ...}
+  ;;                                            :list {:slope 2.0 ...}}}}}"
+  [extract axis]
+  (let [impl-axis-key (:impl-axis extract)
+        impls (:implementations extract)
+        multi-impl? (> (count impls) 1)
+
+        ;; Helper to fit log-log regression to a set of data points
+        fit-data-points
+        (fn [data with-error-bounds]
+          (let [get-value (if with-error-bounds
+                            (fn [v] (when (map? v) (:value v)))
+                            identity)
+                get-lower (when with-error-bounds
+                            (fn [v] (when (map? v) (:lower v))))
+                get-upper (when with-error-bounds
+                            (fn [v] (when (map? v) (:upper v))))
+                ;; Filter: valid coord with axis, positive x and y
+                valid-data (filterv (fn [[coord value]]
+                                      (let [y (get-value value)
+                                            x (when (map? coord) (get coord axis))]
+                                        (and (some? y) (pos? (double y))
+                                             (some? x) (pos? (double x)))))
+                                    data)]
+            (when (>= (count valid-data) 2)
+              (let [xs (mapv (fn [[coord _]] (double (get coord axis))) valid-data)
+                    ys (mapv (fn [[_ v]] (double (get-value v))) valid-data)
+                    {:keys [slope intercept r-squared log-xs log-ys residuals predict-fn]}
+                    (log-log-regression xs ys)
+                    ;; Transform error bounds to log space if present
+                    log-lowers (when with-error-bounds
+                                 (mapv (fn [[_ v]]
+                                         (let [lower (get-lower v)]
+                                           (when (and lower (pos? (double lower)))
+                                             (Math/log (double lower)))))
+                                       valid-data))
+                    log-uppers (when with-error-bounds
+                                 (mapv (fn [[_ v]]
+                                         (let [upper (get-upper v)]
+                                           (when (and upper (pos? (double upper)))
+                                             (Math/log (double upper)))))
+                                       valid-data))]
+                (cond-> {:slope slope
+                         :intercept intercept
+                         :r-squared r-squared
+                         :xs xs
+                         :ys ys
+                         :log-xs log-xs
+                         :log-ys log-ys
+                         :residuals residuals
+                         :predict-fn predict-fn}
+                  (and with-error-bounds (some some? log-lowers))
+                  (assoc :log-lowers log-lowers :log-uppers log-uppers))))))
+
+        ;; Fit a single metric's data (no implementation grouping)
+        fit-single
+        (fn [[_metric-id metric-data]]
+          (let [{:keys [metric data with-error-bounds]} metric-data
+                result (fit-data-points data with-error-bounds)]
+            (cond-> {:metric metric
+                     :with-error-bounds (boolean with-error-bounds)}
+              result (merge result))))
+
+        ;; Fit a single metric's data with implementation grouping
+        fit-single-by-impl
+        (fn [[_metric-id metric-data]]
+          (let [{:keys [metric data with-error-bounds]} metric-data
+                ;; Group data by implementation
+                by-impl (group-by (fn [[coord _]] (get coord impl-axis-key)) data)
+                ;; Fit each implementation separately
+                impl-results
+                (into {}
+                      (keep (fn [[impl-val impl-data]]
+                              (when-let [result (fit-data-points
+                                                 impl-data with-error-bounds)]
+                                [impl-val result])))
+                      by-impl)]
+            {:metric metric
+             :with-error-bounds (boolean with-error-bounds)
+             :by-impl impl-results}))]
+
+    (if multi-impl?
+      ;; Multi-implementation: group and fit separately
+      {:type :criterium/domain-log-log-regression
+       :axis axis
+       :impl-axis impl-axis-key
+       :implementations impls
+       :regressions (into {}
+                          (map (fn [[metric-id metric-data]]
+                                 [metric-id
+                                  (fit-single-by-impl [metric-id metric-data])]))
+                          (:metrics extract))}
+      ;; Single implementation
+      {:type :criterium/domain-log-log-regression
+       :axis axis
+       :regressions (into {}
+                          (map (fn [[metric-id metric-data]]
+                                 [metric-id
+                                  (fit-single [metric-id metric-data])]))
+                          (:metrics extract))})))
+
+(defn domain-log-log-fn
+  "Returns a function that fits log-log regression to a domain extract in a data-map.
+
+  Parameters:
+    opts - Map with keys:
+      :id         - Key for result in output (default: :log-log)
+      :extract-id - Key for source domain-extract in input (default: :extract)
+      :axis       - Coordinate key to use for x-values (required, e.g., :n)
+
+  The returned function:
+  - Takes a data-map containing a domain-extract under :extract-id
+  - Returns the data-map with a domain-log-log-regression result added under :id
+
+  Example:
+  (-> {:domain my-domain}
+      ((domain-extract-fn {:id :extract
+                           :metric-path [:stats :elapsed-time :mean]}))
+      ((domain-log-log-fn {:id :log-log :axis :n})))
+  ;; => {:domain my-domain
+  ;;     :extract {:type :criterium/domain-extract ...}
+  ;;     :log-log {:type :criterium/domain-log-log-regression ...}}"
+  ([] (domain-log-log-fn {}))
+  ([{:keys [id extract-id axis]}]
+   (fn [data-map]
+     (let [extract-id (or extract-id :extract)
+           id (or id :log-log)
+           extract (data-map extract-id)
+           result (fit-log-log extract axis)]
        (assoc data-map id result)))))
 
 ;;; Domain Plan Execution

--- a/bases/criterium/src/criterium/domain_plans.clj
+++ b/bases/criterium/src/criterium/domain_plans.clj
@@ -18,10 +18,13 @@
   complexity. Requires map coordinates with an :n key for input size.
 
   Includes error bounds (±3σ) for each data point when viewed with kindly.
+  Shows log-log diagnostic chart before model fits for intuitive complexity
+  class estimation (slope ≈ 1 for O(n), slope ≈ 2 for O(n²), etc.).
 
   Example:
     (analyse-domain complexity-analysis my-domain)"
   {:analyse [[:domain-extract-fn {:with-error-bounds true}]
+             [:domain-log-log-fn {:axis :n}]
              [:domain-regression-fn {:axis :n}]]
    :view [[:domain-extract {}]
           [:domain-regression {}]]})

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -1387,7 +1387,8 @@
 
 (defn prepare-regression-model-table
   "Prepare model table rows for single-impl regression display.
-  Returns vector of row maps with :model :r-squared :equation :best-fit keys.
+  Returns vector of row maps with :model :r-squared :aic :bic :equation :best-fit keys.
+  AIC and BIC values may be nil when insufficient data points.
   Options:
     :best-fit-marker - string to show for best fit (default \"✓\")
     :plotted-marker - string to show for plotted but not best (default \"\")
@@ -1408,10 +1409,12 @@
                              (map :id)
                              set))
           sorted-models (sort-by :r-squared > models)]
-      (mapv (fn [{:keys [id label equation-str r-squared]}]
+      (mapv (fn [{:keys [id label equation-str r-squared aic bic]}]
               (let [plotted? (and plotted-ids (plotted-ids id))]
                 {:model label
                  :r-squared (format "%.4f" r-squared)
+                 :aic (when aic (format "%.1f" aic))
+                 :bic (when bic (format "%.1f" bic))
                  :equation (or equation-str "")
                  :best-fit (cond
                              (= id best-fit) best-fit-marker
@@ -1421,7 +1424,7 @@
 
 (defn prepare-regression-model-table-multi-impl
   "Prepare model table rows for multi-impl regression display.
-  Returns vector of row maps with :implementation :model :r-squared :equation :best-fit.
+  Returns vector of row maps with :implementation :model :r-squared :aic :bic :equation :best-fit.
   Options same as prepare-regression-model-table."
   [by-impl impl-keys options]
   (vec

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -1705,8 +1705,14 @@
   "Format log-log slope as complexity class estimate.
   Returns string like 'O(n^1.02)' or 'O(n)' for integer slopes."
   [^double slope]
-  (let [rounded (Math/round slope)]
-    (if (< (Math/abs (- slope rounded)) 0.05)
+  (let [rounded (Math/round slope)
+        ;; Use 0.05 threshold (5% tolerance) for integer rounding. This is
+        ;; generous enough to handle typical measurement noise while avoiding
+        ;; false simplifications. A slope of 1.94 displays as O(n²) but 1.90
+        ;; shows the precise O(n^1.90). Chosen empirically to balance
+        ;; readability with accuracy for common complexity classes.
+        integer-tolerance 0.05]
+    (if (< (Math/abs (- slope rounded)) integer-tolerance)
       ;; Close to integer - use simplified form
       (case rounded
         0 "O(1)"

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -1560,6 +1560,157 @@
                   valid-data)))
         models)))))
 
+;;; Log-Log Regression view helpers
+;;
+;; Functions for preparing log-log regression data for chart display.
+;; Log-log plots show log(time) vs log(n), where the slope indicates
+;; complexity class directly (slope ≈ 1 for O(n), slope ≈ 2 for O(n²)).
+
+(defn prepare-log-log-points
+  "Prepare log-log transformed data points for scatter plot.
+  Returns {:points [...] :axis-name string} or nil.
+
+  Points have keys: x (log(n)), y (log(time)), and optionally
+  yLower, yUpper for log-transformed error bounds.
+  For multi-impl mode, points also have :impl key.
+
+  The log-log-data comes from the :regressions map of a
+  :criterium/domain-log-log-regression result."
+  [log-log-data {:keys [axis impl-axis]}]
+  (when log-log-data
+    (let [multi-impl? (contains? log-log-data :by-impl)]
+      (if multi-impl?
+        ;; Multi-implementation mode
+        (let [by-impl (:by-impl log-log-data)
+              impl-keys (keys by-impl)
+              all-points
+              (vec
+               (mapcat
+                (fn [impl-key]
+                  (let [{:keys [log-xs log-ys log-lowers log-uppers]}
+                        (get by-impl impl-key)]
+                    (when (and log-xs log-ys)
+                      (map-indexed
+                       (fn [i log-x]
+                         (let [log-y (nth log-ys i)]
+                           (cond-> {"x" log-x
+                                    "y" log-y
+                                    "impl" (name impl-key)}
+                             (and log-lowers (nth log-lowers i nil))
+                             (assoc "yLower" (nth log-lowers i))
+                             (and log-uppers (nth log-uppers i nil))
+                             (assoc "yUpper" (nth log-uppers i)))))
+                       log-xs))))
+                impl-keys))]
+          (when (seq all-points)
+            {:points all-points
+             :axis-name (name axis)
+             :has-error-bounds? (boolean
+                                 (some #(contains? % "yLower") all-points))}))
+        ;; Single implementation mode
+        (let [{:keys [log-xs log-ys log-lowers log-uppers]} log-log-data]
+          (when (and log-xs log-ys)
+            (let [points (vec
+                          (map-indexed
+                           (fn [i log-x]
+                             (let [log-y (nth log-ys i)]
+                               (cond-> {"x" log-x
+                                        "y" log-y}
+                                 (and log-lowers (nth log-lowers i nil))
+                                 (assoc "yLower" (nth log-lowers i))
+                                 (and log-uppers (nth log-uppers i nil))
+                                 (assoc "yUpper" (nth log-uppers i)))))
+                           log-xs))]
+              {:points points
+               :axis-name (name axis)
+               :has-error-bounds? (boolean
+                                   (some #(contains? % "yLower") points))})))))))
+
+(defn prepare-log-log-fit-line
+  "Generate fit line points for log-log plot.
+  Returns vector of point maps with x, y, and optionally impl key.
+
+  Uses the pre-computed slope and intercept: y = slope * x + intercept
+  where x = log(n), y = log(time)."
+  [log-log-data {:keys [axis impl-axis]}]
+  (when log-log-data
+    (let [multi-impl? (contains? log-log-data :by-impl)]
+      (if multi-impl?
+        ;; Multi-implementation mode: one line per impl
+        (let [by-impl (:by-impl log-log-data)]
+          (vec
+           (mapcat
+            (fn [[impl-key {:keys [slope intercept log-xs]}]]
+              (when (and slope intercept log-xs (seq log-xs))
+                (let [x-min (reduce min log-xs)
+                      x-max (reduce max log-xs)
+                      x-range (range x-min (+ x-max 0.1) (/ (- x-max x-min) 50))]
+                  (mapv (fn [x]
+                          {"x" x
+                           "y" (+ (* (double slope) x) (double intercept))
+                           "impl" (name impl-key)})
+                        x-range))))
+            by-impl)))
+        ;; Single implementation mode
+        (let [{:keys [slope intercept log-xs]} log-log-data]
+          (when (and slope intercept log-xs (seq log-xs))
+            (let [x-min (reduce min log-xs)
+                  x-max (reduce max log-xs)
+                  x-range (range x-min (+ x-max 0.1) (/ (- x-max x-min) 50))]
+              (vec
+               (mapv (fn [x]
+                       {"x" x
+                        "y" (+ (* (double slope) x) (double intercept))})
+                     x-range)))))))))
+
+(defn prepare-log-log-residuals
+  "Compute residual points for log-log plot.
+  Returns vector of point maps with x (log(n)), residual, and optionally impl.
+
+  Residuals are in log space: residual = log(y) - (slope * log(x) + intercept)"
+  [log-log-data {:keys [axis impl-axis]}]
+  (when log-log-data
+    (let [multi-impl? (contains? log-log-data :by-impl)]
+      (if multi-impl?
+        ;; Multi-implementation mode
+        (let [by-impl (:by-impl log-log-data)]
+          (vec
+           (mapcat
+            (fn [[impl-key {:keys [log-xs residuals]}]]
+              (when (and log-xs residuals)
+                (map-indexed
+                 (fn [i log-x]
+                   {"x" log-x
+                    "residual" (nth residuals i)
+                    "impl" (name impl-key)})
+                 log-xs)))
+            by-impl)))
+        ;; Single implementation mode
+        (let [{:keys [log-xs residuals]} log-log-data]
+          (when (and log-xs residuals)
+            (vec
+             (map-indexed
+              (fn [i log-x]
+                {"x" log-x
+                 "residual" (nth residuals i)})
+              log-xs))))))))
+
+(defn format-log-log-slope
+  "Format log-log slope as complexity class estimate.
+  Returns string like 'O(n^1.02)' or 'O(n)' for integer slopes."
+  [^double slope]
+  (let [rounded (Math/round slope)]
+    (if (< (Math/abs (- slope rounded)) 0.05)
+      ;; Close to integer - use simplified form
+      (case rounded
+        0 "O(1)"
+        1 "O(n)"
+        2 "O(n²)"
+        3 "O(n³)"
+        (format "O(n^%d)" rounded))
+      ;; Show decimal
+      (format "O(n^%.2f)" slope))))
+
 ;;; Allocation view helpers
 
 (defn format-call-site

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -1582,7 +1582,7 @@
 
   The log-log-data comes from the :regressions map of a
   :criterium/domain-log-log-regression result."
-  [log-log-data {:keys [axis impl-axis]}]
+  [log-log-data {:keys [axis _impl-axis]}]
   (when log-log-data
     (let [multi-impl? (contains? log-log-data :by-impl)]
       (if multi-impl?
@@ -1638,7 +1638,7 @@
 
   Uses the pre-computed slope and intercept: y = slope * x + intercept
   where x = log(n), y = log(time)."
-  [log-log-data {:keys [axis impl-axis]}]
+  [log-log-data {:keys [_axis _impl-axis]}]
   (when log-log-data
     (let [multi-impl? (contains? log-log-data :by-impl)]
       (if multi-impl?
@@ -1674,7 +1674,7 @@
   Returns vector of point maps with x (log(n)), residual, and optionally impl.
 
   Residuals are in log space: residual = log(y) - (slope * log(x) + intercept)"
-  [log-log-data {:keys [axis impl-axis]}]
+  [log-log-data {:keys [_axis _impl-axis]}]
   (when log-log-data
     (let [multi-impl? (contains? log-log-data :by-impl)]
       (if multi-impl?
@@ -1716,6 +1716,233 @@
         (format "O(n^%d)" rounded))
       ;; Show decimal
       (format "O(n^%.2f)" slope))))
+
+;;; Domain regression rendering orchestration
+;;
+;; A higher-order function to reduce duplication across viewers for the
+;; domain-regression* view. The iteration and data-preparation logic is
+;; common; only the rendering differs.
+
+(defn with-domain-regression-data
+  "Orchestrate domain-regression rendering by iterating over metrics and
+  implementations, calling the provided render functions at appropriate points.
+
+  The opts map must contain:
+    :regression-id - key for regression in data-map (default :regression)
+    :extract-id    - key for extract in data-map (default :extract)
+    :log-log-id    - key for log-log in data-map (default :log-log)
+    :tolerance     - tolerance for selecting plotted models (default 0.01)
+    :table-options - options for prepare-regression-model-table functions
+
+  The handlers map must contain render functions:
+    :render-log-log-charts     - (fn [{:keys [title axis metric impl-axis points
+                                             line-pts residual-pts chart-opts]}] ...)
+    :render-model-heading      - (fn [{:keys [title axis metric impl-axis]}] ...)
+    :render-model-table        - (fn [{:keys [table-rows multi-impl?]}] ...)
+    :render-regression-charts  - (fn [{:keys [points line-pts residual-pts
+                                             y-title residual-title axis
+                                             chart-opts multi-impl?]}] ...)
+
+  For multi-impl mode, the impl-key is included in callback maps.
+  For single-impl mode, slope/r-squared from log-log are included for display."
+  [data-map opts handlers]
+  (let [{:keys [regression-id extract-id log-log-id tolerance table-options]}
+        opts
+        regression-id (or regression-id :regression)
+        regression (data-map regression-id)
+        log-log-id (or log-log-id :log-log)
+        log-log (data-map log-log-id)
+        tolerance (double (or tolerance 0.01))
+        extract-id (or extract-id :extract)
+        extract (data-map extract-id)
+
+        {:keys [render-log-log-charts render-model-heading
+                render-model-table render-regression-charts]}
+        handlers]
+
+    (when regression
+      (let [{:keys [axis regressions impl-axis implementations]} regression
+            multi-impl? (> (count implementations) 1)]
+
+        (if multi-impl?
+          ;; Multi-implementation mode
+          (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
+                  regressions]
+            (let [metric-extract-data (get-in extract [:metrics metric-id])
+                  impl-keys (sort (keys by-impl))
+                  log-log-data (get-in log-log [:regressions metric-id])]
+
+              ;; Log-log diagnostic charts (before model fit)
+              (when log-log-data
+                (when-let [point-data (prepare-log-log-points
+                                       log-log-data
+                                       {:axis axis :impl-axis impl-axis})]
+                  (let [{:keys [points has-error-bounds?]} point-data
+                        line-pts (prepare-log-log-fit-line
+                                  log-log-data {:axis axis :impl-axis impl-axis})
+                        residual-pts (prepare-log-log-residuals
+                                      log-log-data
+                                      {:axis axis :impl-axis impl-axis})]
+                    (when (seq points)
+                      (render-log-log-charts
+                       {:title (str "Log-Log Diagnostic (axis: " (name axis)
+                                    ", metric: " (pr-str metric)
+                                    ", by: " (name impl-axis) ")")
+                        :axis axis
+                        :metric metric
+                        :impl-axis impl-axis
+                        :points points
+                        :line-pts line-pts
+                        :residual-pts residual-pts
+                        :chart-opts {:axis-name (name axis)
+                                     :color-field "impl"
+                                     :has-error-bounds? has-error-bounds?}})))))
+
+              ;; Model heading
+              (render-model-heading
+               {:title (str "Domain Regression (axis: " (name axis)
+                            ", metric: " (pr-str metric)
+                            ", by: " (name impl-axis) ")")
+                :axis axis
+                :metric metric
+                :impl-axis impl-axis})
+
+              ;; Model table
+              (render-model-table
+               {:table-rows (when (seq by-impl)
+                              (prepare-regression-model-table-multi-impl
+                               by-impl impl-keys table-options))
+                :multi-impl? true})
+
+              ;; Regression charts
+              (when-let [point-data (prepare-regression-points
+                                     metric-extract-data
+                                     {:axis axis
+                                      :impl-axis impl-axis
+                                      :has-error-bounds? with-error-bounds
+                                      :metric metric})]
+                (let [{:keys [points unit]} point-data
+                      line-pts (prepare-regression-fit-lines
+                                point-data
+                                {:by-impl by-impl :impl-keys impl-keys})
+                      y-title (if (seq unit)
+                                (str (pr-str metric) " (" unit ")")
+                                (pr-str metric))
+                      residual-title (if (seq unit)
+                                       (str "Residual (" unit ")")
+                                       "Residual")]
+                  (when (seq points)
+                    (let [residual-pts (prepare-regression-residuals
+                                        point-data
+                                        {:axis axis
+                                         :impl-axis impl-axis
+                                         :has-error-bounds? with-error-bounds
+                                         :by-impl by-impl
+                                         :impl-keys impl-keys})]
+                      (render-regression-charts
+                       {:points points
+                        :line-pts line-pts
+                        :residual-pts residual-pts
+                        :y-title y-title
+                        :residual-title residual-title
+                        :axis axis
+                        :chart-opts {:axis-name (name axis)
+                                     :color-field "impl"
+                                     :has-error-bounds? with-error-bounds}
+                        :multi-impl? true})))))))
+
+          ;; Single-implementation mode
+          (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
+                  regressions]
+            (let [metric-extract-data (get-in extract [:metrics metric-id])
+                  log-log-data (get-in log-log [:regressions metric-id])
+                  best-r-squared (when best-fit
+                                   (->> models
+                                        (filter #(= (:id %) best-fit))
+                                        first
+                                        :r-squared))
+                  models-to-plot (when best-r-squared
+                                   (->> models
+                                        (filter
+                                         #(>= (double (:r-squared %))
+                                              (* (double best-r-squared)
+                                                 (- 1.0 tolerance))))
+                                        (sort-by :r-squared >)))]
+
+              ;; Log-log diagnostic charts (before model fit)
+              (when log-log-data
+                (when-let [point-data (prepare-log-log-points
+                                       log-log-data {:axis axis})]
+                  (let [{:keys [points has-error-bounds?]} point-data
+                        line-pts (prepare-log-log-fit-line
+                                  log-log-data {:axis axis})
+                        {:keys [slope r-squared]} log-log-data
+                        residual-pts (prepare-log-log-residuals
+                                      log-log-data {:axis axis})]
+                    (when (seq points)
+                      (render-log-log-charts
+                       {:title (str "Log-Log Diagnostic (axis: " (name axis)
+                                    ", metric: " (pr-str metric) ")")
+                        :axis axis
+                        :metric metric
+                        :points points
+                        :line-pts line-pts
+                        :residual-pts residual-pts
+                        :slope slope
+                        :r-squared r-squared
+                        :chart-opts {:axis-name (name axis)
+                                     :has-error-bounds? has-error-bounds?
+                                     :slope slope
+                                     :r-squared r-squared}})))))
+
+              ;; Model heading
+              (render-model-heading
+               {:title (str "Domain Regression (axis: " (name axis)
+                            ", metric: " (pr-str metric) ")")
+                :axis axis
+                :metric metric})
+
+              ;; Model table
+              (render-model-table
+               {:table-rows (when (seq models)
+                              (prepare-regression-model-table
+                               {:models models :best-fit best-fit}
+                               table-options))
+                :multi-impl? false})
+
+              ;; Regression charts
+              (when (and metric-extract-data (seq models-to-plot))
+                (when-let [point-data (prepare-regression-points
+                                       metric-extract-data
+                                       {:axis axis
+                                        :has-error-bounds? with-error-bounds
+                                        :metric metric})]
+                  (let [{:keys [points unit]} point-data
+                        line-pts (prepare-regression-fit-lines
+                                  point-data {:models models-to-plot})
+                        y-title (if (seq unit)
+                                  (str (pr-str metric) " (" unit ")")
+                                  (pr-str metric))
+                        residual-title (if (seq unit)
+                                         (str "Residual (" unit ")")
+                                         "Residual")]
+                    (when (seq points)
+                      (let [residual-pts (prepare-regression-residuals
+                                          point-data
+                                          {:axis axis
+                                           :has-error-bounds? with-error-bounds
+                                           :models models-to-plot})]
+                        (render-regression-charts
+                         {:points points
+                          :line-pts line-pts
+                          :residual-pts residual-pts
+                          :y-title y-title
+                          :residual-title residual-title
+                          :axis axis
+                          :chart-opts {:axis-name (name axis)
+                                       :color-field "model"
+                                       :has-error-bounds? with-error-bounds}
+                          :multi-impl? false})))))))))))))
 
 ;;; Allocation view helpers
 

--- a/bases/criterium/src/criterium/viewer/common.clj
+++ b/bases/criterium/src/criterium/viewer/common.clj
@@ -1149,11 +1149,12 @@
                                :factor (cond
                                          (nil? value) "-"
                                          (nil? baseline-value) "-"
-                                         (zero? baseline-value) "-"
+                                         (zero? ^double baseline-value) "-"
                                          :else
                                          (format
                                           "%.2f"
-                                          (double (/ value baseline-value)))))]))
+                                          (/ ^double value
+                                             ^double baseline-value))))]))
                         col-specs col-headers)))
            row-keys)]
       {:heading (str "Domain Comparison by " (name axis) ": " (pr-str metric))
@@ -1233,8 +1234,10 @@
                     :factor (cond
                               (nil? value) "-"
                               (nil? baseline-value) "-"
-                              (zero? baseline-value) "-"
-                              :else (format "%.2f" (/ value baseline-value))))]))
+                              (zero? ^double baseline-value) "-"
+                              :else (format "%.2f"
+                                            (/ ^double value
+                                               ^double baseline-value))))]))
              col-specs col-headers)))
          row-keys)]
     {:heading (str "Domain Comparison by " (name axis))
@@ -1645,10 +1648,10 @@
            (mapcat
             (fn [[impl-key {:keys [slope intercept log-xs]}]]
               (when (and slope intercept log-xs (seq log-xs))
-                (let [x-min (reduce min log-xs)
-                      x-max (reduce max log-xs)
+                (let [x-min (double (reduce min log-xs))
+                      x-max (double (reduce max log-xs))
                       x-range (range x-min (+ x-max 0.1) (/ (- x-max x-min) 50))]
-                  (mapv (fn [x]
+                  (mapv (fn [^double x]
                           {"x" x
                            "y" (+ (* (double slope) x) (double intercept))
                            "impl" (name impl-key)})
@@ -1657,11 +1660,11 @@
         ;; Single implementation mode
         (let [{:keys [slope intercept log-xs]} log-log-data]
           (when (and slope intercept log-xs (seq log-xs))
-            (let [x-min (reduce min log-xs)
-                  x-max (reduce max log-xs)
+            (let [x-min (double (reduce min log-xs))
+                  x-max (double (reduce max log-xs))
                   x-range (range x-min (+ x-max 0.1) (/ (- x-max x-min) 50))]
               (vec
-               (mapv (fn [x]
+               (mapv (fn [^double x]
                        {"x" x
                         "y" (+ (* (double slope) x) (double intercept))})
                      x-range)))))))))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -577,7 +577,7 @@
 (defn log-log-line-layer
   "Build fit line layer for log-log plot.
   Line represents: y = slope * x + intercept in log space."
-  [line-pts {:keys [color-field legend-options]}]
+  [line-pts {:keys [color-field _legend-options]}]
   {:data {:values (vec line-pts)}
    :mark {:type "line" :strokeWidth 2}
    :encoding (cond-> {:x {:field "x" :type "quantitative"}

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -503,18 +503,22 @@
                                      legend-options)}}})
 
 (defn regression-loess-layer
-  "Build loess smoothing layer for residual plot."
+  "Build loess smoothing layer for residual plot.
+  When color-field is nil, LOESS is applied to all data points as one series."
   [residual-pts {:keys [color-field]}]
   {:data {:values (vec residual-pts)}
-   :transform [{:loess "residual"
-                :on "x"
-                :groupby [color-field]
-                :bandwidth 0.3}]
+   :transform [(cond-> {:loess "residual"
+                        :on "x"
+                        :bandwidth 0.3}
+                 color-field (assoc :groupby [color-field]))]
    :mark {:type "line" :strokeWidth 1}
-   :encoding {:x {:field "x" :type "quantitative"}
-              :y {:field "residual" :type "quantitative"}
-              :color {:field color-field :type "nominal" :legend nil}
-              :opacity {:value 0.4}}})
+   :encoding (cond-> {:x {:field "x" :type "quantitative"}
+                      :y {:field "residual" :type "quantitative"}
+                      :opacity {:value 0.4}}
+               color-field
+               (assoc :color {:field color-field :type "nominal" :legend nil})
+               (not color-field)
+               (assoc :color {:value "steelblue"}))})
 
 (defn regression-zero-line-layer
   "Build zero reference line layer for residual plot."
@@ -665,13 +669,9 @@
                  :or {width 600 height 200} :as opts}]
   {:width width
    :height height
-   :layer (cond-> [(log-log-residual-layer residual-pts
-                                           (assoc opts :axis-name axis-name))]
-            ;; Only include loess smoothing when groupby field is present
-            color-field
-            (conj (regression-loess-layer residual-pts {:color-field color-field}))
-            :always
-            (conj (regression-zero-line-layer)))})
+   :layer [(log-log-residual-layer residual-pts (assoc opts :axis-name axis-name))
+           (regression-loess-layer residual-pts {:color-field color-field})
+           (regression-zero-line-layer)]})
 
 ;;; Single-point comparison bar charts
 

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -541,6 +541,138 @@
            (regression-loess-layer residual-pts {:color-field color-field})
            (regression-zero-line-layer)]})
 
+;;; Log-Log Regression Charts
+;;
+;; Charts for visualizing log-log regression analysis.
+;; In log-log space, power law relationships become linear:
+;; log(y) = slope * log(x) + intercept
+;; The slope directly indicates complexity class (1 for O(n), 2 for O(n²), etc.)
+
+(defn log-log-scatter-layer
+  "Build scatter layer for log-log plot.
+  Points are in log space: x = log(n), y = log(time)."
+  [points {:keys [axis-name color-field color-value legend-options]}]
+  {:data {:values (vec points)}
+   :mark {:type "point" :size 60 :filled true}
+   :encoding (cond-> {:x {:field "x"
+                          :type "quantitative"
+                          :title (str "log(" axis-name ")")}
+                      :y {:field "y"
+                          :type "quantitative"
+                          :title "log(time)"}}
+               color-field
+               (assoc :color {:field color-field
+                              :type "nominal"
+                              :legend (merge {:title (if (= color-field "impl")
+                                                       "Implementation"
+                                                       "Model")}
+                                             legend-options)})
+               (and (nil? color-field) color-value)
+               (assoc :color {:value color-value}))})
+
+(defn log-log-line-layer
+  "Build fit line layer for log-log plot.
+  Line represents: y = slope * x + intercept in log space."
+  [line-pts {:keys [color-field legend-options]}]
+  {:data {:values (vec line-pts)}
+   :mark {:type "line" :strokeWidth 2}
+   :encoding (cond-> {:x {:field "x" :type "quantitative"}
+                      :y {:field "y" :type "quantitative"}}
+               color-field
+               (assoc :color {:field color-field
+                              :type "nominal"
+                              :legend nil}))})
+
+(defn log-log-error-layer
+  "Build error bar layer for log-log plot.
+  Shows confidence bounds in log space."
+  [points {:keys [color-field color-value]}]
+  {:data {:values (vec (filter #(and (contains? % "yLower")
+                                     (contains? % "yUpper"))
+                               points))}
+   :mark {:type "rule" :strokeWidth 1}
+   :encoding (cond-> {:x {:field "x" :type "quantitative"}
+                      :y {:field "yLower" :type "quantitative"}
+                      :y2 {:field "yUpper"}}
+               color-field
+               (assoc :color {:field color-field :type "nominal" :legend nil})
+               (and (nil? color-field) color-value)
+               (assoc :color {:value color-value}))})
+
+(defn log-log-chart-spec
+  "Build complete log-log scatter plot with fit line.
+  Options:
+    :width - chart width
+    :height - chart height
+    :axis-name - name of the axis variable (e.g., 'n')
+    :color-field - field for color encoding ('impl' or nil)
+    :color-value - static color when color-field is nil
+    :legend-options - legend config map
+    :has-error-bounds? - whether to include error bars
+    :slope - slope value to show in title
+    :r-squared - R² value to show in title"
+  [points line-pts
+   {:keys [width height color-field color-value
+           legend-options has-error-bounds? slope r-squared]
+    :or {width 600 height 400 color-value "steelblue"} :as opts}]
+  (let [scatter-layer (log-log-scatter-layer points opts)
+        line-layer (log-log-line-layer line-pts
+                                       {:color-field color-field
+                                        :legend-options legend-options})
+        error-layer (when has-error-bounds?
+                      (log-log-error-layer points
+                                           {:color-field color-field
+                                            :color-value color-value}))
+        layers (cond-> [scatter-layer line-layer]
+                 has-error-bounds? (conj error-layer))
+        title (when (and slope r-squared (nil? color-field))
+                (format "Log-Log Plot: slope=%.2f (R²=%.4f)"
+                        (double slope) (double r-squared)))]
+    (cond-> {:width width
+             :height height
+             :layer layers}
+      title (assoc :title title))))
+
+(defn log-log-residual-layer
+  "Build scatter layer for log-log residual plot."
+  [residual-pts {:keys [axis-name residual-title color-field legend-options]}]
+  {:data {:values (vec residual-pts)}
+   :mark {:type "point" :size 60}
+   :encoding (cond-> {:x {:field "x"
+                          :type "quantitative"
+                          :title (str "log(" axis-name ")")}
+                      :y {:field "residual"
+                          :type "quantitative"
+                          :title (or residual-title "Residual (log space)")}}
+               color-field
+               (assoc :color {:field color-field
+                              :type "nominal"
+                              :legend (merge {:title (if (= color-field "impl")
+                                                       "Implementation"
+                                                       "Model")}
+                                             legend-options)}))})
+
+(defn log-log-residual-spec
+  "Build complete log-log residual plot spec.
+  Options:
+    :width - chart width
+    :height - chart height (typically half of main chart)
+    :axis-name - name of the axis variable (e.g., 'n')
+    :residual-title - y-axis title
+    :color-field - field for color encoding
+    :legend-options - legend config map"
+  [residual-pts {:keys [width height color-field axis-name]
+                 :or {width 600 height 200} :as opts}]
+  {:width width
+   :height height
+   :layer (cond-> [(log-log-residual-layer residual-pts
+                                           (assoc opts :axis-name axis-name))]
+            ;; Only include loess smoothing when groupby field is present
+            color-field
+            (conj (regression-loess-layer residual-pts {:color-field color-field}))
+            :always
+            (conj (regression-zero-line-layer)))})
+
 ;;; Single-point comparison bar charts
 
 (defn prepare-single-point-bar-data

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -305,225 +305,70 @@
 
 (defmethod view/domain-regression* :kindly
   [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]
-  (let [regression-id (or regression-id :regression)
-        regression (data-map regression-id)
-        log-log-id (or log-log-id :log-log)
-        log-log (data-map log-log-id)
-        tolerance (double (or tolerance 0.01))
-        table-options {:best-fit-marker "✓"
-                       :plotted-marker ""
-                       :tolerance tolerance}
+  (let [tolerance (double (or tolerance 0.01))
         legend-options {:orient "none"
                         :legendX 10
                         :legendY 10}]
-    (when regression
-      (let [{:keys [axis regressions impl-axis implementations]} regression
-            extract-id (or extract-id :extract)
-            extract (data-map extract-id)
-            multi-impl? (> (count implementations) 1)]
+    (viewer-common/with-domain-regression-data
+      data-map
+      {:regression-id regression-id
+       :extract-id extract-id
+       :log-log-id log-log-id
+       :tolerance tolerance
+       :table-options {:best-fit-marker "✓"
+                       :plotted-marker ""
+                       :tolerance tolerance}}
+      {:render-log-log-charts
+       (fn [{:keys [title points line-pts residual-pts chart-opts]}]
+         (kindly-heading title)
+         (when (seq points)
+           (kindly-vega-lite
+            (charts/log-log-chart-spec
+             points line-pts
+             (assoc chart-opts
+                    :width chart-width
+                    :height chart-height
+                    :legend-options legend-options)))
+           (when (seq residual-pts)
+             (kindly-heading "Log-Log Residual Plot")
+             (kindly-vega-lite
+              (charts/log-log-residual-spec
+               residual-pts
+               (assoc chart-opts
+                      :width chart-width
+                      :height (long (/ (long chart-height) 2))
+                      :legend-options legend-options))))))
 
-        (if multi-impl?
-          ;; Multi-implementation mode
-          (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
-                  regressions]
-            (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  impl-keys (sort (keys by-impl))
-                  log-log-data (get-in log-log [:regressions metric-id])]
-              ;; Log-log diagnostic chart (before model fit chart)
-              (when log-log-data
-                (kindly-heading (str "Log-Log Diagnostic (axis: " (name axis)
-                                     ", metric: " (pr-str metric)
-                                     ", by: " (name impl-axis) ")"))
-                (when-let [point-data (viewer-common/prepare-log-log-points
-                                       log-log-data
-                                       {:axis axis :impl-axis impl-axis})]
-                  (let [{:keys [points has-error-bounds?]} point-data
-                        line-pts (viewer-common/prepare-log-log-fit-line
-                                  log-log-data {:axis axis :impl-axis impl-axis})]
-                    (when (seq points)
-                      (kindly-vega-lite
-                       (charts/log-log-chart-spec
-                        points line-pts
-                        {:width chart-width
-                         :height chart-height
-                         :axis-name (name axis)
-                         :color-field "impl"
-                         :legend-options legend-options
-                         :has-error-bounds? has-error-bounds?}))
-                      ;; Log-log residual plot
-                      (let [residual-pts (viewer-common/prepare-log-log-residuals
-                                          log-log-data
-                                          {:axis axis :impl-axis impl-axis})]
-                        (when (seq residual-pts)
-                          (kindly-heading "Log-Log Residual Plot")
-                          (kindly-vega-lite
-                           (charts/log-log-residual-spec
-                            residual-pts
-                            {:width chart-width
-                             :height (long (/ (long chart-height) 2))
-                             :axis-name (name axis)
-                             :color-field "impl"
-                             :legend-options legend-options}))))))))
+       :render-model-heading
+       (fn [{:keys [title]}]
+         (kindly-heading title))
 
-              (kindly-heading (str "Domain Regression (axis: " (name axis)
-                                   ", metric: " (pr-str metric)
-                                   ", by: " (name impl-axis) ")"))
-              ;; Model table
-              (when (seq by-impl)
-                (kindly-table
-                 (viewer-common/prepare-regression-model-table-multi-impl
-                  by-impl impl-keys table-options)))
-              ;; Charts
-              (when-let [point-data (viewer-common/prepare-regression-points
-                                     metric-extract-data
-                                     {:axis axis
-                                      :impl-axis impl-axis
-                                      :has-error-bounds? with-error-bounds
-                                      :metric metric})]
-                (let [{:keys [points unit]}
-                      point-data
-                      line-pts
-                      (viewer-common/prepare-regression-fit-lines
-                       point-data
-                       {:by-impl by-impl :impl-keys impl-keys})
-                      y-title (if (seq unit)
-                                (str (pr-str metric) " (" unit ")")
-                                (pr-str metric))
-                      residual-title (if (seq unit)
-                                       (str "Residual (" unit ")")
-                                       "Residual")]
-                  (when (seq points)
-                    (kindly-vega-lite
-                     (charts/regression-chart-spec
-                      points line-pts
-                      {:width chart-width
-                       :height chart-height
-                       :axis-name (name axis) :y-title y-title
-                       :color-field "impl"
-                       :legend-options legend-options
-                       :has-error-bounds? with-error-bounds}))
-                    ;; Residual plot
-                    (let [residual-pts
-                          (viewer-common/prepare-regression-residuals
-                           point-data
-                           {:axis axis
-                            :impl-axis impl-axis
-                            :has-error-bounds? with-error-bounds
-                            :by-impl by-impl
-                            :impl-keys impl-keys})]
-                      (kindly-heading "Residual Plot")
-                      (kindly-vega-lite
-                       (charts/regression-residual-spec
-                        residual-pts
-                        {:width chart-width
-                         :height (long (/ (long chart-height) 2))
-                         :axis-name (name axis)
-                         :residual-title residual-title
-                         :color-field "impl"
-                         :legend-options legend-options}))))))))
+       :render-model-table
+       (fn [{:keys [table-rows]}]
+         (when (seq table-rows)
+           (kindly-table table-rows)))
 
-          ;; Single-implementation mode
-          (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
-                  regressions]
-            (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  log-log-data (get-in log-log [:regressions metric-id])
-                  best-r-squared (when best-fit
-                                   (->> models
-                                        (filter #(= (:id %) best-fit))
-                                        first :r-squared))
-                  models-to-plot (when best-r-squared
-                                   (->> models
-                                        (filter
-                                         #(>= (double (:r-squared %))
-                                              (* (double best-r-squared)
-                                                 (- 1.0 tolerance))))
-                                        (sort-by :r-squared >)))]
-              ;; Log-log diagnostic chart (before model fit chart)
-              (when log-log-data
-                (kindly-heading (str "Log-Log Diagnostic (axis: " (name axis)
-                                     ", metric: " (pr-str metric) ")"))
-                (when-let [point-data (viewer-common/prepare-log-log-points
-                                       log-log-data {:axis axis})]
-                  (let [{:keys [points has-error-bounds?]} point-data
-                        line-pts (viewer-common/prepare-log-log-fit-line
-                                  log-log-data {:axis axis})
-                        {:keys [slope r-squared]} log-log-data]
-                    (when (seq points)
-                      (kindly-vega-lite
-                       (charts/log-log-chart-spec
-                        points line-pts
-                        {:width chart-width
-                         :height chart-height
-                         :axis-name (name axis)
-                         :has-error-bounds? has-error-bounds?
-                         :slope slope
-                         :r-squared r-squared}))
-                      ;; Log-log residual plot
-                      (let [residual-pts (viewer-common/prepare-log-log-residuals
-                                          log-log-data {:axis axis})]
-                        (when (seq residual-pts)
-                          (kindly-heading "Log-Log Residual Plot")
-                          (kindly-vega-lite
-                           (charts/log-log-residual-spec
-                            residual-pts
-                            {:width chart-width
-                             :height (long (/ (long chart-height) 2))
-                             :axis-name (name axis)}))))))))
-
-              (kindly-heading (str "Domain Regression (axis: " (name axis)
-                                   ", metric: " (pr-str metric) ")"))
-              ;; Model table
-              (when (seq models)
-                (kindly-table
-                 (viewer-common/prepare-regression-model-table
-                  {:models models :best-fit best-fit}
-                  table-options)))
-              ;; Charts
-              (when (and metric-extract-data (seq models-to-plot))
-                (when-let [point-data (viewer-common/prepare-regression-points
-                                       metric-extract-data
-                                       {:axis axis
-                                        :has-error-bounds? with-error-bounds
-                                        :metric metric})]
-                  (let [{:keys [points unit]}
-                        point-data
-                        line-pts
-                        (viewer-common/prepare-regression-fit-lines
-                         point-data {:models models-to-plot})
-                        y-title (if (seq unit)
-                                  (str (pr-str metric) " (" unit ")")
-                                  (pr-str metric))
-                        residual-title (if (seq unit)
-                                         (str "Residual (" unit ")")
-                                         "Residual")]
-                    (when (seq points)
-                      (kindly-vega-lite
-                       (charts/regression-chart-spec
-                        points line-pts
-                        {:width chart-width
-                         :height chart-height
-                         :axis-name (name axis)
-                         :y-title y-title
-                         :color-field "model"
-                         :legend-options legend-options
-                         :has-error-bounds? with-error-bounds}))
-                      ;; Residual plot
-                      (let [residual-pts
-                            (viewer-common/prepare-regression-residuals
-                             point-data
-                             {:axis axis
-                              :has-error-bounds? with-error-bounds
-                              :models models-to-plot})]
-                        (kindly-heading "Residual Plot")
-                        (kindly-vega-lite
-                         (charts/regression-residual-spec
-                          residual-pts
-                          {:width chart-width
-                           :height (long (/ (long chart-height) 2))
-                           :axis-name (name axis)
-                           :residual-title residual-title
-                           :color-field "model"
-                           :legend-options legend-options}))))))))))))))
+       :render-regression-charts
+       (fn [{:keys [points line-pts residual-pts y-title residual-title chart-opts]}]
+         (when (seq points)
+           (kindly-vega-lite
+            (charts/regression-chart-spec
+             points line-pts
+             (assoc chart-opts
+                    :width chart-width
+                    :height chart-height
+                    :y-title y-title
+                    :legend-options legend-options)))
+           (when (seq residual-pts)
+             (kindly-heading "Residual Plot")
+             (kindly-vega-lite
+              (charts/regression-residual-spec
+               residual-pts
+               (assoc chart-opts
+                      :width chart-width
+                      :height (long (/ (long chart-height) 2))
+                      :residual-title residual-title
+                      :legend-options legend-options))))))})))
 
 ;;; Allocation view implementations
 

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -304,9 +304,11 @@
         :default-table nil))))
 
 (defmethod view/domain-regression* :kindly
-  [_ {:keys [regression-id extract-id tolerance]} data-map]
+  [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]
   (let [regression-id (or regression-id :regression)
         regression (data-map regression-id)
+        log-log-id (or log-log-id :log-log)
+        log-log (data-map log-log-id)
         tolerance (double (or tolerance 0.01))
         table-options {:best-fit-marker "✓"
                        :plotted-marker ""
@@ -325,7 +327,44 @@
           (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  impl-keys (sort (keys by-impl))]
+                  impl-keys (sort (keys by-impl))
+                  log-log-data (get-in log-log [:regressions metric-id])]
+              ;; Log-log diagnostic chart (before model fit chart)
+              (when log-log-data
+                (kindly-heading (str "Log-Log Diagnostic (axis: " (name axis)
+                                     ", metric: " (pr-str metric)
+                                     ", by: " (name impl-axis) ")"))
+                (when-let [point-data (viewer-common/prepare-log-log-points
+                                       log-log-data
+                                       {:axis axis :impl-axis impl-axis})]
+                  (let [{:keys [points has-error-bounds?]} point-data
+                        line-pts (viewer-common/prepare-log-log-fit-line
+                                  log-log-data {:axis axis :impl-axis impl-axis})]
+                    (when (seq points)
+                      (kindly-vega-lite
+                       (charts/log-log-chart-spec
+                        points line-pts
+                        {:width chart-width
+                         :height chart-height
+                         :axis-name (name axis)
+                         :color-field "impl"
+                         :legend-options legend-options
+                         :has-error-bounds? has-error-bounds?}))
+                      ;; Log-log residual plot
+                      (let [residual-pts (viewer-common/prepare-log-log-residuals
+                                          log-log-data
+                                          {:axis axis :impl-axis impl-axis})]
+                        (when (seq residual-pts)
+                          (kindly-heading "Log-Log Residual Plot")
+                          (kindly-vega-lite
+                           (charts/log-log-residual-spec
+                            residual-pts
+                            {:width chart-width
+                             :height (long (/ (long chart-height) 2))
+                             :axis-name (name axis)
+                             :color-field "impl"
+                             :legend-options legend-options}))))))))
+
               (kindly-heading (str "Domain Regression (axis: " (name axis)
                                    ", metric: " (pr-str metric)
                                    ", by: " (name impl-axis) ")"))
@@ -387,6 +426,7 @@
           (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
+                  log-log-data (get-in log-log [:regressions metric-id])
                   best-r-squared (when best-fit
                                    (->> models
                                         (filter #(= (:id %) best-fit))
@@ -398,6 +438,38 @@
                                               (* (double best-r-squared)
                                                  (- 1.0 tolerance))))
                                         (sort-by :r-squared >)))]
+              ;; Log-log diagnostic chart (before model fit chart)
+              (when log-log-data
+                (kindly-heading (str "Log-Log Diagnostic (axis: " (name axis)
+                                     ", metric: " (pr-str metric) ")"))
+                (when-let [point-data (viewer-common/prepare-log-log-points
+                                       log-log-data {:axis axis})]
+                  (let [{:keys [points has-error-bounds?]} point-data
+                        line-pts (viewer-common/prepare-log-log-fit-line
+                                  log-log-data {:axis axis})
+                        {:keys [slope r-squared]} log-log-data]
+                    (when (seq points)
+                      (kindly-vega-lite
+                       (charts/log-log-chart-spec
+                        points line-pts
+                        {:width chart-width
+                         :height chart-height
+                         :axis-name (name axis)
+                         :has-error-bounds? has-error-bounds?
+                         :slope slope
+                         :r-squared r-squared}))
+                      ;; Log-log residual plot
+                      (let [residual-pts (viewer-common/prepare-log-log-residuals
+                                          log-log-data {:axis axis})]
+                        (when (seq residual-pts)
+                          (kindly-heading "Log-Log Residual Plot")
+                          (kindly-vega-lite
+                           (charts/log-log-residual-spec
+                            residual-pts
+                            {:width chart-width
+                             :height (long (/ (long chart-height) 2))
+                             :axis-name (name axis)}))))))))
+
               (kindly-heading (str "Domain Regression (axis: " (name axis)
                                    ", metric: " (pr-str metric) ")"))
               ;; Model table

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -280,216 +280,65 @@
 
 (defmethod view/domain-regression* :portal
   [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]
-  (let [regression-id (or regression-id :regression)
-        regression (data-map regression-id)
-        log-log-id (or log-log-id :log-log)
-        log-log (data-map log-log-id)
-        tolerance (double (or tolerance 0.01))
+  (let [tolerance (double (or tolerance 0.01))
         chart-width 600
-        chart-height 400
-        table-options {:best-fit-marker "✓"
+        chart-height 400]
+    (viewer-common/with-domain-regression-data
+      data-map
+      {:regression-id regression-id
+       :extract-id extract-id
+       :log-log-id log-log-id
+       :tolerance tolerance
+       :table-options {:best-fit-marker "✓"
                        :plotted-marker ""
-                       :tolerance tolerance}]
-    (when regression
-      (let [{:keys [axis regressions impl-axis implementations]}
-            regression
-            extract-id (or extract-id :extract)
-            extract (data-map extract-id)
-            multi-impl? (> (count implementations) 1)]
+                       :tolerance tolerance}}
+      {:render-log-log-charts
+       (fn [{:keys [title points line-pts residual-pts chart-opts]}]
+         (heading title)
+         (when (seq points)
+           (portal-vega-lite
+            (charts/log-log-chart-spec
+             points line-pts
+             (assoc chart-opts
+                    :width chart-width
+                    :height chart-height)))
+           (when (seq residual-pts)
+             (heading "Log-Log Residual Plot")
+             (portal-vega-lite
+              (charts/log-log-residual-spec
+               residual-pts
+               (assoc chart-opts
+                      :width chart-width
+                      :height (/ chart-height 2)))))))
 
-        (if multi-impl?
-          ;; Multi-implementation mode
-          (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
-                  regressions]
-            (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  impl-keys (sort (keys by-impl))
-                  log-log-data (get-in log-log [:regressions metric-id])]
-              ;; Log-log diagnostic chart (before model fit chart)
-              (when log-log-data
-                (heading (str "Log-Log Diagnostic (axis: " (name axis)
-                              ", metric: " (pr-str metric)
-                              ", by: " (name impl-axis) ")"))
-                (when-let [point-data (viewer-common/prepare-log-log-points
-                                       log-log-data
-                                       {:axis axis :impl-axis impl-axis})]
-                  (let [{:keys [points has-error-bounds?]} point-data
-                        line-pts (viewer-common/prepare-log-log-fit-line
-                                  log-log-data {:axis axis :impl-axis impl-axis})]
-                    (when (seq points)
-                      (portal-vega-lite
-                       (charts/log-log-chart-spec
-                        points line-pts
-                        {:width chart-width
-                         :height chart-height
-                         :axis-name (name axis)
-                         :color-field "impl"
-                         :has-error-bounds? has-error-bounds?}))
-                      ;; Log-log residual plot
-                      (let [residual-pts (viewer-common/prepare-log-log-residuals
-                                          log-log-data
-                                          {:axis axis :impl-axis impl-axis})]
-                        (when (seq residual-pts)
-                          (heading "Log-Log Residual Plot")
-                          (portal-vega-lite
-                           (charts/log-log-residual-spec
-                            residual-pts
-                            {:width chart-width
-                             :height (/ chart-height 2)
-                             :axis-name (name axis)
-                             :color-field "impl"}))))))))
+       :render-model-heading
+       (fn [{:keys [title]}]
+         (heading title))
 
-              (heading (str "Domain Regression (axis: " (name axis)
-                            ", metric: " (pr-str metric)
-                            ", by: " (name impl-axis) ")"))
-              ;; Model table
-              (when (seq by-impl)
-                (portal-table
-                 (viewer-common/prepare-regression-model-table-multi-impl
-                  by-impl impl-keys table-options)))
-              ;; Charts
-              (when-let [point-data (viewer-common/prepare-regression-points
-                                     metric-extract-data
-                                     {:axis axis
-                                      :impl-axis impl-axis
-                                      :has-error-bounds? with-error-bounds
-                                      :metric metric})]
-                (let [{:keys [points unit]} point-data
-                      line-pts
-                      (viewer-common/prepare-regression-fit-lines
-                       point-data
-                       {:by-impl by-impl
-                        :impl-keys impl-keys})
-                      y-title (if (seq unit)
-                                (str (pr-str metric)
-                                     " (" unit ")")
-                                (pr-str metric))
-                      residual-title (if (seq unit)
-                                       (str "Residual (" unit ")")
-                                       "Residual")]
-                  (when (seq points)
-                    (portal-vega-lite
-                     (charts/regression-chart-spec
-                      points line-pts
-                      {:width chart-width :height chart-height
-                       :axis-name (name axis) :y-title y-title
-                       :color-field "impl"
-                       :has-error-bounds? with-error-bounds}))
-                    ;; Residual plot
-                    (let [residual-pts
-                          (viewer-common/prepare-regression-residuals
-                           point-data
-                           {:axis axis
-                            :impl-axis impl-axis
-                            :has-error-bounds? with-error-bounds
-                            :by-impl by-impl
-                            :impl-keys impl-keys})]
-                      (heading "Residual Plot")
-                      (portal-vega-lite
-                       (charts/regression-residual-spec
-                        residual-pts
-                        {:width chart-width
-                         :height (/ chart-height 2)
-                         :axis-name (name axis) :residual-title residual-title
-                         :color-field "impl"}))))))))
+       :render-model-table
+       (fn [{:keys [table-rows]}]
+         (when (seq table-rows)
+           (portal-table table-rows)))
 
-          ;; Single-implementation mode
-          (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
-                  regressions]
-            (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  log-log-data (get-in log-log [:regressions metric-id])
-                  best-r-squared (when best-fit
-                                   (->> models
-                                        (filter #(= (:id %) best-fit))
-                                        first
-                                        :r-squared))
-                  models-to-plot (when best-r-squared
-                                   (->> models
-                                        (filter
-                                         #(>= (double (:r-squared %))
-                                              (* (double best-r-squared)
-                                                 (- 1 tolerance))))
-                                        (sort-by :r-squared >)))]
-              ;; Log-log diagnostic chart (before model fit chart)
-              (when log-log-data
-                (heading (str "Log-Log Diagnostic (axis: " (name axis)
-                              ", metric: " (pr-str metric) ")"))
-                (when-let [point-data (viewer-common/prepare-log-log-points
-                                       log-log-data {:axis axis})]
-                  (let [{:keys [points has-error-bounds?]} point-data
-                        line-pts (viewer-common/prepare-log-log-fit-line
-                                  log-log-data {:axis axis})
-                        {:keys [slope r-squared]} log-log-data]
-                    (when (seq points)
-                      (portal-vega-lite
-                       (charts/log-log-chart-spec
-                        points line-pts
-                        {:width chart-width
-                         :height chart-height
-                         :axis-name (name axis)
-                         :has-error-bounds? has-error-bounds?
-                         :slope slope
-                         :r-squared r-squared}))
-                      ;; Log-log residual plot
-                      (let [residual-pts (viewer-common/prepare-log-log-residuals
-                                          log-log-data {:axis axis})]
-                        (when (seq residual-pts)
-                          (heading "Log-Log Residual Plot")
-                          (portal-vega-lite
-                           (charts/log-log-residual-spec
-                            residual-pts
-                            {:width chart-width
-                             :height (/ chart-height 2)
-                             :axis-name (name axis)}))))))))
-
-              (heading (str "Domain Regression (axis: " (name axis)
-                            ", metric: " (pr-str metric) ")"))
-              ;; Model table
-              (when (seq models)
-                (portal-table
-                 (viewer-common/prepare-regression-model-table
-                  {:models models :best-fit best-fit}
-                  table-options)))
-              ;; Charts
-              (when (and metric-extract-data (seq models-to-plot))
-                (when-let [point-data (viewer-common/prepare-regression-points
-                                       metric-extract-data
-                                       {:axis axis
-                                        :has-error-bounds? with-error-bounds
-                                        :metric metric})]
-                  (let [{:keys [points unit]}
-                        point-data
-                        line-pts (viewer-common/prepare-regression-fit-lines
-                                  point-data
-                                  {:models models-to-plot})
-                        y-title (if (seq unit)
-                                  (str (pr-str metric) " (" unit ")")
-                                  (pr-str metric))
-                        residual-title (if (seq unit)
-                                         (str "Residual (" unit ")")
-                                         "Residual")]
-                    (when (seq points)
-                      (portal-vega-lite
-                       (charts/regression-chart-spec
-                        points line-pts
-                        {:width chart-width :height chart-height
-                         :axis-name (name axis) :y-title y-title
-                         :color-field "model"
-                         :has-error-bounds? with-error-bounds}))
-                      ;; Residual plot
-                      (let [residual-pts (viewer-common/prepare-regression-residuals
-                                          point-data
-                                          {:axis axis
-                                           :has-error-bounds? with-error-bounds
-                                           :models models-to-plot})]
-                        (heading "Residual Plot")
-                        (portal-vega-lite
-                         (charts/regression-residual-spec
-                          residual-pts
-                          {:width chart-width
-                           :height (/ chart-height 2)
-                           :axis-name (name axis)
-                           :residual-title residual-title
-                           :color-field "model"}))))))))))))))
+       :render-regression-charts
+       (fn [{:keys [points line-pts residual-pts y-title residual-title chart-opts]}]
+         (when (seq points)
+           (portal-vega-lite
+            (charts/regression-chart-spec
+             points line-pts
+             (assoc chart-opts
+                    :width chart-width
+                    :height chart-height
+                    :y-title y-title)))
+           (when (seq residual-pts)
+             (heading "Residual Plot")
+             (portal-vega-lite
+              (charts/regression-residual-spec
+               residual-pts
+               (assoc chart-opts
+                      :width chart-width
+                      :height (/ chart-height 2)
+                      :residual-title residual-title))))))})))
 
 ;;; Allocation Views
 

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -279,9 +279,11 @@
         :default-table nil))))
 
 (defmethod view/domain-regression* :portal
-  [_ {:keys [regression-id extract-id tolerance]} data-map]
+  [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]
   (let [regression-id (or regression-id :regression)
         regression (data-map regression-id)
+        log-log-id (or log-log-id :log-log)
+        log-log (data-map log-log-id)
         tolerance (double (or tolerance 0.01))
         chart-width 600
         chart-height 400
@@ -300,7 +302,42 @@
           (doseq [[metric-id {:keys [metric by-impl with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
-                  impl-keys (sort (keys by-impl))]
+                  impl-keys (sort (keys by-impl))
+                  log-log-data (get-in log-log [:regressions metric-id])]
+              ;; Log-log diagnostic chart (before model fit chart)
+              (when log-log-data
+                (heading (str "Log-Log Diagnostic (axis: " (name axis)
+                              ", metric: " (pr-str metric)
+                              ", by: " (name impl-axis) ")"))
+                (when-let [point-data (viewer-common/prepare-log-log-points
+                                       log-log-data
+                                       {:axis axis :impl-axis impl-axis})]
+                  (let [{:keys [points has-error-bounds?]} point-data
+                        line-pts (viewer-common/prepare-log-log-fit-line
+                                  log-log-data {:axis axis :impl-axis impl-axis})]
+                    (when (seq points)
+                      (portal-vega-lite
+                       (charts/log-log-chart-spec
+                        points line-pts
+                        {:width chart-width
+                         :height chart-height
+                         :axis-name (name axis)
+                         :color-field "impl"
+                         :has-error-bounds? has-error-bounds?}))
+                      ;; Log-log residual plot
+                      (let [residual-pts (viewer-common/prepare-log-log-residuals
+                                          log-log-data
+                                          {:axis axis :impl-axis impl-axis})]
+                        (when (seq residual-pts)
+                          (heading "Log-Log Residual Plot")
+                          (portal-vega-lite
+                           (charts/log-log-residual-spec
+                            residual-pts
+                            {:width chart-width
+                             :height (/ chart-height 2)
+                             :axis-name (name axis)
+                             :color-field "impl"}))))))))
+
               (heading (str "Domain Regression (axis: " (name axis)
                             ", metric: " (pr-str metric)
                             ", by: " (name impl-axis) ")"))
@@ -359,6 +396,7 @@
           (doseq [[metric-id {:keys [metric models best-fit with-error-bounds]}]
                   regressions]
             (let [metric-extract-data (get-in extract [:metrics metric-id])
+                  log-log-data (get-in log-log [:regressions metric-id])
                   best-r-squared (when best-fit
                                    (->> models
                                         (filter #(= (:id %) best-fit))
@@ -371,6 +409,38 @@
                                               (* (double best-r-squared)
                                                  (- 1 tolerance))))
                                         (sort-by :r-squared >)))]
+              ;; Log-log diagnostic chart (before model fit chart)
+              (when log-log-data
+                (heading (str "Log-Log Diagnostic (axis: " (name axis)
+                              ", metric: " (pr-str metric) ")"))
+                (when-let [point-data (viewer-common/prepare-log-log-points
+                                       log-log-data {:axis axis})]
+                  (let [{:keys [points has-error-bounds?]} point-data
+                        line-pts (viewer-common/prepare-log-log-fit-line
+                                  log-log-data {:axis axis})
+                        {:keys [slope r-squared]} log-log-data]
+                    (when (seq points)
+                      (portal-vega-lite
+                       (charts/log-log-chart-spec
+                        points line-pts
+                        {:width chart-width
+                         :height chart-height
+                         :axis-name (name axis)
+                         :has-error-bounds? has-error-bounds?
+                         :slope slope
+                         :r-squared r-squared}))
+                      ;; Log-log residual plot
+                      (let [residual-pts (viewer-common/prepare-log-log-residuals
+                                          log-log-data {:axis axis})]
+                        (when (seq residual-pts)
+                          (heading "Log-Log Residual Plot")
+                          (portal-vega-lite
+                           (charts/log-log-residual-spec
+                            residual-pts
+                            {:width chart-width
+                             :height (/ chart-height 2)
+                             :axis-name (name axis)}))))))))
+
               (heading (str "Domain Regression (axis: " (name axis)
                             ", metric: " (pr-str metric) ")"))
               ;; Model table

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -917,129 +917,74 @@
               (println (format "Domain Comparison by %s: %s (no data)"
                                (name axis) (pr-str metric))))))))))
 
-(defn- format-aic-bic
-  "Format AIC/BIC values for display. Returns empty string if both nil."
-  [aic bic]
-  (cond
-    (and aic bic) (format "  AIC=%.1f BIC=%.1f" aic bic)
-    aic (format "  AIC=%.1f" aic)
-    bic (format "  BIC=%.1f" bic)
-    :else ""))
-
 (defn- print-log-log-info
-  "Print log-log regression summary for a metric."
-  [log-log-data axis metric impl-key]
-  (when log-log-data
-    (let [{:keys [slope r-squared]} log-log-data]
-      (when (and slope r-squared)
-        (let [complexity (viewer-common/format-log-log-slope slope)]
-          (if impl-key
-            (println (format "  Log-log: slope=%.3f ≈ %s (R²=%.4f)"
-                             slope complexity r-squared))
-            (println (format "  Log-log diagnostic: slope=%.3f ≈ %s (R²=%.4f)"
-                             slope complexity r-squared))))))))
+  "Print log-log regression summary."
+  [slope r-squared multi-impl?]
+  (when (and slope r-squared)
+    (let [complexity (viewer-common/format-log-log-slope slope)]
+      (if multi-impl?
+        (println (format "    Log-log: slope=%.3f ≈ %s (R²=%.4f)"
+                         slope complexity r-squared))
+        (println (format "  Log-log diagnostic: slope=%.3f ≈ %s (R²=%.4f)"
+                         slope complexity r-squared))))))
+
+(defn- print-model-rows
+  "Print regression model rows with consistent formatting."
+  [table-rows multi-impl? _tolerance]
+  (when (seq table-rows)
+    (let [label-width (reduce max (map #(count (:model %)) table-rows))]
+      (doseq [{:keys [model r-squared aic bic equation best-fit implementation]}
+              table-rows]
+        (let [indent (if multi-impl? "    " "  ")
+              impl-prefix (when (and multi-impl? implementation)
+                            (str "[" implementation "] "))]
+          (println
+           (format "%s%s%s  R²=%s%s%s%s%s"
+                   indent
+                   (or impl-prefix "")
+                   (format (str "%-" label-width "s") model)
+                   r-squared
+                   (if (and aic bic) (format "  AIC=%s BIC=%s" aic bic) "")
+                   (if (seq equation) (str "  " equation) "")
+                   (if (= best-fit "✓") "  <- best fit" "")
+                   (if (and (not (= best-fit "✓")) (seq best-fit))
+                     "  [plotted]" ""))))))))
 
 (defmethod view/domain-regression* :print
-  [_ {:keys [regression-id log-log-id tolerance]} data-map]
-  (let [regression-id (or regression-id :regression)
-        regression (data-map regression-id)
-        log-log-id (or log-log-id :log-log)
-        log-log (data-map log-log-id)
-        tolerance (or tolerance 0.01)]
-    (when regression
-      (let [{:keys [axis regressions impl-axis implementations]}
-            regression
-            multi-impl? (> (count implementations) 1)]
-        (if multi-impl?
-          ;; Multi-implementation mode
-          (doseq [[metric-id {:keys [metric by-impl]}] regressions]
-            (let [log-log-data (get-in log-log [:regressions metric-id])]
-              (println (format "Domain Regression (axis: %s, metric: %s, by: %s)"
-                               (name axis) (pr-str metric) (name impl-axis)))
-              (if (seq by-impl)
-                (doseq [impl-key (sort (keys by-impl))]
-                  (let [{:keys [models best-fit]} (get by-impl impl-key)
-                        impl-log-log (get-in log-log-data [:by-impl impl-key])
-                        best-r-squared
-                        (when best-fit
-                          (->> models
-                               (filter #(= (:id %) best-fit))
-                               first
-                               :r-squared))
-                        plotted-ids
-                        (when best-r-squared
-                          (->> models
-                               (filter #(>= (:r-squared %)
-                                            (* best-r-squared (- 1 tolerance))))
-                               (map :id)
-                               set))]
-                    (println (format "  [%s]" (name impl-key)))
-                    ;; Print log-log info for this impl
-                    (print-log-log-info impl-log-log axis metric impl-key)
-                    (if (seq models)
-                      (let [sorted-models (sort-by :r-squared > models)
-                            label-width (reduce
-                                         max
-                                         (map #(count (:label %)) models))]
-                        (doseq [{:keys [id label equation-str r-squared aic bic]}
-                                sorted-models]
-                          (let [plotted? (and plotted-ids (plotted-ids id))]
-                            (println
-                             (format
-                              "    %s  R²=%.4f%s%s%s%s"
-                              (format (str "%-" label-width "s") label)
-                              r-squared
-                              (format-aic-bic aic bic)
-                              (if equation-str (str "  " equation-str) "")
-                              (if (= id best-fit) "  <- best fit" "")
-                              (if (and plotted? (not= id best-fit))
-                                "  [plotted]"
-                                ""))))))
-                      (println "    (insufficient data)"))))
-                (println "  (no implementations)"))
-              (println)))
+  [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]
+  (let [tolerance (double (or tolerance 0.01))]
+    (viewer-common/with-domain-regression-data
+      data-map
+      {:regression-id regression-id
+       :extract-id extract-id
+       :log-log-id log-log-id
+       :tolerance tolerance
+       :table-options {:best-fit-marker "✓"
+                       :plotted-marker "*"
+                       :tolerance tolerance}}
+      {:render-log-log-charts
+       (fn [{:keys [slope r-squared chart-opts]}]
+         ;; Print viewer shows log-log info as text
+         (let [multi-impl? (some? (:color-field chart-opts))]
+           (print-log-log-info slope r-squared multi-impl?)))
 
-          ;; Single-implementation mode (original behavior)
-          (doseq [[metric-id {:keys [metric models best-fit]}] regressions]
-            (let [log-log-data (get-in log-log [:regressions metric-id])
-                  best-r-squared (when best-fit
-                                   (->> models
-                                        (filter #(= (:id %) best-fit))
-                                        first
-                                        :r-squared))
-                  plotted-ids (when best-r-squared
-                                (->> models
-                                     (filter
-                                      #(>= (:r-squared %)
-                                           (* best-r-squared
-                                              (- 1 tolerance))))
-                                     (map :id)
-                                     set))]
-              (println (format "Domain Regression (axis: %s, metric: %s)"
-                               (name axis) (pr-str metric)))
-              ;; Print log-log diagnostic info
-              (print-log-log-info log-log-data axis metric nil)
-              (if (seq models)
-                (let [sorted-models (sort-by :r-squared > models)
-                      label-width (reduce
-                                   max
-                                   (map #(count (:label %)) models))]
-                  (doseq [{:keys [id label equation-str r-squared aic bic]}
-                          sorted-models]
-                    (let [plotted? (and plotted-ids (plotted-ids id))]
-                      (println
-                       (format
-                        "  %s  R²=%.4f%s%s%s%s"
-                        (format (str "%-" label-width "s") label)
-                        r-squared
-                        (format-aic-bic aic bic)
-                        (if equation-str (str "  " equation-str) "")
-                        (if (= id best-fit) "  <- best fit" "")
-                        (if (and plotted? (not= id best-fit))
-                          "  [plotted]"
-                          ""))))))
-                (println "  (insufficient data for regression)"))
-              (println))))))))
+       :render-model-heading
+       (fn [{:keys [title]}]
+         (println title))
+
+       :render-model-table
+       (fn [{:keys [table-rows multi-impl?]}]
+         (if (seq table-rows)
+           (print-model-rows table-rows multi-impl? tolerance)
+           (println (if multi-impl?
+                      "  (no implementations)"
+                      "  (insufficient data for regression)")))
+         (println))
+
+       :render-regression-charts
+       (fn [_]
+         ;; Print viewer doesn't render charts
+         nil)})))
 
 ;;; Allocation Views
 

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -917,10 +917,34 @@
               (println (format "Domain Comparison by %s: %s (no data)"
                                (name axis) (pr-str metric))))))))))
 
+(defn- format-aic-bic
+  "Format AIC/BIC values for display. Returns empty string if both nil."
+  [aic bic]
+  (cond
+    (and aic bic) (format "  AIC=%.1f BIC=%.1f" aic bic)
+    aic (format "  AIC=%.1f" aic)
+    bic (format "  BIC=%.1f" bic)
+    :else ""))
+
+(defn- print-log-log-info
+  "Print log-log regression summary for a metric."
+  [log-log-data axis metric impl-key]
+  (when log-log-data
+    (let [{:keys [slope r-squared]} log-log-data]
+      (when (and slope r-squared)
+        (let [complexity (viewer-common/format-log-log-slope slope)]
+          (if impl-key
+            (println (format "  Log-log: slope=%.3f ≈ %s (R²=%.4f)"
+                             slope complexity r-squared))
+            (println (format "  Log-log diagnostic: slope=%.3f ≈ %s (R²=%.4f)"
+                             slope complexity r-squared))))))))
+
 (defmethod view/domain-regression* :print
-  [_ {:keys [regression-id tolerance]} data-map]
+  [_ {:keys [regression-id log-log-id tolerance]} data-map]
   (let [regression-id (or regression-id :regression)
         regression (data-map regression-id)
+        log-log-id (or log-log-id :log-log)
+        log-log (data-map log-log-id)
         tolerance (or tolerance 0.01)]
     (when regression
       (let [{:keys [axis regressions impl-axis implementations]}
@@ -928,51 +952,57 @@
             multi-impl? (> (count implementations) 1)]
         (if multi-impl?
           ;; Multi-implementation mode
-          (doseq [[_metric-id {:keys [metric by-impl]}] regressions]
-            (println (format "Domain Regression (axis: %s, metric: %s, by: %s)"
-                             (name axis) (pr-str metric) (name impl-axis)))
-            (if (seq by-impl)
-              (doseq [impl-key (sort (keys by-impl))]
-                (let [{:keys [models best-fit]} (get by-impl impl-key)
-                      best-r-squared
-                      (when best-fit
-                        (->> models
-                             (filter #(= (:id %) best-fit))
-                             first
-                             :r-squared))
-                      plotted-ids
-                      (when best-r-squared
-                        (->> models
-                             (filter #(>= (:r-squared %)
-                                          (* best-r-squared (- 1 tolerance))))
-                             (map :id)
-                             set))]
-                  (println (format "  [%s]" (name impl-key)))
-                  (if (seq models)
-                    (let [sorted-models (sort-by :r-squared > models)
-                          label-width (reduce
-                                       max
-                                       (map #(count (:label %)) models))]
-                      (doseq [{:keys [id label equation-str r-squared]}
-                              sorted-models]
-                        (let [plotted? (and plotted-ids (plotted-ids id))]
-                          (println
-                           (format
-                            "    %s  R²=%.4f%s%s%s"
-                            (format (str "%-" label-width "s") label)
-                            r-squared
-                            (if equation-str (str "  " equation-str) "")
-                            (if (= id best-fit) "  <- best fit" "")
-                            (if (and plotted? (not= id best-fit))
-                              "  [plotted]"
-                              ""))))))
-                    (println "    (insufficient data)"))))
-              (println "  (no implementations)"))
-            (println))
+          (doseq [[metric-id {:keys [metric by-impl]}] regressions]
+            (let [log-log-data (get-in log-log [:regressions metric-id])]
+              (println (format "Domain Regression (axis: %s, metric: %s, by: %s)"
+                               (name axis) (pr-str metric) (name impl-axis)))
+              (if (seq by-impl)
+                (doseq [impl-key (sort (keys by-impl))]
+                  (let [{:keys [models best-fit]} (get by-impl impl-key)
+                        impl-log-log (get-in log-log-data [:by-impl impl-key])
+                        best-r-squared
+                        (when best-fit
+                          (->> models
+                               (filter #(= (:id %) best-fit))
+                               first
+                               :r-squared))
+                        plotted-ids
+                        (when best-r-squared
+                          (->> models
+                               (filter #(>= (:r-squared %)
+                                            (* best-r-squared (- 1 tolerance))))
+                               (map :id)
+                               set))]
+                    (println (format "  [%s]" (name impl-key)))
+                    ;; Print log-log info for this impl
+                    (print-log-log-info impl-log-log axis metric impl-key)
+                    (if (seq models)
+                      (let [sorted-models (sort-by :r-squared > models)
+                            label-width (reduce
+                                         max
+                                         (map #(count (:label %)) models))]
+                        (doseq [{:keys [id label equation-str r-squared aic bic]}
+                                sorted-models]
+                          (let [plotted? (and plotted-ids (plotted-ids id))]
+                            (println
+                             (format
+                              "    %s  R²=%.4f%s%s%s%s"
+                              (format (str "%-" label-width "s") label)
+                              r-squared
+                              (format-aic-bic aic bic)
+                              (if equation-str (str "  " equation-str) "")
+                              (if (= id best-fit) "  <- best fit" "")
+                              (if (and plotted? (not= id best-fit))
+                                "  [plotted]"
+                                ""))))))
+                      (println "    (insufficient data)"))))
+                (println "  (no implementations)"))
+              (println)))
 
           ;; Single-implementation mode (original behavior)
-          (doseq [[_metric-id {:keys [metric models best-fit]}] regressions]
-            (let [best-r-squared (when best-fit
+          (doseq [[metric-id {:keys [metric models best-fit]}] regressions]
+            (let [log-log-data (get-in log-log [:regressions metric-id])
+                  best-r-squared (when best-fit
                                    (->> models
                                         (filter #(= (:id %) best-fit))
                                         first
@@ -987,19 +1017,22 @@
                                      set))]
               (println (format "Domain Regression (axis: %s, metric: %s)"
                                (name axis) (pr-str metric)))
+              ;; Print log-log diagnostic info
+              (print-log-log-info log-log-data axis metric nil)
               (if (seq models)
                 (let [sorted-models (sort-by :r-squared > models)
                       label-width (reduce
                                    max
                                    (map #(count (:label %)) models))]
-                  (doseq [{:keys [id label equation-str r-squared]}
+                  (doseq [{:keys [id label equation-str r-squared aic bic]}
                           sorted-models]
                     (let [plotted? (and plotted-ids (plotted-ids id))]
                       (println
                        (format
-                        "  %s  R²=%.4f%s%s%s"
+                        "  %s  R²=%.4f%s%s%s%s"
                         (format (str "%-" label-width "s") label)
                         r-squared
+                        (format-aic-bic aic bic)
                         (if equation-str (str "  " equation-str) "")
                         (if (= id best-fit) "  <- best fit" "")
                         (if (and plotted? (not= id best-fit))

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -1162,3 +1162,246 @@
             result (analysis/analyse-domain plan d)]
         (is (= d (:domain result)))
         (is (contains? result :viewer))))))
+
+;; Tests for log-log regression functions.
+;; Validates log-log transformation and linear regression in log space
+;; for intuitive complexity class identification.
+
+(deftest log-log-regression-test
+  ;; Tests the core log-log-regression function.
+  ;; In log-log space, power laws become linear: slope indicates exponent.
+  ;; Contracts: returns correct slope, intercept, r-squared, and residuals.
+  (testing "log-log-regression"
+    (testing "identifies O(n) complexity with slope ≈ 1"
+      ;; y = c * n^1 → log(y) = log(c) + 1 * log(n)
+      (let [xs [10.0 20.0 40.0 80.0]
+            ys [10.0 20.0 40.0 80.0]
+            result (analysis/log-log-regression xs ys)]
+        (is (< (Math/abs (- (:slope result) 1.0)) 0.01))
+        (is (> (:r-squared result) 0.99))))
+    (testing "identifies O(n²) complexity with slope ≈ 2"
+      ;; y = c * n^2 → log(y) = log(c) + 2 * log(n)
+      (let [xs [10.0 20.0 40.0 80.0]
+            ys [100.0 400.0 1600.0 6400.0]
+            result (analysis/log-log-regression xs ys)]
+        (is (< (Math/abs (- (:slope result) 2.0)) 0.01))
+        (is (> (:r-squared result) 0.99))))
+    (testing "identifies O(1) complexity with slope ≈ 0"
+      ;; y = c → log(y) = log(c) + 0 * log(n)
+      (let [xs [10.0 20.0 40.0 80.0]
+            ys [100.0 100.0 100.0 100.0]
+            result (analysis/log-log-regression xs ys)]
+        (is (< (Math/abs (:slope result)) 0.01))))
+    (testing "returns log-transformed xs and ys"
+      (let [xs [10.0 100.0]
+            ys [20.0 200.0]
+            result (analysis/log-log-regression xs ys)]
+        (is (= 2 (count (:log-xs result))))
+        (is (= 2 (count (:log-ys result))))
+        ;; log(10) ≈ 2.303, log(100) ≈ 4.605
+        (is (< (Math/abs (- (first (:log-xs result)) (Math/log 10))) 0.001))
+        (is (< (Math/abs (- (second (:log-xs result)) (Math/log 100))) 0.001))))
+    (testing "returns residuals in log space"
+      (let [xs [10.0 20.0 40.0 80.0]
+            ys [10.0 20.0 40.0 80.0]
+            result (analysis/log-log-regression xs ys)]
+        (is (= 4 (count (:residuals result))))
+        ;; Perfect linear data should have near-zero residuals
+        (is (every? #(< (Math/abs (double %)) 0.01) (:residuals result)))))
+    (testing "returns predict-fn that works in original space"
+      (let [xs [10.0 20.0 40.0]
+            ys [100.0 200.0 400.0]
+            result (analysis/log-log-regression xs ys)
+            predict (:predict-fn result)]
+        ;; Should predict y = 10 * n for this linear data
+        (is (< (Math/abs (- (predict 30.0) 300.0)) 5.0))))
+    (testing "requires positive x and y values"
+      (is (thrown? AssertionError
+                   (analysis/log-log-regression [0.0 1.0 2.0] [1.0 2.0 3.0])))
+      (is (thrown? AssertionError
+                   (analysis/log-log-regression [1.0 2.0 3.0] [0.0 2.0 3.0]))))))
+
+(deftest fit-log-log-test
+  ;; Tests the domain-level log-log regression function.
+  ;; Applies log-log regression to domain extract data.
+  ;; Contracts: returns domain-log-log-regression, handles multi-impl.
+  (testing "fit-log-log"
+    (testing "returns a domain-log-log-regression result"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]
+                                                     [{:n 40} 400.0]]}}}
+            result (analysis/fit-log-log extract :n)]
+        (is (= :criterium/domain-log-log-regression (:type result)))
+        (is (= :n (:axis result)))
+        (is (contains? (:regressions result) :elapsed-time))))
+    (testing "identifies linear complexity"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]
+                                                     [{:n 40} 400.0]
+                                                     [{:n 80} 800.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        ;; Slope should be ≈ 1 for O(n)
+        (is (< (Math/abs (- (:slope reg) 1.0)) 0.01))
+        (is (> (:r-squared reg) 0.99))))
+    (testing "identifies quadratic complexity"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 400.0]
+                                                     [{:n 40} 1600.0]
+                                                     [{:n 80} 6400.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        ;; Slope should be ≈ 2 for O(n²)
+        (is (< (Math/abs (- (:slope reg) 2.0)) 0.01))))
+    (testing "includes log-transformed data"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        (is (= 2 (count (:log-xs reg))))
+        (is (= 2 (count (:log-ys reg))))
+        (is (= 2 (count (:xs reg))))
+        (is (= 2 (count (:ys reg))))))
+    (testing "filters out nil values"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} nil]
+                                                     [{:n 40} 400.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        (is (some? (:slope reg)))
+        (is (= 2 (count (:log-xs reg))))))
+    (testing "filters out non-positive values"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 0.0]
+                                                     [{:n 40} 400.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        (is (some? (:slope reg)))
+        (is (= 2 (count (:log-xs reg))))))
+    (testing "handles error-bound data"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :with-error-bounds true
+                                              :data [[{:n 10} {:value 100.0 :lower 90.0 :upper 110.0}]
+                                                     [{:n 20} {:value 200.0 :lower 180.0 :upper 220.0}]
+                                                     [{:n 40} {:value 400.0 :lower 360.0 :upper 440.0}]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        (is (some? (:slope reg)))
+        (is (contains? reg :log-lowers))
+        (is (contains? reg :log-uppers))
+        (is (= 3 (count (:log-lowers reg))))))
+    (testing "returns nil for insufficient data"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        (is (nil? (:slope reg)))
+        (is (nil? (:log-xs reg)))))))
+
+(deftest fit-log-log-multi-impl-test
+  ;; Tests fit-log-log with multi-implementation domains.
+  ;; Data should be grouped by implementation and fit separately.
+  (testing "fit-log-log with multiple implementations"
+    (testing "returns regression with :impl-axis and :implementations"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:vec :list]
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10 :impl :vec} 100.0]
+                                                     [{:n 20 :impl :vec} 200.0]
+                                                     [{:n 10 :impl :list} 100.0]
+                                                     [{:n 20 :impl :list} 400.0]]}}}
+            result (analysis/fit-log-log extract :n)]
+        (is (= :criterium/domain-log-log-regression (:type result)))
+        (is (= :impl (:impl-axis result)))
+        (is (= [:vec :list] (:implementations result)))))
+    (testing "groups regression by implementation in :by-impl"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:vec :list]
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10 :impl :vec} 100.0]
+                                                     [{:n 20 :impl :vec} 200.0]
+                                                     [{:n 10 :impl :list} 100.0]
+                                                     [{:n 20 :impl :list} 400.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            reg (get-in result [:regressions :elapsed-time])]
+        (is (contains? reg :by-impl))
+        (is (contains? (:by-impl reg) :vec))
+        (is (contains? (:by-impl reg) :list))))
+    (testing "fits slopes separately per implementation"
+      (let [;; vec is O(n): 100, 200
+            ;; list is O(n²): 100, 400
+            extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:vec :list]
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10 :impl :vec} 100.0]
+                                                     [{:n 20 :impl :vec} 200.0]
+                                                     [{:n 10 :impl :list} 100.0]
+                                                     [{:n 20 :impl :list} 400.0]]}}}
+            result (analysis/fit-log-log extract :n)
+            by-impl (get-in result [:regressions :elapsed-time :by-impl])]
+        ;; vec slope ≈ 1
+        (is (< (Math/abs (- (get-in by-impl [:vec :slope]) 1.0)) 0.01))
+        ;; list slope ≈ 2
+        (is (< (Math/abs (- (get-in by-impl [:list :slope]) 2.0)) 0.01))))))
+
+(deftest domain-log-log-fn-test
+  ;; Tests the factory function that creates log-log regression pipelines.
+  ;; Contracts: returns function, fits log-log from data-map, supports options.
+  (testing "domain-log-log-fn"
+    (testing "returns a function"
+      (is (fn? (analysis/domain-log-log-fn)))
+      (is (fn? (analysis/domain-log-log-fn {}))))
+    (testing "fits log-log regression to extract in data-map"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]
+                                                     [{:n 40} 400.0]]}}}
+            f (analysis/domain-log-log-fn {:id :log-log :axis :n})
+            result (f {:extract extract})]
+        (is (contains? result :extract))
+        (is (contains? result :log-log))
+        (is (= :criterium/domain-log-log-regression (:type (:log-log result))))))
+    (testing "uses default :id when not specified"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]]}}}
+            f (analysis/domain-log-log-fn {:axis :n})
+            result (f {:extract extract})]
+        (is (contains? result :log-log))))
+    (testing "uses custom :extract-id"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]]}}}
+            f (analysis/domain-log-log-fn
+               {:id :scaling :extract-id :my-extract :axis :n})
+            result (f {:my-extract extract})]
+        (is (contains? result :scaling))
+        (is (= :criterium/domain-log-log-regression (:type (:scaling result))))))
+    (testing "preserves other keys in data-map"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 10} 100.0]
+                                                     [{:n 20} 200.0]]}}}
+            f (analysis/domain-log-log-fn {:id :log-log :axis :n})
+            result (f {:extract extract :other-key "value"})]
+        (is (= "value" (:other-key result)))))))

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -7,6 +7,73 @@
                                        mock-bench-result
                                        mock-bench-result-with-defs]]))
 
+;; Tests for AIC/BIC computation functions.
+;; Validates information criterion formulas for model selection.
+
+(deftest compute-aic-test
+  ;; Tests compute-aic (AICc with small-sample correction).
+  ;; Formula: AICc = n*ln(RSS/n) + 2k + (2k(k+1))/(n-k-1)
+  ;; Contracts: returns correct value, handles edge cases.
+  (testing "compute-aic"
+    (testing "computes AICc with small-sample correction"
+      ;; Known values: n=10, k=2, RSS=5.0
+      ;; base-aic = 10*ln(5/10) + 2*2 = 10*(-0.693147) + 4 = -2.931
+      ;; correction = (2*2*(2+1))/(10-2-1) = 12/7 = 1.714
+      ;; AICc = -2.931 + 1.714 = -1.217
+      (let [result (double (analysis/compute-aic 5.0 10 2))]
+        (is (< (Math/abs (- result -1.217)) 0.01))))
+    (testing "returns nil when n <= k+1"
+      ;; Correction term has division by (n-k-1), undefined when n <= k+1
+      (is (nil? (analysis/compute-aic 5.0 3 2)))
+      (is (nil? (analysis/compute-aic 5.0 2 2))))
+    (testing "works with minimum valid sample size"
+      ;; n=4, k=2 gives n-k-1=1, minimum valid
+      (is (some? (analysis/compute-aic 5.0 4 2))))
+    (testing "handles k=1 (simple regression)"
+      ;; n=5, k=1, RSS=2.0
+      ;; base-aic = 5*ln(2/5) + 2*1 = 5*(-0.916) + 2 = -2.581
+      ;; correction = (2*1*2)/(5-1-1) = 4/3 = 1.333
+      ;; AICc = -2.581 + 1.333 = -1.248
+      (let [result (double (analysis/compute-aic 2.0 5 1))]
+        (is (< (Math/abs (- result -1.248)) 0.01))))
+    (testing "lower AICc indicates better fit"
+      ;; With same n and k, lower RSS gives lower AICc
+      (let [aic-low-rss (analysis/compute-aic 1.0 10 2)
+            aic-high-rss (analysis/compute-aic 5.0 10 2)]
+        (is (< aic-low-rss aic-high-rss))))))
+
+(deftest compute-bic-test
+  ;; Tests compute-bic (Bayesian Information Criterion).
+  ;; Formula: BIC = n*ln(RSS/n) + k*ln(n)
+  ;; Contracts: returns correct value, handles edge cases.
+  (testing "compute-bic"
+    (testing "computes BIC correctly"
+      ;; Known values: n=10, k=2, RSS=5.0
+      ;; BIC = 10*ln(5/10) + 2*ln(10) = 10*(-0.693) + 2*2.303 = -2.325
+      (let [result (double (analysis/compute-bic 5.0 10 2))]
+        (is (< (Math/abs (- result -2.325)) 0.01))))
+    (testing "returns nil when n = 0"
+      (is (nil? (analysis/compute-bic 5.0 0 2))))
+    (testing "handles k=1 (simple regression)"
+      ;; n=5, k=1, RSS=2.0
+      ;; BIC = 5*ln(2/5) + 1*ln(5) = 5*(-0.916) + 1.609 = -2.972
+      (let [result (double (analysis/compute-bic 2.0 5 1))]
+        (is (< (Math/abs (- result -2.972)) 0.01))))
+    (testing "penalizes complexity more than AIC for large n"
+      ;; BIC penalty is k*ln(n), AIC penalty is 2k
+      ;; For n > e^2 ≈ 7.4, BIC penalizes complexity more
+      (let [;; For n=20, k=3: BIC penalty = 3*ln(20) = 8.99
+            ;; AIC base penalty = 2*3 = 6
+            bic (analysis/compute-bic 10.0 20 3)
+            aic (analysis/compute-aic 10.0 20 3)]
+        ;; For large n, BIC is larger (more penalized) than AICc
+        (is (> bic aic))))
+    (testing "lower BIC indicates better fit"
+      ;; With same n and k, lower RSS gives lower BIC
+      (let [bic-low-rss (analysis/compute-bic 1.0 10 2)
+            bic-high-rss (analysis/compute-bic 5.0 10 2)]
+        (is (< bic-low-rss bic-high-rss))))))
+
 ;; Tests for domain analysis function extract.
 ;; Validates extracting metric values across runs with coordinate-value pairs,
 ;; handling missing metrics, preserving order, and applying transforms.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -1313,21 +1313,21 @@
       (let [xs [10.0 20.0 40.0 80.0]
             ys [10.0 20.0 40.0 80.0]
             result (analysis/log-log-regression xs ys)]
-        (is (< (Math/abs (- (:slope result) 1.0)) 0.01))
+        (is (< (Math/abs (- (double (:slope result)) 1.0)) 0.01))
         (is (> (:r-squared result) 0.99))))
     (testing "identifies O(n²) complexity with slope ≈ 2"
       ;; y = c * n^2 → log(y) = log(c) + 2 * log(n)
       (let [xs [10.0 20.0 40.0 80.0]
             ys [100.0 400.0 1600.0 6400.0]
             result (analysis/log-log-regression xs ys)]
-        (is (< (Math/abs (- (:slope result) 2.0)) 0.01))
+        (is (< (Math/abs (- (double (:slope result)) 2.0)) 0.01))
         (is (> (:r-squared result) 0.99))))
     (testing "identifies O(1) complexity with slope ≈ 0"
       ;; y = c → log(y) = log(c) + 0 * log(n)
       (let [xs [10.0 20.0 40.0 80.0]
             ys [100.0 100.0 100.0 100.0]
             result (analysis/log-log-regression xs ys)]
-        (is (< (Math/abs (:slope result)) 0.01))))
+        (is (< (Math/abs (double (:slope result))) 0.01))))
     (testing "returns log-transformed xs and ys"
       (let [xs [10.0 100.0]
             ys [20.0 200.0]
@@ -1335,8 +1335,8 @@
         (is (= 2 (count (:log-xs result))))
         (is (= 2 (count (:log-ys result))))
         ;; log(10) ≈ 2.303, log(100) ≈ 4.605
-        (is (< (Math/abs (- (first (:log-xs result)) (Math/log 10))) 0.001))
-        (is (< (Math/abs (- (second (:log-xs result)) (Math/log 100))) 0.001))))
+        (is (< (Math/abs (- (double (first (:log-xs result))) (Math/log 10))) 0.001))
+        (is (< (Math/abs (- (double (second (:log-xs result))) (Math/log 100))) 0.001))))
     (testing "returns residuals in log space"
       (let [xs [10.0 20.0 40.0 80.0]
             ys [10.0 20.0 40.0 80.0]
@@ -1350,7 +1350,7 @@
             result (analysis/log-log-regression xs ys)
             predict (:predict-fn result)]
         ;; Should predict y = 10 * n for this linear data
-        (is (< (Math/abs (- (predict 30.0) 300.0)) 5.0))))
+        (is (< (Math/abs (- (double (predict 30.0)) 300.0)) 5.0))))
     (testing "requires positive x and y values"
       (is (thrown? AssertionError
                    (analysis/log-log-regression [0.0 1.0 2.0] [1.0 2.0 3.0])))
@@ -1382,7 +1382,7 @@
             result (analysis/fit-log-log extract :n)
             reg (get-in result [:regressions :elapsed-time])]
         ;; Slope should be ≈ 1 for O(n)
-        (is (< (Math/abs (- (:slope reg) 1.0)) 0.01))
+        (is (< (Math/abs (- (double (:slope reg)) 1.0)) 0.01))
         (is (> (:r-squared reg) 0.99))))
     (testing "identifies quadratic complexity"
       (let [extract {:type :criterium/domain-extract
@@ -1394,7 +1394,7 @@
             result (analysis/fit-log-log extract :n)
             reg (get-in result [:regressions :elapsed-time])]
         ;; Slope should be ≈ 2 for O(n²)
-        (is (< (Math/abs (- (:slope reg) 2.0)) 0.01))))
+        (is (< (Math/abs (- (double (:slope reg)) 2.0)) 0.01))))
     (testing "includes log-transformed data"
       (let [extract {:type :criterium/domain-extract
                      :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
@@ -1493,9 +1493,9 @@
             result (analysis/fit-log-log extract :n)
             by-impl (get-in result [:regressions :elapsed-time :by-impl])]
         ;; vec slope ≈ 1
-        (is (< (Math/abs (- (get-in by-impl [:vec :slope]) 1.0)) 0.01))
+        (is (< (Math/abs (- (double (get-in by-impl [:vec :slope])) 1.0)) 0.01))
         ;; list slope ≈ 2
-        (is (< (Math/abs (- (get-in by-impl [:list :slope]) 2.0)) 0.01))))))
+        (is (< (Math/abs (- (double (get-in by-impl [:list :slope])) 2.0)) 0.01))))))
 
 (deftest domain-log-log-fn-test
   ;; Tests the factory function that creates log-log regression pipelines.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -90,7 +90,6 @@
                   :data (mock-bench-result {:elapsed-time {:mean 1.0}})})
               result (analysis/extract d [:stats :elapsed-time :mean])]
           (is (= :criterium/domain-extract (:type result)))
-          (is (= :criterium/domain-extract (:type result)))
           (is (contains? (:metrics result) :elapsed-time))
           (is (= [:stats :elapsed-time :mean]
                  (get-in result [:metrics :elapsed-time :metric])))))
@@ -718,7 +717,6 @@
                                                      [{:n 200} 200.0]
                                                      [{:n 300} 300.0]]}}}
             result (analysis/fit-complexity extract :n)]
-        (is (= :criterium/domain-regression (:type result)))
         (is (= :criterium/domain-regression (:type result)))
         (is (= :n (:axis result)))
         (is (contains? (:regressions result) :elapsed-time))

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -932,6 +932,129 @@
         (is (not (contains? regression :by-impl)))
         (is (contains? regression :models))))))
 
+;; Tests for AIC/BIC computation and model selection in fit-complexity.
+;; Validates that information criteria are computed and used for model selection.
+
+(deftest fit-complexity-aic-bic-test
+  ;; Tests that fit-complexity computes and returns AIC/BIC values for models.
+  ;; Contracts: models include :aic and :bic, values are correct.
+  (testing "fit-complexity returns AIC/BIC values"
+    (testing "models include :aic and :bic keys"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n)
+            models (get-in result [:regressions :elapsed-time :models])]
+        (is (every? #(contains? % :aic) models))
+        (is (every? #(contains? % :bic) models))))
+    (testing "AIC/BIC values are numbers for sufficient data"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n)
+            linear (first (filter #(= :linear (:id %))
+                                  (get-in result [:regressions :elapsed-time :models])))]
+        (is (number? (:aic linear)))
+        (is (number? (:bic linear)))))
+    (testing "AIC/BIC can be nil for insufficient data"
+      ;; With only 3 data points and k=2, AICc correction term may still work
+      ;; but with k=3 (composite model), we need n > k+1 = 4
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]]}}}
+            result (analysis/fit-complexity extract :n)
+            ;; nlogn-linear has 3 parameters, needs n > 4 for AICc
+            composite (first (filter #(= :nlogn-linear (:id %))
+                                     (get-in result [:regressions :elapsed-time :models])))]
+        ;; With n=3 and k=3, AICc correction is undefined (n <= k+1)
+        (is (nil? (:aic composite)))))))
+
+(deftest fit-complexity-selection-method-test
+  ;; Tests model selection using different methods.
+  ;; Contracts: :aic, :bic, :r-squared methods work correctly.
+  (testing "fit-complexity with :selection-method"
+    (testing "defaults to :aic selection"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n)]
+        ;; Linear data should select linear model
+        (is (= :linear (get-in result [:regressions :elapsed-time :best-fit])))))
+    (testing ":r-squared selection uses highest R²"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n {:selection-method :r-squared})]
+        (is (= :linear (get-in result [:regressions :elapsed-time :best-fit])))))
+    (testing ":bic selection uses lowest BIC"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n {:selection-method :bic})]
+        (is (= :linear (get-in result [:regressions :elapsed-time :best-fit])))))
+    (testing "backward compatible with models map as third arg"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]]}}}
+            models {:linear {:transform identity
+                             :label "O(n)"}}
+            result (analysis/fit-complexity extract :n models)
+            regression (get-in result [:regressions :elapsed-time])]
+        (is (= 1 (count (:models regression))))
+        (is (= :linear (:id (first (:models regression)))))))
+    (testing "options map with :models and :selection-method"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n {:models nil
+                                                        :selection-method :bic})]
+        (is (= :linear (get-in result [:regressions :elapsed-time :best-fit]))))))
+  (testing "selection method prefers simpler models when values are equal"
+    ;; With perfect linear data, multiple models may have near-perfect fit
+    ;; Selection should prefer simpler (fewer param) models
+    (testing "AIC selection prefers simpler model"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            result (analysis/fit-complexity extract :n {:selection-method :aic})
+            models (get-in result [:regressions :elapsed-time :models])
+            linear (first (filter #(= :linear (:id %)) models))]
+        ;; Linear should be selected as it fits perfectly and has fewer params
+        (is (= :linear (get-in result [:regressions :elapsed-time :best-fit])))
+        (is (> (:r-squared linear) 0.99))))))
+
 (deftest domain-regression-fn-test
   ;; Tests the factory function that creates regression pipelines.
   ;; Contracts: returns function, fits regression from data-map, supports options.
@@ -976,6 +1099,19 @@
             f (analysis/domain-regression-fn {:id :scaling :axis :n})
             result (f {:extract extract :other-key "value"})]
         (is (= "value" (:other-key result)))))
+    (testing "passes :selection-method to fit-complexity"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
+                                              :data [[{:n 100} 100.0]
+                                                     [{:n 200} 200.0]
+                                                     [{:n 300} 300.0]
+                                                     [{:n 400} 400.0]
+                                                     [{:n 500} 500.0]]}}}
+            f (analysis/domain-regression-fn {:id :scaling
+                                              :axis :n
+                                              :selection-method :bic})
+            result (f {:extract extract})]
+        (is (= :linear (get-in result [:scaling :regressions :elapsed-time :best-fit])))))
     (testing "composes with domain-extract-fn"
       (let [d (domain/domain
                {:coord {:n 100}

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -1067,8 +1067,8 @@
         (is (contains? spec :height))
         (is (contains? spec :layer))
         (is (= 200 (:height spec)))
-        ;; Should have scatter layer and zero line (no loess without color-field)
-        (is (= 2 (count (:layer spec))))))
+        ;; Should have scatter layer, loess layer, and zero line
+        (is (= 3 (count (:layer spec))))))
     (testing "uses log axis title"
       (let [spec (charts/log-log-residual-spec
                   sample-log-log-residuals

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -983,3 +983,144 @@
         (is (:valid? result)
             (str "treemap-vega-spec validation failed: "
                  (pr-str (:errors result))))))))
+
+;;; Log-Log Chart Tests
+;;
+;; Tests for log-log regression chart functions.
+;; These charts display log-transformed data where slope indicates complexity class.
+
+(def sample-log-log-points
+  "Sample log-log scatter plot points."
+  [{"x" 2.3 "y" 4.6}
+   {"x" 3.0 "y" 6.0}
+   {"x" 3.7 "y" 7.4}
+   {"x" 4.4 "y" 8.8}])
+
+(def sample-log-log-line-points
+  "Sample log-log fit line points."
+  [{"x" 2.0 "y" 4.0}
+   {"x" 3.0 "y" 6.0}
+   {"x" 4.0 "y" 8.0}
+   {"x" 5.0 "y" 10.0}])
+
+(def sample-log-log-residuals
+  "Sample log-log residual points."
+  [{"x" 2.3 "residual" 0.01}
+   {"x" 3.0 "residual" -0.02}
+   {"x" 3.7 "residual" 0.01}
+   {"x" 4.4 "residual" -0.01}])
+
+(deftest log-log-chart-spec-test
+  ;; Tests the log-log-chart-spec function for structure correctness.
+  ;; Contracts: returns valid Vega-Lite spec with correct layers.
+  (testing "log-log-chart-spec"
+    (testing "produces valid Vega-Lite spec structure"
+      (let [spec (charts/log-log-chart-spec
+                  sample-log-log-points
+                  sample-log-log-line-points
+                  {:width 600 :height 400 :axis-name "n"})]
+        (is (map? spec))
+        (is (contains? spec :width))
+        (is (contains? spec :height))
+        (is (contains? spec :layer))
+        (is (= 600 (:width spec)))
+        (is (= 400 (:height spec)))
+        ;; Should have scatter layer and line layer
+        (is (>= (count (:layer spec)) 2))))
+    (testing "includes error bar layer when error bounds present"
+      (let [points-with-error [{"x" 2.3 "y" 4.6 "yLower" 4.4 "yUpper" 4.8}]
+            spec (charts/log-log-chart-spec
+                  points-with-error
+                  sample-log-log-line-points
+                  {:has-error-bounds? true})]
+        ;; Should have scatter, line, and error bar layers
+        (is (= 3 (count (:layer spec))))))
+    (testing "includes title with slope and r-squared when provided"
+      (let [spec (charts/log-log-chart-spec
+                  sample-log-log-points
+                  sample-log-log-line-points
+                  {:slope 1.02 :r-squared 0.998})]
+        (is (some? (:title spec)))
+        (is (string? (:title spec)))))
+    (testing "handles multi-impl with color field"
+      (let [points [{"x" 2.3 "y" 4.6 "impl" "vec"}
+                    {"x" 2.3 "y" 5.0 "impl" "list"}]
+            line-pts [{"x" 2.0 "y" 4.0 "impl" "vec"}
+                      {"x" 2.0 "y" 4.5 "impl" "list"}]
+            spec (charts/log-log-chart-spec
+                  points line-pts
+                  {:color-field "impl"})]
+        (is (map? spec))
+        ;; Check that color encoding exists in scatter layer
+        (let [scatter-layer (first (:layer spec))]
+          (is (contains? (get-in scatter-layer [:encoding :color]) :field)))))))
+
+(deftest log-log-residual-spec-test
+  ;; Tests the log-log-residual-spec function for structure correctness.
+  (testing "log-log-residual-spec"
+    (testing "produces valid Vega-Lite spec structure"
+      (let [spec (charts/log-log-residual-spec
+                  sample-log-log-residuals
+                  {:width 600 :height 200 :axis-name "n"})]
+        (is (map? spec))
+        (is (contains? spec :width))
+        (is (contains? spec :height))
+        (is (contains? spec :layer))
+        (is (= 200 (:height spec)))
+        ;; Should have scatter layer and zero line (no loess without color-field)
+        (is (= 2 (count (:layer spec))))))
+    (testing "uses log axis title"
+      (let [spec (charts/log-log-residual-spec
+                  sample-log-log-residuals
+                  {:axis-name "n"})
+            scatter-layer (first (:layer spec))
+            x-title (get-in scatter-layer [:encoding :x :title])]
+        (is (= "log(n)" x-title))))))
+
+(deftest log-log-chart-spec-schema-validation-test
+  ;; Validates log-log-chart-spec output against Vega-Lite v5 schema.
+  (testing "log-log-chart-spec"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/log-log-chart-spec
+                  sample-log-log-points
+                  sample-log-log-line-points
+                  {:width 600 :height 400 :axis-name "n"})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "log-log-chart-spec validation failed: "
+                 (pr-str (:errors result))))))
+    (testing "with error bounds produces valid spec"
+      (let [points-with-error [{"x" 2.3 "y" 4.6 "yLower" 4.4 "yUpper" 4.8}
+                               {"x" 3.0 "y" 6.0 "yLower" 5.8 "yUpper" 6.2}]
+            spec (charts/log-log-chart-spec
+                  points-with-error
+                  sample-log-log-line-points
+                  {:has-error-bounds? true})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "log-log-chart-spec with error bounds failed: "
+                 (pr-str (:errors result))))))
+    (testing "with color field produces valid spec"
+      (let [points [{"x" 2.3 "y" 4.6 "impl" "vec"}
+                    {"x" 3.0 "y" 6.0 "impl" "list"}]
+            line-pts [{"x" 2.0 "y" 4.0 "impl" "vec"}
+                      {"x" 3.0 "y" 6.0 "impl" "list"}]
+            spec (charts/log-log-chart-spec
+                  points line-pts
+                  {:color-field "impl"})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "log-log-chart-spec with color field failed: "
+                 (pr-str (:errors result))))))))
+
+(deftest log-log-residual-spec-schema-validation-test
+  ;; Validates log-log-residual-spec output against Vega-Lite v5 schema.
+  (testing "log-log-residual-spec"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/log-log-residual-spec
+                  sample-log-log-residuals
+                  {:width 600 :height 200 :axis-name "n"})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "log-log-residual-spec validation failed: "
+                 (pr-str (:errors result))))))))

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -1434,7 +1434,7 @@
         (is (vector? result))
         (is (> (count result) 2))
         ;; Check that y = x (slope 1, intercept 0)
-        (is (every? #(< (Math/abs (- (get % "y") (get % "x"))) 0.01) result))))
+        (is (every? #(< (Math/abs (- (double (get % "y")) (double (get % "x")))) 0.01) result))))
     (testing "returns nil for missing data"
       (is (nil? (common/prepare-log-log-fit-line nil {:axis :n})))
       (is (nil? (common/prepare-log-log-fit-line {} {:axis :n}))))

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -1375,3 +1375,124 @@
                         (str/includes? % "└──"))
                   lines)
             "Expected java.lang.Long as last child with └── connector")))))
+
+;;; Log-Log regression view helper tests.
+;;; Verifies data preparation functions for log-log charts.
+
+(deftest prepare-log-log-points-test
+  ;; Tests prepare-log-log-points which formats log-log regression data for charts.
+  ;; Contracts: returns correct structure, handles error bounds, supports multi-impl.
+  (testing "prepare-log-log-points"
+    (testing "returns points in log space"
+      (let [log-log-data {:log-xs [(Math/log 10) (Math/log 20)]
+                          :log-ys [(Math/log 100) (Math/log 200)]}
+            result (common/prepare-log-log-points
+                    log-log-data
+                    {:axis :n})]
+        (is (map? result))
+        (is (= 2 (count (:points result))))
+        (is (= "n" (:axis-name result)))
+        (is (= (Math/log 10) (get (first (:points result)) "x")))
+        (is (= (Math/log 100) (get (first (:points result)) "y")))))
+    (testing "includes error bounds when present"
+      (let [log-log-data {:log-xs [(Math/log 10)]
+                          :log-ys [(Math/log 100)]
+                          :log-lowers [(Math/log 90)]
+                          :log-uppers [(Math/log 110)]}
+            result (common/prepare-log-log-points
+                    log-log-data
+                    {:axis :n})]
+        (is (true? (:has-error-bounds? result)))
+        (is (= (Math/log 90) (get (first (:points result)) "yLower")))
+        (is (= (Math/log 110) (get (first (:points result)) "yUpper")))))
+    (testing "returns nil for missing data"
+      (is (nil? (common/prepare-log-log-points nil {:axis :n})))
+      (is (nil? (common/prepare-log-log-points {} {:axis :n}))))
+    (testing "handles multi-implementation data"
+      (let [log-log-data {:by-impl {:vec {:log-xs [(Math/log 10)]
+                                          :log-ys [(Math/log 100)]}
+                                    :list {:log-xs [(Math/log 10)]
+                                           :log-ys [(Math/log 200)]}}}
+            result (common/prepare-log-log-points
+                    log-log-data
+                    {:axis :n :impl-axis :impl})]
+        (is (= 2 (count (:points result))))
+        (is (some #(= "vec" (get % "impl")) (:points result)))
+        (is (some #(= "list" (get % "impl")) (:points result)))))))
+
+(deftest prepare-log-log-fit-line-test
+  ;; Tests prepare-log-log-fit-line which generates fit line points.
+  ;; Uses slope and intercept to compute line: y = slope * x + intercept
+  (testing "prepare-log-log-fit-line"
+    (testing "generates fit line points"
+      (let [log-log-data {:slope 1.0
+                          :intercept 0.0
+                          :log-xs [(Math/log 10) (Math/log 100)]}
+            result (common/prepare-log-log-fit-line
+                    log-log-data
+                    {:axis :n})]
+        (is (vector? result))
+        (is (> (count result) 2))
+        ;; Check that y = x (slope 1, intercept 0)
+        (is (every? #(< (Math/abs (- (get % "y") (get % "x"))) 0.01) result))))
+    (testing "returns nil for missing data"
+      (is (nil? (common/prepare-log-log-fit-line nil {:axis :n})))
+      (is (nil? (common/prepare-log-log-fit-line {} {:axis :n}))))
+    (testing "handles multi-implementation data"
+      (let [log-log-data {:by-impl {:vec {:slope 1.0
+                                          :intercept 0.0
+                                          :log-xs [(Math/log 10) (Math/log 20)]}
+                                    :list {:slope 2.0
+                                           :intercept 0.0
+                                           :log-xs [(Math/log 10) (Math/log 20)]}}}
+            result (common/prepare-log-log-fit-line
+                    log-log-data
+                    {:axis :n :impl-axis :impl})]
+        (is (vector? result))
+        (is (some #(= "vec" (get % "impl")) result))
+        (is (some #(= "list" (get % "impl")) result))))))
+
+(deftest prepare-log-log-residuals-test
+  ;; Tests prepare-log-log-residuals which formats residual points.
+  ;; Residuals are pre-computed in analysis layer.
+  (testing "prepare-log-log-residuals"
+    (testing "returns residual points"
+      (let [log-log-data {:log-xs [(Math/log 10) (Math/log 20)]
+                          :residuals [0.01 -0.02]}
+            result (common/prepare-log-log-residuals
+                    log-log-data
+                    {:axis :n})]
+        (is (vector? result))
+        (is (= 2 (count result)))
+        (is (= 0.01 (get (first result) "residual")))
+        (is (= (Math/log 10) (get (first result) "x")))))
+    (testing "returns nil for missing data"
+      (is (nil? (common/prepare-log-log-residuals nil {:axis :n})))
+      (is (nil? (common/prepare-log-log-residuals {} {:axis :n}))))
+    (testing "handles multi-implementation data"
+      (let [log-log-data {:by-impl {:vec {:log-xs [(Math/log 10)]
+                                          :residuals [0.01]}
+                                    :list {:log-xs [(Math/log 10)]
+                                           :residuals [-0.01]}}}
+            result (common/prepare-log-log-residuals
+                    log-log-data
+                    {:axis :n :impl-axis :impl})]
+        (is (= 2 (count result)))
+        (is (some #(= "vec" (get % "impl")) result))
+        (is (some #(= "list" (get % "impl")) result))))))
+
+(deftest format-log-log-slope-test
+  ;; Tests formatting of log-log slope as complexity class.
+  (testing "format-log-log-slope"
+    (testing "formats integer slopes with simplified form"
+      (is (= "O(1)" (common/format-log-log-slope 0.0)))
+      (is (= "O(n)" (common/format-log-log-slope 1.0)))
+      (is (= "O(n²)" (common/format-log-log-slope 2.0)))
+      (is (= "O(n³)" (common/format-log-log-slope 3.0))))
+    (testing "formats near-integer slopes as integers"
+      (is (= "O(n)" (common/format-log-log-slope 0.98)))
+      (is (= "O(n)" (common/format-log-log-slope 1.02)))
+      (is (= "O(n²)" (common/format-log-log-slope 1.97))))
+    (testing "formats fractional slopes with decimals"
+      (is (str/includes? (common/format-log-log-slope 1.5) "1.50"))
+      (is (str/includes? (common/format-log-log-slope 0.5) "0.50")))))

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -1482,20 +1482,69 @@
         (is (some #(= "list" (get % "impl")) result))))))
 
 (deftest format-log-log-slope-test
-  ;; Tests formatting of log-log slope as complexity class.
+  ;; Tests formatting of log-log slope as complexity class estimate.
+  ;; The function uses a 0.05 (5%) tolerance for integer rounding.
   (testing "format-log-log-slope"
-    (testing "formats integer slopes with simplified form"
+    (testing "exact integer slopes use simplified form"
       (is (= "O(1)" (common/format-log-log-slope 0.0)))
       (is (= "O(n)" (common/format-log-log-slope 1.0)))
       (is (= "O(n²)" (common/format-log-log-slope 2.0)))
       (is (= "O(n³)" (common/format-log-log-slope 3.0))))
-    (testing "formats near-integer slopes as integers"
-      (is (= "O(n)" (common/format-log-log-slope 0.98)))
-      (is (= "O(n)" (common/format-log-log-slope 1.02)))
-      (is (= "O(n²)" (common/format-log-log-slope 1.97))))
-    (testing "formats fractional slopes with decimals"
-      (is (str/includes? (common/format-log-log-slope 1.5) "1.50"))
-      (is (str/includes? (common/format-log-log-slope 0.5) "0.50")))))
+
+    (testing "slopes greater than 3 use O(n^k) form"
+      (is (= "O(n^4)" (common/format-log-log-slope 4.0)))
+      (is (= "O(n^5)" (common/format-log-log-slope 5.0))))
+
+    (testing "slopes within 0.05 of integer round to integer form"
+      ;; Near 0: tolerance = 0.05
+      (is (= "O(1)" (common/format-log-log-slope 0.04)))
+      (is (= "O(1)" (common/format-log-log-slope -0.04)))
+      ;; Near 1
+      (is (= "O(n)" (common/format-log-log-slope 0.96)))
+      (is (= "O(n)" (common/format-log-log-slope 1.04)))
+      ;; Near 2
+      (is (= "O(n²)" (common/format-log-log-slope 1.96)))
+      (is (= "O(n²)" (common/format-log-log-slope 2.04)))
+      ;; Near 3
+      (is (= "O(n³)" (common/format-log-log-slope 2.96)))
+      (is (= "O(n³)" (common/format-log-log-slope 3.04))))
+
+    (testing "slopes outside 0.05 tolerance show decimal form"
+      ;; Just outside the 0.05 threshold (testing boundary)
+      (is (= "O(n^0.06)" (common/format-log-log-slope 0.06)))
+      (is (= "O(n^0.94)" (common/format-log-log-slope 0.94)))
+      (is (= "O(n^1.06)" (common/format-log-log-slope 1.06)))
+      (is (= "O(n^1.94)" (common/format-log-log-slope 1.94)))
+      (is (= "O(n^2.06)" (common/format-log-log-slope 2.06)))
+      (is (= "O(n^2.94)" (common/format-log-log-slope 2.94))))
+
+    (testing "non-integer slopes show two decimal places"
+      (is (= "O(n^0.50)" (common/format-log-log-slope 0.5)))
+      (is (= "O(n^1.50)" (common/format-log-log-slope 1.5)))
+      (is (= "O(n^2.50)" (common/format-log-log-slope 2.5)))
+      (is (= "O(n^1.23)" (common/format-log-log-slope 1.23))))
+
+    (testing "edge cases at exact tolerance boundary"
+      ;; The 0.05 threshold uses strict < comparison. Due to floating point
+      ;; representation, values like 2.05, 2.95, 3.05 round to integer form
+      ;; (their diff from nearest int is 0.04999... < 0.05), while 0.05, 0.95,
+      ;; 1.05, 1.95 show decimal (their diff is exactly 0.05 or slightly more).
+      (is (= "O(n^0.05)" (common/format-log-log-slope 0.05)))
+      (is (= "O(n^0.95)" (common/format-log-log-slope 0.95)))
+      (is (= "O(n^1.05)" (common/format-log-log-slope 1.05)))
+      (is (= "O(n^1.95)" (common/format-log-log-slope 1.95)))
+      ;; Larger values round to integer due to floating-point representation
+      (is (= "O(n²)" (common/format-log-log-slope 2.05)))
+      (is (= "O(n³)" (common/format-log-log-slope 2.95)))
+      (is (= "O(n³)" (common/format-log-log-slope 3.05)))
+      ;; Just inside boundary: 0.049 is within tolerance (< 0.05)
+      (is (= "O(1)" (common/format-log-log-slope 0.049)))
+      (is (= "O(n)" (common/format-log-log-slope 0.951)))
+      (is (= "O(n)" (common/format-log-log-slope 1.049)))
+      (is (= "O(n²)" (common/format-log-log-slope 1.951)))
+      (is (= "O(n²)" (common/format-log-log-slope 2.049)))
+      (is (= "O(n³)" (common/format-log-log-slope 2.951)))
+      (is (= "O(n³)" (common/format-log-log-slope 3.049))))))
 
 ;;; Regression model table tests.
 ;;; Verifies prepare-regression-model-table and prepare-regression-model-table-multi-impl

--- a/bases/criterium/test/criterium/viewer/common_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_test.clj
@@ -1496,3 +1496,117 @@
     (testing "formats fractional slopes with decimals"
       (is (str/includes? (common/format-log-log-slope 1.5) "1.50"))
       (is (str/includes? (common/format-log-log-slope 0.5) "0.50")))))
+
+;;; Regression model table tests.
+;;; Verifies prepare-regression-model-table and prepare-regression-model-table-multi-impl
+;;; correctly format model data for table rendering, including AIC and BIC columns.
+
+(deftest prepare-regression-model-table-test
+  ;; Tests prepare-regression-model-table which formats model data for table rendering.
+  ;; Contracts: returns vector of row maps with :model :r-squared :aic :bic :equation :best-fit keys.
+  (testing "prepare-regression-model-table"
+    (testing "includes AIC and BIC columns"
+      (let [models [{:id :linear
+                     :label "O(n)"
+                     :equation-str "y = 2.5x + 1"
+                     :r-squared 0.95
+                     :aic 10.5
+                     :bic 12.3}
+                    {:id :quadratic
+                     :label "O(n²)"
+                     :equation-str "y = 0.1x² + 0.5"
+                     :r-squared 0.98
+                     :aic 8.2
+                     :bic 10.1}]
+            result (common/prepare-regression-model-table
+                    {:models models :best-fit :quadratic}
+                    {})]
+        (is (vector? result))
+        (is (= 2 (count result)))
+        (let [best-row (first (filter #(= "✓" (:best-fit %)) result))
+              other-row (first (filter #(= "" (:best-fit %)) result))]
+          (is (= "O(n²)" (:model best-row)))
+          (is (= "0.9800" (:r-squared best-row)))
+          (is (= "8.2" (:aic best-row)))
+          (is (= "10.1" (:bic best-row)))
+          (is (= "10.5" (:aic other-row)))
+          (is (= "12.3" (:bic other-row))))))
+
+    (testing "handles nil AIC/BIC values"
+      (let [models [{:id :linear
+                     :label "O(n)"
+                     :equation-str "y = 2.5x + 1"
+                     :r-squared 0.95
+                     :aic nil
+                     :bic nil}]
+            result (common/prepare-regression-model-table
+                    {:models models :best-fit :linear}
+                    {})]
+        (is (= 1 (count result)))
+        (is (nil? (:aic (first result))))
+        (is (nil? (:bic (first result))))))
+
+    (testing "handles missing AIC/BIC keys"
+      (let [models [{:id :linear
+                     :label "O(n)"
+                     :equation-str "y = 2.5x + 1"
+                     :r-squared 0.95}]
+            result (common/prepare-regression-model-table
+                    {:models models :best-fit :linear}
+                    {})]
+        (is (= 1 (count result)))
+        (is (nil? (:aic (first result))))
+        (is (nil? (:bic (first result))))))
+
+    (testing "formats negative AIC/BIC values"
+      (let [models [{:id :linear
+                     :label "O(n)"
+                     :equation-str "y = 2.5x + 1"
+                     :r-squared 0.95
+                     :aic -15.7
+                     :bic -12.3}]
+            result (common/prepare-regression-model-table
+                    {:models models :best-fit :linear}
+                    {})]
+        (is (= "-15.7" (:aic (first result))))
+        (is (= "-12.3" (:bic (first result))))))
+
+    (testing "returns nil for empty models"
+      (is (nil? (common/prepare-regression-model-table {:models [] :best-fit nil} {}))))
+
+    (testing "sorts models by r-squared descending"
+      (let [models [{:id :linear :label "O(n)" :r-squared 0.8 :aic 10.0 :bic 12.0}
+                    {:id :quadratic :label "O(n²)" :r-squared 0.95 :aic 8.0 :bic 10.0}
+                    {:id :log :label "O(log n)" :r-squared 0.7 :aic 15.0 :bic 17.0}]
+            result (common/prepare-regression-model-table
+                    {:models models :best-fit :quadratic}
+                    {})]
+        (is (= ["O(n²)" "O(n)" "O(log n)"]
+               (mapv :model result)))))))
+
+(deftest prepare-regression-model-table-multi-impl-test
+  ;; Tests prepare-regression-model-table-multi-impl which formats multi-impl model data.
+  ;; Contracts: returns vector with :implementation :model :r-squared :aic :bic :equation :best-fit.
+  (testing "prepare-regression-model-table-multi-impl"
+    (testing "includes implementation and AIC/BIC columns"
+      (let [by-impl {:vec {:models [{:id :linear :label "O(n)" :r-squared 0.95 :aic 10.5 :bic 12.3}]
+                           :best-fit :linear}
+                     :list {:models [{:id :linear :label "O(n)" :r-squared 0.85 :aic 15.2 :bic 17.0}]
+                            :best-fit :linear}}
+            impl-keys [:vec :list]
+            result (common/prepare-regression-model-table-multi-impl by-impl impl-keys {})]
+        (is (vector? result))
+        (is (= 2 (count result)))
+        (let [vec-row (first (filter #(= "vec" (:implementation %)) result))
+              list-row (first (filter #(= "list" (:implementation %)) result))]
+          (is (= "10.5" (:aic vec-row)))
+          (is (= "12.3" (:bic vec-row)))
+          (is (= "15.2" (:aic list-row)))
+          (is (= "17.0" (:bic list-row))))))
+
+    (testing "handles nil AIC/BIC in multi-impl"
+      (let [by-impl {:vec {:models [{:id :linear :label "O(n)" :r-squared 0.95}]
+                           :best-fit :linear}}
+            result (common/prepare-regression-model-table-multi-impl by-impl [:vec] {})]
+        (is (nil? (:aic (first result))))
+        (is (nil? (:bic (first result))))))))


### PR DESCRIPTION
## Summary

Enhances the domain complexity analysis with better statistical methods and visualization:

- **AIC/BIC computation**: Add Akaike and Bayesian Information Criteria for model selection
- **Model selection methods**: Support AIC (default), BIC, or R² based selection
- **Log-log diagnostic charts**: Show log-log scatter plots before model fits for intuitive complexity class estimation (slope ≈ 1 for O(n), slope ≈ 2 for O(n²), etc.)
- **Updated model tables**: Display AIC/BIC columns alongside R²
- **Viewer integration**: All three viewers (print, kindly, portal) support the new features
- **Code refactoring**: Extract shared domain-regression logic to reduce duplication

## Changes

- Add `compute-aic`, `compute-bic` functions to domain/analysis.clj
- Add log-log regression functions (`log-log-regression`, `fit-log-log`, `domain-log-log-fn`)
- Add `:selection-method` option to `fit-complexity` (`:aic`, `:bic`, `:r-squared`)
- Add log-log chart specifications to viewer/common-charts.clj
- Update regression model tables to include AIC/BIC columns
- Extract `with-domain-regression-data` helper to reduce viewer duplication
- Add type hints to eliminate boxed math warnings

## Test plan

- [ ] Run test suite: `clojure -M:kaocha:dev:test --reporter dots`
- [ ] Verify AIC/BIC values appear in model tables
- [ ] Verify log-log chart appears before model fit charts
- [ ] Test with Portal viewer for interactive charts