### PR TITLE
fix(viewer): fix single point domain comparison regression

### DIFF
--- a/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
@@ -696,12 +696,29 @@
           (when-let [table (build-absolute-value-table axis metric data)]
             [table]))))))
 
+(defn- extract-median-value
+  "Extract median value from a bootstrap stats value map.
+  Falls back to :value then raw value for backward compatibility."
+  [value]
+  (cond
+    (and (map? value) (contains? value :median)) (:median value)
+    (and (map? value) (contains? value :value)) (:value value)
+    :else value))
+
+(defn- has-ci-bounds?
+  "Check if a value map has confidence interval bounds."
+  [value]
+  (and (map? value)
+       (contains? value :ci-lower)
+       (contains? value :ci-upper)))
+
 (defn prepare-domain-comparison-table-transposed
   "Prepare transposed domain-comparison table for single-point multi-impl scenarios.
   Returns {:heading :col-headers :rows} where each row is one implementation.
 
-  Columns include implementation name, then for each metric: value and factor.
-  Factor is relative to baseline (first implementation)."
+  Columns include implementation name, then for each metric: median value,
+  CI bounds (when available), and factor. Factor is relative to baseline
+  (first implementation), calculated using median values."
   [comparison]
   (when comparison
     (let [{:keys [axis metric metrics implementations data]} comparison
@@ -713,18 +730,16 @@
                             {metric-id {:metric metric :data data}}))
           metric-ids (sort (keys metrics-map))
 
-          ;; Build lookup: {[impl metric-id] -> raw-value}
-          lookup
+          ;; Build lookup: {[impl metric-id] -> full-value-map}
+          ;; Keep the full value map so we can extract CI bounds
+          value-lookup
           (reduce
            (fn [acc [metric-id {:keys [data]}]]
              (reduce
               (fn [acc2 [impl-val entries]]
                 (reduce
                  (fn [acc3 {:keys [value]}]
-                   (let [raw-value (if (and (map? value) (contains? value :value))
-                                     (:value value)
-                                     value)]
-                     (assoc acc3 [impl-val metric-id] raw-value)))
+                   (assoc acc3 [impl-val metric-id] value))
                  acc2
                  entries))
               acc
@@ -732,27 +747,48 @@
            {}
            metrics-map)
 
-          ;; Compute SI scaling per metric (using all values for that metric)
+          ;; Build median lookup for SI scaling and factor calculation
+          median-lookup
+          (into {}
+                (map (fn [[k v]] [k (extract-median-value v)]))
+                value-lookup)
+
+          ;; Check which metrics have CI bounds available
+          metric-has-ci
+          (into {}
+                (map (fn [metric-id]
+                       [metric-id
+                        (some (fn [impl]
+                                (has-ci-bounds? (get value-lookup [impl metric-id])))
+                              implementations)]))
+                metric-ids)
+
+          ;; Compute SI scaling per metric (using median values)
           metric-scales
           (into {}
                 (map (fn [metric-id]
                        (let [metric-path (get-in metrics-map [metric-id :metric])
                              all-values (keep (fn [impl]
-                                                (get lookup [impl metric-id]))
+                                                (get median-lookup [impl metric-id]))
                                               implementations)]
                          [metric-id (core/compute-si-scaling metric-path all-values)])))
                 metric-ids)
 
-          ;; Build column headers: Implementation, then for each metric: value and ×
+          ;; Build column headers: Implementation, then for each metric:
+          ;; median value, CI (when available), and factor
           col-headers
           (into ["Implementation"]
                 (mapcat (fn [metric-id]
                           (let [{:keys [unit]} (get metric-scales metric-id)
                                 metric-name (name metric-id)
                                 value-header (if (seq unit)
-                                               (str metric-name " (" unit ")")
-                                               metric-name)]
-                            [value-header (str metric-name " ×")]))
+                                               (str "median " metric-name " (" unit ")")
+                                               (str "median " metric-name))
+                                ci-header (str metric-name " CI")
+                                factor-header (str metric-name " ×")]
+                            (if (get metric-has-ci metric-id)
+                              [value-header ci-header factor-header]
+                              [value-header factor-header])))
                         metric-ids))
 
           ;; Build table rows: one per implementation
@@ -766,22 +802,35 @@
                             (get metric-scales metric-id)
                             metric-name (name metric-id)
                             value-header (if (seq unit)
-                                           (str metric-name " (" unit ")")
-                                           metric-name)
+                                           (str "median " metric-name " (" unit ")")
+                                           (str "median " metric-name))
+                            ci-header (str metric-name " CI")
                             factor-header (str metric-name " ×")
-                            raw-value (get lookup [impl metric-id])
-                            baseline-value (get lookup [baseline-impl metric-id])
-                            formatted-value (when raw-value
+                            full-value (get value-lookup [impl metric-id])
+                            median-value (get median-lookup [impl metric-id])
+                            baseline-median (get median-lookup [baseline-impl metric-id])
+                            formatted-value (when median-value
                                               (format "%.3g"
-                                                      (* (double raw-value)
+                                                      (* (double median-value)
                                                          total-scale)))
-                            factor (when (and raw-value baseline-value
-                                              (not (zero? (double baseline-value))))
+                            ;; Format CI as "lower - upper" when available
+                            formatted-ci (when (has-ci-bounds? full-value)
+                                           (format "%.3g - %.3g"
+                                                   (* (double (:ci-lower full-value))
+                                                      total-scale)
+                                                   (* (double (:ci-upper full-value))
+                                                      total-scale)))
+                            factor (when (and median-value baseline-median
+                                              (not (zero? (double baseline-median))))
                                      (format "%.2f"
-                                             (/ (double raw-value)
-                                                (double baseline-value))))]
-                        [[value-header formatted-value]
-                         [factor-header factor]]))
+                                             (/ (double median-value)
+                                                (double baseline-median))))]
+                        (if (get metric-has-ci metric-id)
+                          [[value-header formatted-value]
+                           [ci-header formatted-ci]
+                           [factor-header factor]]
+                          [[value-header formatted-value]
+                           [factor-header factor]])))
                     metric-ids)))
            implementations)]
 

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -303,13 +303,12 @@
   [_ {:keys [comparison-id]} data-map]
   (let [comparison-id (or comparison-id :comparison)
         comparison (data-map comparison-id)]
-    (when-let [tables (comparison/prepare-domain-comparison-tables
-                       comparison)]
-      (doseq [{:keys [heading coord-header col-headers rows]} tables]
+    (case (detection/comparison-visualization-strategy comparison)
+      :single-point
+      (when-let [{:keys [heading col-headers rows]}
+                 (comparison/prepare-domain-comparison-table-transposed comparison)]
         (kindly-heading heading)
-        (kindly-table rows {:column-names (into [coord-header] col-headers)}))
-      (case (detection/comparison-visualization-strategy comparison)
-        :single-point
+        (kindly-table rows {:column-names col-headers})
         (let [box-spec (charts/comparison-box-chart-spec comparison {:width chart-width
                                                                      :height chart-height})]
           ;; Fall back to bar chart if box plot has no data (missing bootstrap stats)
@@ -317,12 +316,22 @@
             (kindly-vega-lite box-spec)
             (kindly-vega-lite
              (charts/comparison-bar-chart-spec comparison {:width chart-width
-                                                           :height chart-height}))))
-        :multi-point
+                                                           :height chart-height})))))
+
+      :multi-point
+      (when-let [tables (comparison/prepare-domain-comparison-tables comparison)]
+        (doseq [{:keys [heading coord-header col-headers rows]} tables]
+          (kindly-heading heading)
+          (kindly-table rows {:column-names (into [coord-header] col-headers)}))
         (kindly-vega-lite
          (charts/comparison-line-chart-spec comparison {:width chart-width
-                                                        :height chart-height}))
-        :default-table nil))))
+                                                        :height chart-height})))
+
+      :default-table
+      (when-let [tables (comparison/prepare-domain-comparison-tables comparison)]
+        (doseq [{:keys [heading coord-header col-headers rows]} tables]
+          (kindly-heading heading)
+          (kindly-table rows {:column-names (into [coord-header] col-headers)}))))))
 
 (defmethod view/domain-regression* :kindly
   [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -449,23 +449,32 @@
   [_ {:keys [comparison-id]} data-map]
   (let [comparison-id (or comparison-id :comparison)
         comparison (data-map comparison-id)]
-    (when-let [tables (comparison/prepare-domain-comparison-tables
-                       comparison)]
-      (doseq [{:keys [rows] heading-text :heading} tables]
-        (heading heading-text)
-        (portal-table rows))
-      (case (detection/comparison-visualization-strategy comparison)
-        :single-point
+    (case (detection/comparison-visualization-strategy comparison)
+      :single-point
+      (when-let [{:keys [heading rows]}
+                 (comparison/prepare-domain-comparison-table-transposed comparison)]
+        (heading heading)
+        (portal-table rows)
         (let [box-spec (charts/comparison-box-chart-spec comparison {:height 400})]
           ;; Fall back to bar chart if box plot has no data (missing bootstrap stats)
           (if (seq (:vconcat box-spec))
             (portal-vega-lite box-spec)
             (portal-vega-lite
-             (charts/comparison-bar-chart-spec comparison {:height 400}))))
-        :multi-point
+             (charts/comparison-bar-chart-spec comparison {:height 400})))))
+
+      :multi-point
+      (when-let [tables (comparison/prepare-domain-comparison-tables comparison)]
+        (doseq [{:keys [rows] heading-text :heading} tables]
+          (heading heading-text)
+          (portal-table rows))
         (portal-vega-lite
-         (charts/comparison-line-chart-spec comparison {:height 400}))
-        :default-table nil))))
+         (charts/comparison-line-chart-spec comparison {:height 400})))
+
+      :default-table
+      (when-let [tables (comparison/prepare-domain-comparison-tables comparison)]
+        (doseq [{:keys [rows] heading-text :heading} tables]
+          (heading heading-text)
+          (portal-table rows))))))
 
 (defmethod view/domain-regression* :portal
   [_ {:keys [regression-id extract-id log-log-id tolerance]} data-map]

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -705,3 +705,155 @@
                  (get foo-data "ciUpper")
                  (get foo-data "p90"))
               "values should be in correct order"))))))
+
+;;; Tests for prepare-domain-comparison-table-transposed helper.
+;;; Verifies transposed table preparation with bootstrapped median values.
+
+(deftest prepare-domain-comparison-table-transposed-test
+  ;; Tests transposed table data preparation for single-point domain comparison.
+  ;; Verifies correct extraction of median values, CI bounds display, and factor calculation.
+  (testing "prepare-domain-comparison-table-transposed"
+    (testing "extracts median values from bootstrap stats"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:median 1.0e-6
+                                                         :value 1.1e-6}}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value {:median 2.0e-6
+                                                         :value 2.2e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            rows (:rows result)]
+        (is (= 2 (count rows)))
+        ;; The median column header should contain "median"
+        (is (some #(str/includes? % "median") (:col-headers result)))))
+
+    (testing "includes CI columns when CI bounds present"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:median 1.0e-6
+                                                         :ci-lower 0.9e-6
+                                                         :ci-upper 1.1e-6}}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value {:median 2.0e-6
+                                                         :ci-lower 1.8e-6
+                                                         :ci-upper 2.2e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            col-headers (:col-headers result)]
+        ;; Should have CI column
+        (is (some #(str/includes? % "CI") col-headers))
+        ;; Implementation + median + CI + factor = 4 columns
+        (is (= 4 (count col-headers)))))
+
+    (testing "omits CI columns when CI bounds absent"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:median 1.0e-6}}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value {:median 2.0e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            col-headers (:col-headers result)]
+        ;; Should not have CI column
+        (is (not (some #(str/includes? % "CI") col-headers)))
+        ;; Implementation + median + factor = 3 columns
+        (is (= 3 (count col-headers)))))
+
+    (testing "calculates factor using median values"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:median 1.0e-6
+                                                         :value 1.5e-6}}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value {:median 2.0e-6
+                                                         :value 3.0e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            rows (:rows result)
+            foo-row (first (filter #(= "foo" (get % "Implementation")) rows))
+            bar-row (first (filter #(= "bar" (get % "Implementation")) rows))
+            factor-header (first (filter #(str/includes? % "×") (:col-headers result)))]
+        ;; Baseline (foo) factor should be 1.00
+        (is (= "1.00" (get foo-row factor-header)))
+        ;; Bar factor should be 2.0 (2.0e-6 / 1.0e-6) based on median, not 2.0 (3.0e-6 / 1.5e-6)
+        (is (= "2.00" (get bar-row factor-header)))))
+
+    (testing "formats CI bounds as range"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:median 1.0e-6
+                                                         :ci-lower 0.9e-6
+                                                         :ci-upper 1.1e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            rows (:rows result)
+            foo-row (first rows)
+            ci-header (first (filter #(str/includes? % "CI") (:col-headers result)))
+            ci-value (get foo-row ci-header)]
+        ;; CI should be formatted as "lower - upper"
+        (is (string? ci-value))
+        (is (str/includes? ci-value " - "))))
+
+    (testing "falls back to :value when :median absent"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:value 1.0e-6}}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value {:value 2.0e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            rows (:rows result)
+            bar-row (first (filter #(= "bar" (get % "Implementation")) rows))
+            factor-header (first (filter #(str/includes? % "×") (:col-headers result)))]
+        ;; Factor should still work using :value fallback
+        (is (= "2.00" (get bar-row factor-header)))))
+
+    (testing "handles plain numeric values (backward compatibility)"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value 1.0e-6}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value 2.0e-6}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            rows (:rows result)
+            bar-row (first (filter #(= "bar" (get % "Implementation")) rows))
+            factor-header (first (filter #(str/includes? % "×") (:col-headers result)))]
+        ;; Factor should work with plain numeric values
+        (is (= "2.00" (get bar-row factor-header)))))
+
+    (testing "handles single-metric mode"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:impl :foo}
+                                      :value {:median 1.0e-6}}]
+                               :bar [{:coord {:impl :bar}
+                                      :value {:median 2.0e-6}}]}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)]
+        (is (map? result))
+        (is (= 2 (count (:rows result))))
+        (is (some #(str/includes? % "median") (:col-headers result)))))))

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -630,12 +630,13 @@
                  "  separator: " (pr-str separator)))))
     (testing "with :implementations and single point uses transposed table"
       ;; Single-point multi-impl scenarios use transposed format where
-      ;; each row is an implementation with value and factor columns
+      ;; each row is an implementation with value and factor columns.
+      ;; Column header shows "median" prefix per task 627.
       (is (= ["Domain Comparison by impl"
-              "Implementation │ elapsed-time (ns) │ elapsed-time ×"
-              "───────────────┼───────────────────┼───────────────"
-              "foo │               100 │           1.00"
-              "bar │               200 │           2.00"]
+              "Implementation │ median elapsed-time (ns) │ elapsed-time ×"
+              "───────────────┼──────────────────────────┼───────────────"
+              "foo │                      100 │           1.00"
+              "bar │                      200 │           2.00"]
              (trimmed-lines
               (with-out-str
                 (view/domain-comparison*


### PR DESCRIPTION
## Summary

Fix regression in single-point domain comparison across all viewers:

- Portal and kindly viewers now use transposed table format for single-point scenarios (matching print viewer)
- Transposed comparison table uses bootstrapped median values instead of mean
- Added CI bounds columns when available
- Factors calculated using median values

## Changes

- `view/domain-comparison*` in portal.clj and kindly.clj now detect single-point scenarios and use `prepare-domain-comparison-table-transposed`
- `prepare-domain-comparison-table-transposed` extracts `:median` (with fallback chain), displays CI columns, and calculates factors from median
- Column headers updated to show "median metric-name"
- Added helper functions `extract-median-value` and `has-ci-bounds?`

## Commits

- fix(viewer): use transposed table for single-point domain comparison
- fix(viewer): use bootstrapped median in transposed comparison table
- test(viewer): update print test for median column header

## Test plan

- [x] Existing tests pass
- [x] Print viewer test updated for new median column header