### PR TITLE
feat(viewer): add domain-apply view for per-run benchmark viewing

### DIFF
--- a/bases/agent/test/criterium/agent/core_test.clj
+++ b/bases/agent/test/criterium/agent/core_test.clj
@@ -60,7 +60,10 @@
                      :allocation-tracing-starting :allocation-tracing-active
                      :allocation-tracing-stopping :allocation-tracing-flushing
                      :allocation-tracing-flushed :allocation-tracing-reporting
-                     :allocation-tracing-reported}
+                     :allocation-tracing-reported
+                     :method-tracing-starting :method-tracing-active
+                     :method-tracing-stopping :method-tracing-stopped
+                     :method-tracing-reporting :method-tracing-reported}
                    (agent-core/agent-state))
         "Agent state should be a valid state keyword"))
 

--- a/bases/criterium/src/criterium/view.clj
+++ b/bases/criterium/src/criterium/view.clj
@@ -71,6 +71,7 @@
 (def-multi-view domain-grouped)
 (def-multi-view domain-comparison)
 (def-multi-view domain-regression)
+(def-multi-view domain-apply)
 
 (defmulti flush-viewer (fn [viewer] viewer))
 (defmethod flush-viewer :default [_])
@@ -123,3 +124,4 @@
 (defmethod domain-grouped* :none [_ _ _])
 (defmethod domain-comparison* :none [_ _ _])
 (defmethod domain-regression* :none [_ _ _])
+(defmethod domain-apply* :none [_ _ _])

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -9,6 +9,7 @@
   appropriate `:kindly/kind` metadata."
   (:refer-clojure :exclude [flush])
   (:require
+   [criterium.domain.types :as domain.types]
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
@@ -714,3 +715,29 @@
                             location metric-config transforms)
                  :density (format "%.4g" density)})
               modes))))))
+
+;;; Domain Apply View
+
+(defn- resolve-view-fn-without-flush
+  "Resolve a view spec to a function without automatic flushing.
+  Used by domain-apply to accumulate all run outputs before flushing."
+  [view-spec]
+  (let [[view-kw opts] (if (sequential? view-spec)
+                         [(first view-spec) (second view-spec)]
+                         [view-spec {}])
+        view-fn-var (ns-resolve 'criterium.view (symbol (name view-kw)))]
+    (when view-fn-var
+      (view-fn-var (or opts {})))))
+
+(defmethod view/domain-apply* :kindly
+  [viewer {:keys [domain-id view-spec]} data-map]
+  (let [domain-id (or domain-id :domain)
+        domain (get data-map domain-id)]
+    (when (and domain view-spec)
+      ;; Use direct view function resolution to avoid automatic flush
+      ;; that benchmark/->view performs after each call.
+      ;; For kindly, we want to accumulate all runs' output first.
+      (when-let [view-fn (resolve-view-fn-without-flush view-spec)]
+        (doseq [{:keys [coord data]} (domain.types/runs domain)]
+          (kindly-heading (format "Run: %s" (pr-str coord)))
+          (view-fn viewer data))))))

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -737,7 +737,15 @@
   [viewer {:keys [domain-id view-spec]} data-map]
   (let [domain-id (or domain-id :domain)
         domain (get data-map domain-id)]
-    (when (and domain view-spec)
+    (cond
+      (nil? view-spec)
+      (binding [*out* *err*]
+        (println "WARNING: domain-apply requires :view-spec option"))
+
+      (nil? domain)
+      nil
+
+      :else
       ;; Use direct view function resolution to avoid automatic flush
       ;; that benchmark/->view performs after each call.
       ;; For kindly, we want to accumulate all runs' output first.

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -720,14 +720,18 @@
 
 (defn- resolve-view-fn-without-flush
   "Resolve a view spec to a function without automatic flushing.
+  Returns nil and logs a warning if the view-spec cannot be resolved.
   Used by domain-apply to accumulate all run outputs before flushing."
   [view-spec]
   (let [[view-kw opts] (if (sequential? view-spec)
                          [(first view-spec) (second view-spec)]
                          [view-spec {}])
         view-fn-var (ns-resolve 'criterium.view (symbol (name view-kw)))]
-    (when view-fn-var
-      (view-fn-var (or opts {})))))
+    (if view-fn-var
+      (view-fn-var (or opts {}))
+      (binding [*out* *err*]
+        (println (format "WARNING: Unknown view-spec '%s' - no such view function in criterium.view"
+                         view-kw))))))
 
 (defmethod view/domain-apply* :kindly
   [viewer {:keys [domain-id view-spec]} data-map]

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -664,7 +664,15 @@
   [viewer {:keys [domain-id view-spec]} data-map]
   (let [domain-id (or domain-id :domain)
         domain (get data-map domain-id)]
-    (when (and domain view-spec)
+    (cond
+      (nil? view-spec)
+      (binding [*out* *err*]
+        (println "WARNING: domain-apply requires :view-spec option"))
+
+      (nil? domain)
+      nil
+
+      :else
       (let [view-fn (benchmark/->view [view-spec])]
         (doseq [{:keys [coord data]} (domain.types/runs domain)]
           (heading (format "Run: %s" (pr-str coord)))

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -2,6 +2,8 @@
   "A viewer that outputs to portal using tap>."
   (:refer-clojure :exclude [flush])
   (:require
+   [criterium.benchmark :as benchmark]
+   [criterium.domain.types :as domain.types]
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
@@ -655,3 +657,15 @@
                             location metric-config transforms)
                  :density (format "%.4g" density)})
               modes))))))
+
+;;; Domain Apply View
+
+(defmethod view/domain-apply* :portal
+  [viewer {:keys [domain-id view-spec]} data-map]
+  (let [domain-id (or domain-id :domain)
+        domain (get data-map domain-id)]
+    (when (and domain view-spec)
+      (let [view-fn (benchmark/->view [view-spec])]
+        (doseq [{:keys [coord data]} (domain.types/runs domain)]
+          (heading (format "Run: %s" (pr-str coord)))
+          (view-fn viewer data))))))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -2,8 +2,6 @@
   "A pretty print viewer"
   (:require
    [clojure.pprint :as pprint]
-   [criterium.benchmark :as benchmark]
-   [criterium.domain.types :as domain.types]
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
@@ -468,12 +466,7 @@
 
 ;;; Domain Apply View
 
+;; Delegates to :print since the output format is identical
 (defmethod view/domain-apply* :pprint
-  [viewer {:keys [domain-id view-spec]} data-map]
-  (let [domain-id (or domain-id :domain)
-        domain (get data-map domain-id)]
-    (when (and domain view-spec)
-      (let [view-fn (benchmark/->view [view-spec])]
-        (doseq [{:keys [coord data]} (domain.types/runs domain)]
-          (println (format "--- %s ---" (pr-str coord)))
-          (view-fn viewer data))))))
+  [viewer view-opts data-map]
+  ((get-method view/domain-apply* :print) viewer view-opts data-map))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -2,6 +2,8 @@
   "A pretty print viewer"
   (:require
    [clojure.pprint :as pprint]
+   [criterium.benchmark :as benchmark]
+   [criterium.domain.types :as domain.types]
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
@@ -463,3 +465,15 @@
        (pprint/print-table
         [:location :density]
         (modes-table modes metric-config transforms))))))
+
+;;; Domain Apply View
+
+(defmethod view/domain-apply* :pprint
+  [viewer {:keys [domain-id view-spec]} data-map]
+  (let [domain-id (or domain-id :domain)
+        domain (get data-map domain-id)]
+    (when (and domain view-spec)
+      (let [view-fn (benchmark/->view [view-spec])]
+        (doseq [{:keys [coord data]} (domain.types/runs domain)]
+          (println (format "--- %s ---" (pr-str coord)))
+          (view-fn viewer data))))))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -1326,7 +1326,15 @@
   [viewer {:keys [domain-id view-spec]} data-map]
   (let [domain-id (or domain-id :domain)
         domain (get data-map domain-id)]
-    (when (and domain view-spec)
+    (cond
+      (nil? view-spec)
+      (binding [*out* *err*]
+        (println "WARNING: domain-apply requires :view-spec option"))
+
+      (nil? domain)
+      nil
+
+      :else
       (let [view-fn (benchmark/->view [view-spec])]
         (doseq [{:keys [coord data]} (domain.types/runs domain)]
           (println (format "Run: %s" (pr-str coord)))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -1329,5 +1329,5 @@
     (when (and domain view-spec)
       (let [view-fn (benchmark/->view [view-spec])]
         (doseq [{:keys [coord data]} (domain.types/runs domain)]
-          (println (format "--- %s ---" (pr-str coord)))
+          (println (format "Run: %s" (pr-str coord)))
           (view-fn viewer data))))))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -2,6 +2,8 @@
   "A print viewer"
   (:require
    [clojure.string :as str]
+   [criterium.benchmark :as benchmark]
+   [criterium.domain.types :as domain.types]
    [criterium.jvm :as jvm]
    [criterium.metric :as metric]
    [criterium.util.format :as format]
@@ -1317,3 +1319,15 @@
                             modes)]
          (println (format "%32s  Mode locations: %s" ""
                           (str/join ", " locations))))))))
+
+;;; Domain Apply View
+
+(defmethod view/domain-apply* :print
+  [viewer {:keys [domain-id view-spec]} data-map]
+  (let [domain-id (or domain-id :domain)
+        domain (get data-map domain-id)]
+    (when (and domain view-spec)
+      (let [view-fn (benchmark/->view [view-spec])]
+        (doseq [{:keys [coord data]} (domain.types/runs domain)]
+          (println (format "--- %s ---" (pr-str coord)))
+          (view-fn viewer data))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -6,7 +6,9 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
+   [criterium.collect-plan :as collect-plan]
    [criterium.collector.metrics :as metrics]
+   [criterium.domain.types :as domain.types]
    [criterium.test-data :as test-data]
    [criterium.view :as view]
    [criterium.viewer.kindly :as kindly]))
@@ -1546,3 +1548,123 @@
         (let [result (kindly/flush)]
           (is (= 4 (count result))
               "Expected output with custom modes-id"))))))
+
+;;; Domain Apply View Tests
+
+(defn- make-bench-data
+  "Create minimal benchmark data with stats for testing domain-apply.
+  Unlike print viewer, kindly stats view also requires :max-val in stats."
+  [mean-ns]
+  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+    {:samples {:type :criterium/collected-metrics-samples
+               :metrics-defs metrics-defs
+               :metric->values {[:elapsed-time] [mean-ns]}
+               :transform collect-plan/identity-transforms
+               :batch-size 1
+               :num-samples 1
+               :eval-count 1
+               :elapsed-time mean-ns}
+     :stats {:type :criterium/stats
+             :metrics-defs metrics-defs
+             :transform collect-plan/identity-transforms
+             :batch-size 1
+             :source-id :samples
+             :outliers-id nil
+             :stats {:elapsed-time {:mean mean-ns
+                                    :variance 1.0
+                                    :mean-plus-3sigma (+ mean-ns 3)
+                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :min-val mean-ns
+                                    :max-val (+ mean-ns 10)}}}}))
+
+(deftest domain-apply-kindly-test
+  ;; Tests the view/domain-apply* multimethod for :kindly viewer.
+  ;; Verifies that each run is rendered with a heading showing the coord
+  ;; and the view-spec is applied to produce output in the accumulator.
+  (testing "view/domain-apply* :kindly"
+    (testing "renders heading and applies view-spec to each run"
+      (reset! kindly/accumulated [])
+      (let [domain (-> (domain.types/domain)
+                       (domain.types/add-run {:n 100} (make-bench-data 100))
+                       (domain.types/add-run {:n 200} (make-bench-data 200)))]
+        (view/domain-apply*
+         :kindly
+         {:view-spec [:stats {}]}
+         {:domain domain})
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          ;; Each run produces: heading + stats heading + stats table = 3 items
+          ;; 2 runs = 6 items total
+          (is (= 6 (count result))
+              "Expected 6 items: 2 runs × (coord heading + stats heading + stats table)")
+          ;; First item should be the coord heading for first run
+          (let [first-heading (first result)]
+            (is (= :kind/md (:kindly/kind (meta first-heading))))
+            (is (str/includes? (first first-heading) "Run:")
+                "First item should be run heading")
+            (is (str/includes? (first first-heading) "{:n 100}")
+                "Run heading should contain coord"))
+          ;; Fourth item should be the coord heading for second run
+          (let [second-heading (nth result 3)]
+            (is (= :kind/md (:kindly/kind (meta second-heading))))
+            (is (str/includes? (first second-heading) "{:n 200}")
+                "Second run heading should contain coord")))))
+
+    (testing "handles keyword coord"
+      (reset! kindly/accumulated [])
+      (let [domain (domain.types/domain
+                    {:coord :baseline :data (make-bench-data 50)})]
+        (view/domain-apply*
+         :kindly
+         {:view-spec [:stats {}]}
+         {:domain domain})
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (let [first-heading (first result)]
+            (is (str/includes? (first first-heading) ":baseline")
+                "Coord heading should contain keyword coord")))))
+
+    (testing "uses custom domain-id"
+      (reset! kindly/accumulated [])
+      (let [domain (domain.types/domain
+                    {:coord {:impl :foo} :data (make-bench-data 150)})]
+        (view/domain-apply*
+         :kindly
+         {:domain-id :my-domain
+          :view-spec [:stats {}]}
+         {:my-domain domain})
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (let [first-heading (first result)]
+            (is (str/includes? (first first-heading) "{:impl :foo}")
+                "Should use custom domain-id")))))
+
+    (testing "handles empty domain gracefully"
+      (reset! kindly/accumulated [])
+      (let [domain (domain.types/domain)]
+        (view/domain-apply*
+         :kindly
+         {:view-spec [:stats {}]}
+         {:domain domain})
+        (is (nil? (kindly/flush))
+            "Should produce no output for empty domain")))
+
+    (testing "handles missing domain gracefully"
+      (reset! kindly/accumulated [])
+      (view/domain-apply*
+       :kindly
+       {:view-spec [:stats {}]}
+       {})
+      (is (nil? (kindly/flush))
+          "Should produce no output when domain is missing"))
+
+    (testing "handles missing view-spec gracefully"
+      (reset! kindly/accumulated [])
+      (let [domain (domain.types/domain
+                    {:coord :test :data (make-bench-data 100)})]
+        (view/domain-apply*
+         :kindly
+         {}
+         {:domain domain})
+        (is (nil? (kindly/flush))
+            "Should produce no output when view-spec is missing")))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -1658,13 +1658,18 @@
       (is (nil? (kindly/flush))
           "Should produce no output when domain is missing"))
 
-    (testing "handles missing view-spec gracefully"
+    (testing "warns when view-spec is missing"
       (reset! kindly/accumulated [])
       (let [domain (domain.types/domain
-                    {:coord :test :data (make-bench-data 100)})]
-        (view/domain-apply*
-         :kindly
-         {}
-         {:domain domain})
+                    {:coord :test :data (make-bench-data 100)})
+            stderr-output (java.io.StringWriter.)]
+        (binding [*err* stderr-output]
+          (view/domain-apply*
+           :kindly
+           {}
+           {:domain domain}))
         (is (nil? (kindly/flush))
-            "Should produce no output when view-spec is missing")))))
+            "Should produce no kindly output")
+        (is (str/includes? (str stderr-output)
+                           "WARNING: domain-apply requires :view-spec option")
+            "Should warn on stderr when view-spec is missing")))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -1251,19 +1251,24 @@
           (finally
             (remove-tap f)))))
 
-    (testing "handles missing view-spec gracefully"
+    (testing "warns when view-spec is missing"
       (let [domain (domain.types/domain
                     {:coord :test :data (make-bench-data 100)})
             v (volatile! [])
-            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))
+            stderr-output (java.io.StringWriter.)]
         (try
           (add-tap f)
-          (view/domain-apply*
-           :portal
-           {}
-           {:domain domain})
+          (binding [*err* stderr-output]
+            (view/domain-apply*
+             :portal
+             {}
+             {:domain domain}))
           (portal/flush)
           (is (empty? @v)
-              "Should produce no output when view-spec is missing")
+              "Should produce no tap output")
+          (is (str/includes? (str stderr-output)
+                             "WARNING: domain-apply requires :view-spec option")
+              "Should warn on stderr when view-spec is missing")
           (finally
             (remove-tap f)))))))

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -3,7 +3,9 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
-   [criterium.collector.metrics]
+   [criterium.collect-plan :as collect-plan]
+   [criterium.collector.metrics :as metrics]
+   [criterium.domain.types :as domain.types]
    [criterium.test-data :as test-data]
    [criterium.view :as view]
    [criterium.viewer.portal :as portal])
@@ -1144,3 +1146,124 @@
           (is (contains? row :mean-ci-upper))
           (is (contains? row :p10))
           (is (contains? row :p90)))))))
+
+;;; Domain Apply View Tests
+
+(defn- make-bench-data
+  "Create minimal benchmark data with stats for testing domain-apply."
+  [mean-ns]
+  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+    {:samples {:type :criterium/collected-metrics-samples
+               :metrics-defs metrics-defs
+               :metric->values {[:elapsed-time] [mean-ns]}
+               :transform collect-plan/identity-transforms
+               :batch-size 1
+               :num-samples 1
+               :eval-count 1
+               :elapsed-time mean-ns}
+     :stats {:type :criterium/stats
+             :metrics-defs metrics-defs
+             :transform collect-plan/identity-transforms
+             :batch-size 1
+             :source-id :samples
+             :outliers-id nil
+             :stats {:elapsed-time {:mean mean-ns
+                                    :variance 1.0
+                                    :mean-plus-3sigma (+ mean-ns 3)
+                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :min-val mean-ns
+                                    :max-val (+ mean-ns 3)}}}}))
+
+(deftest domain-apply-portal-test
+  ;; Tests the portal viewer for domain-apply.
+  ;; Verifies that each run's coord is tapped with heading and view-spec applied.
+  (testing "domain-apply*"
+    (testing "taps coord heading and applies view-spec to each run"
+      (let [domain (-> (domain.types/domain)
+                       (domain.types/add-run {:n 100} (make-bench-data 100))
+                       (domain.types/add-run {:n 200} (make-bench-data 200)))
+            outputs (with-tap-out
+                      (view/domain-apply*
+                       :portal
+                       {:view-spec [:stats {}]}
+                       {:domain domain}))]
+        (is (>= (count outputs) 4)
+            "Expected at least 2 headings and 2 tables (one per run)")
+        (let [headings (filter #(and (vector? %) (= :b (first %))) outputs)]
+          (is (some #(str/includes? (second %) "{:n 100}") headings)
+              "Should tap heading with first coord")
+          (is (some #(str/includes? (second %) "{:n 200}") headings)
+              "Should tap heading with second coord"))))
+
+    (testing "formats keyword coord in heading"
+      (let [domain (domain.types/domain
+                    {:coord :baseline :data (make-bench-data 50)})
+            outputs (with-tap-out
+                      (view/domain-apply*
+                       :portal
+                       {:view-spec [:stats {}]}
+                       {:domain domain}))
+            headings (filter #(and (vector? %) (= :b (first %))) outputs)]
+        (is (some #(str/includes? (second %) ":baseline") headings)
+            "Should format keyword coord in heading")))
+
+    (testing "uses custom domain-id"
+      (let [domain (domain.types/domain
+                    {:coord {:impl :foo} :data (make-bench-data 150)})
+            outputs (with-tap-out
+                      (view/domain-apply*
+                       :portal
+                       {:domain-id :my-domain
+                        :view-spec [:stats {}]}
+                       {:my-domain domain}))
+            headings (filter #(and (vector? %) (= :b (first %))) outputs)]
+        (is (some #(str/includes? (second %) "{:impl :foo}") headings)
+            "Should use custom domain-id")))
+
+    (testing "handles empty domain gracefully"
+      (let [domain (domain.types/domain)
+            v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/domain-apply*
+           :portal
+           {:view-spec [:stats {}]}
+           {:domain domain})
+          (portal/flush)
+          (is (empty? @v)
+              "Should produce no output for empty domain")
+          (finally
+            (remove-tap f)))))
+
+    (testing "handles missing domain gracefully"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/domain-apply*
+           :portal
+           {:view-spec [:stats {}]}
+           {})
+          (portal/flush)
+          (is (empty? @v)
+              "Should produce no output when domain is missing")
+          (finally
+            (remove-tap f)))))
+
+    (testing "handles missing view-spec gracefully"
+      (let [domain (domain.types/domain
+                    {:coord :test :data (make-bench-data 100)})
+            v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/domain-apply*
+           :portal
+           {}
+           {:domain domain})
+          (portal/flush)
+          (is (empty? @v)
+              "Should produce no output when view-spec is missing")
+          (finally
+            (remove-tap f)))))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -646,13 +646,18 @@
         (is (str/blank? output)
             "Should produce no output when domain is missing")))
 
-    (testing "handles missing view-spec gracefully"
+    (testing "warns when view-spec is missing"
       (let [domain (domain.types/domain
                     {:coord :test :data (make-bench-data 100)})
-            output (with-out-str
-                     (view/domain-apply*
-                      :pprint
-                      {}
-                      {:domain domain}))]
-        (is (str/blank? output)
-            "Should produce no output when view-spec is missing")))))
+            stderr-output (java.io.StringWriter.)
+            stdout-output (with-out-str
+                            (binding [*err* stderr-output]
+                              (view/domain-apply*
+                               :pprint
+                               {}
+                               {:domain domain})))]
+        (is (str/blank? stdout-output)
+            "Should produce no stdout output")
+        (is (str/includes? (str stderr-output)
+                           "WARNING: domain-apply requires :view-spec option")
+            "Should warn on stderr when view-spec is missing")))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -5,6 +5,7 @@
    [criterium.analyse :as analyse]
    [criterium.collect-plan :as collect-plan]
    [criterium.collector.metrics]
+   [criterium.domain.types :as domain.types]
    [criterium.test-data :as test-data]
    [criterium.test-utils :refer [trimmed-lines]]
    [criterium.util.bootstrap :as bootstrap]
@@ -550,3 +551,108 @@
                   (->> data-map
                        bootstrap-fn
                        (view-fn :pprint))))))))))
+
+;;; Domain Apply View Tests
+
+(defn- make-bench-data
+  "Create minimal benchmark data with stats for testing domain-apply."
+  [mean-ns]
+  (let [metrics-defs (select-keys (criterium.collector.metrics/metrics) [:elapsed-time])]
+    {:samples {:type :criterium/collected-metrics-samples
+               :metrics-defs metrics-defs
+               :metric->values {[:elapsed-time] [mean-ns]}
+               :transform collect-plan/identity-transforms
+               :batch-size 1
+               :num-samples 1
+               :eval-count 1
+               :elapsed-time mean-ns}
+     :stats {:type :criterium/stats
+             :metrics-defs metrics-defs
+             :transform collect-plan/identity-transforms
+             :batch-size 1
+             :source-id :samples
+             :outliers-id nil
+             :stats {:elapsed-time {:mean mean-ns
+                                    :variance 1.0
+                                    :mean-plus-3sigma (+ mean-ns 3)
+                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :min-val mean-ns
+                                    :max-val (+ mean-ns 10)}}}}))
+
+(deftest domain-apply-pprint-test
+  ;; Tests the pprint viewer for domain-apply.
+  ;; Verifies that each run's coord is printed and the view-spec is applied.
+  (testing "domain-apply*"
+    (testing "prints coord and applies view-spec to each run"
+      (let [domain (-> (domain.types/domain)
+                       (domain.types/add-run {:n 100} (make-bench-data 100))
+                       (domain.types/add-run {:n 200} (make-bench-data 200)))
+            output (with-out-str
+                     (view/domain-apply*
+                      :pprint
+                      {:view-spec [:stats {}]}
+                      {:domain domain}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "{:n 100}") lines)
+            "Should print first coord")
+        (is (some #(str/includes? % "{:n 200}") lines)
+            "Should print second coord")
+        (is (some #(str/includes? % "100") lines)
+            "Should show stats for first run")
+        (is (some #(str/includes? % "200") lines)
+            "Should show stats for second run")))
+
+    (testing "formats coord with separator"
+      (let [domain (domain.types/domain
+                    {:coord :baseline :data (make-bench-data 50)})
+            output (with-out-str
+                     (view/domain-apply*
+                      :pprint
+                      {:view-spec [:stats {}]}
+                      {:domain domain}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "--- :baseline ---") lines)
+            "Should format coord with separators")))
+
+    (testing "uses custom domain-id"
+      (let [domain (domain.types/domain
+                    {:coord {:impl :foo} :data (make-bench-data 150)})
+            output (with-out-str
+                     (view/domain-apply*
+                      :pprint
+                      {:domain-id :my-domain
+                       :view-spec [:stats {}]}
+                      {:my-domain domain}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "{:impl :foo}") lines)
+            "Should use custom domain-id")))
+
+    (testing "handles empty domain gracefully"
+      (let [domain (domain.types/domain)
+            output (with-out-str
+                     (view/domain-apply*
+                      :pprint
+                      {:view-spec [:stats {}]}
+                      {:domain domain}))]
+        (is (str/blank? output)
+            "Should produce no output for empty domain")))
+
+    (testing "handles missing domain gracefully"
+      (let [output (with-out-str
+                     (view/domain-apply*
+                      :pprint
+                      {:view-spec [:stats {}]}
+                      {}))]
+        (is (str/blank? output)
+            "Should produce no output when domain is missing")))
+
+    (testing "handles missing view-spec gracefully"
+      (let [domain (domain.types/domain
+                    {:coord :test :data (make-bench-data 100)})
+            output (with-out-str
+                     (view/domain-apply*
+                      :pprint
+                      {}
+                      {:domain domain}))]
+        (is (str/blank? output)
+            "Should produce no output when view-spec is missing")))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -602,7 +602,7 @@
         (is (some #(str/includes? % "200") lines)
             "Should show stats for second run")))
 
-    (testing "formats coord with separator"
+    (testing "formats coord with Run: prefix"
       (let [domain (domain.types/domain
                     {:coord :baseline :data (make-bench-data 50)})
             output (with-out-str
@@ -611,8 +611,8 @@
                       {:view-spec [:stats {}]}
                       {:domain domain}))
             lines (trimmed-lines output)]
-        (is (some #(str/includes? % "--- :baseline ---") lines)
-            "Should format coord with separators")))
+        (is (some #(str/includes? % "Run: :baseline") lines)
+            "Should format coord with Run: prefix")))
 
     (testing "uses custom domain-id"
       (let [domain (domain.types/domain

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -1353,7 +1353,7 @@
         (is (some #(str/includes? % "200 ns") lines)
             "Should show stats for second run")))
 
-    (testing "formats coord with separator"
+    (testing "formats coord with Run: prefix"
       (let [domain (domain.types/domain
                     {:coord :baseline :data (make-bench-data 50)})
             output (with-out-str
@@ -1362,8 +1362,8 @@
                       {:view-spec [:stats {}]}
                       {:domain domain}))
             lines (trimmed-lines output)]
-        (is (some #(str/includes? % "--- :baseline ---") lines)
-            "Should format coord with separators")))
+        (is (some #(str/includes? % "Run: :baseline") lines)
+            "Should format coord with Run: prefix")))
 
     (testing "uses custom domain-id"
       (let [domain (domain.types/domain

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -1397,13 +1397,18 @@
         (is (str/blank? output)
             "Should produce no output when domain is missing")))
 
-    (testing "handles missing view-spec gracefully"
+    (testing "warns when view-spec is missing"
       (let [domain (domain.types/domain
                     {:coord :test :data (make-bench-data 100)})
-            output (with-out-str
-                     (view/domain-apply*
-                      :print
-                      {}
-                      {:domain domain}))]
-        (is (str/blank? output)
-            "Should produce no output when view-spec is missing")))))
+            stderr-output (java.io.StringWriter.)
+            stdout-output (with-out-str
+                            (binding [*err* stderr-output]
+                              (view/domain-apply*
+                               :print
+                               {}
+                               {:domain domain})))]
+        (is (str/blank? stdout-output)
+            "Should produce no stdout output")
+        (is (str/includes? (str stderr-output)
+                           "WARNING: domain-apply requires :view-spec option")
+            "Should warn on stderr when view-spec is missing")))))

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -6,6 +6,7 @@
    [criterium.analyse.metrics-samples :as metrics-samples]
    [criterium.collect-plan :as collect-plan]
    [criterium.collector.metrics :as metrics]
+   [criterium.domain.types :as domain.types]
    [criterium.test-data :as test-data]
    [criterium.test-utils :refer [trimmed-lines]]
    [criterium.util.bootstrap :as bootstrap]
@@ -1302,3 +1303,107 @@
                 "Mode locations: 50.0 ns, 150 ns"]
                lines))
         (is (str/includes? output "                                  Mode locations:"))))))
+
+;;; Domain Apply View Tests
+
+(defn- make-bench-data
+  "Create minimal benchmark data with stats for testing domain-apply."
+  [mean-ns]
+  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+    {:samples {:type :criterium/collected-metrics-samples
+               :metrics-defs metrics-defs
+               :metric->values {[:elapsed-time] [mean-ns]}
+               :transform collect-plan/identity-transforms
+               :batch-size 1
+               :num-samples 1
+               :eval-count 1
+               :elapsed-time mean-ns}
+     :stats {:type :criterium/stats
+             :metrics-defs metrics-defs
+             :transform collect-plan/identity-transforms
+             :batch-size 1
+             :source-id :samples
+             :outliers-id nil
+             :stats {:elapsed-time {:mean mean-ns
+                                    :variance 1.0
+                                    :mean-plus-3sigma (+ mean-ns 3)
+                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :min-val mean-ns}}}}))
+
+(deftest domain-apply-print-test
+  ;; Tests the print viewer for domain-apply.
+  ;; Verifies that each run's coord is printed and the view-spec is applied.
+  (testing "domain-apply*"
+    (testing "prints coord and applies view-spec to each run"
+      (let [domain (-> (domain.types/domain)
+                       (domain.types/add-run {:n 100} (make-bench-data 100))
+                       (domain.types/add-run {:n 200} (make-bench-data 200)))
+            output (with-out-str
+                     (view/domain-apply*
+                      :print
+                      {:view-spec [:stats {}]}
+                      {:domain domain}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "{:n 100}") lines)
+            "Should print first coord")
+        (is (some #(str/includes? % "{:n 200}") lines)
+            "Should print second coord")
+        (is (some #(str/includes? % "100 ns") lines)
+            "Should show stats for first run")
+        (is (some #(str/includes? % "200 ns") lines)
+            "Should show stats for second run")))
+
+    (testing "formats coord with separator"
+      (let [domain (domain.types/domain
+                    {:coord :baseline :data (make-bench-data 50)})
+            output (with-out-str
+                     (view/domain-apply*
+                      :print
+                      {:view-spec [:stats {}]}
+                      {:domain domain}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "--- :baseline ---") lines)
+            "Should format coord with separators")))
+
+    (testing "uses custom domain-id"
+      (let [domain (domain.types/domain
+                    {:coord {:impl :foo} :data (make-bench-data 150)})
+            output (with-out-str
+                     (view/domain-apply*
+                      :print
+                      {:domain-id :my-domain
+                       :view-spec [:stats {}]}
+                      {:my-domain domain}))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "{:impl :foo}") lines)
+            "Should use custom domain-id")))
+
+    (testing "handles empty domain gracefully"
+      (let [domain (domain.types/domain)
+            output (with-out-str
+                     (view/domain-apply*
+                      :print
+                      {:view-spec [:stats {}]}
+                      {:domain domain}))]
+        (is (str/blank? output)
+            "Should produce no output for empty domain")))
+
+    (testing "handles missing domain gracefully"
+      (let [output (with-out-str
+                     (view/domain-apply*
+                      :print
+                      {:view-spec [:stats {}]}
+                      {}))]
+        (is (str/blank? output)
+            "Should produce no output when domain is missing")))
+
+    (testing "handles missing view-spec gracefully"
+      (let [domain (domain.types/domain
+                    {:coord :test :data (make-bench-data 100)})
+            output (with-out-str
+                     (view/domain-apply*
+                      :print
+                      {}
+                      {:domain domain}))]
+        (is (str/blank? output)
+            "Should produce no output when view-spec is missing")))))


### PR DESCRIPTION
## Summary

Add `domain-apply` view that applies a benchmark view spec to every run in a domain, enabling users to see detailed benchmark results (e.g., histograms, statistics) for each point in the domain parameter space.

## Description

This enables inspecting individual benchmark runs within a domain rather than just aggregate comparisons - useful for verifying composite/aggregate results.

**Usage in domain plans:**
```clojure
{:analyse [[:domain-extract-fn {:with-error-bounds true}]]
 :view [[:domain-extract {}]
        [:domain-apply {:view-spec [:histogram {}]}]]}
```

## Changes

- Add `domain-apply` multimethod via `def-multi-view` in criterium.view
- Implement for `:print` viewer - prints `--- <coord> ---` separator, then applies view-spec
- Implement for `:pprint` viewer - delegates to print viewer
- Implement for `:portal` viewer - taps heading then applies view-spec
- Implement for `:kindly` viewer - accumulates output with headings
- Add warning when `domain-apply` called without `:view-spec` option

## Commits

- feat(view): add domain-apply multimethod
- feat(viewer): implement domain-apply for :print viewer
- feat(viewer): implement domain-apply for :portal viewer
- feat(viewer): implement domain-apply for :kindly viewer
- feat(viewer): implement domain-apply for :pprint viewer
- refactor(viewer): delegate pprint domain-apply to print viewer
- fix(viewer): standardize domain-apply heading format across viewers
- fix(viewer): add warning for invalid view-spec in kindly resolver
- fix(viewer): add warning for invalid view-spec in domain-apply