### PR TITLE
fix(viewer): improve single-point domain compare boxplot visibility for tight median CIs

### DIFF
--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -973,10 +973,11 @@
                 :color {:value "#333"}}}]})
 
 (defn- box-plot-ci-layer
-  "Build CI box layer for box plot (rect from ciLower to ciUpper)."
+  "Build CI box layer for box plot (rect from ciLower to ciUpper).
+  Includes stroke styling for visibility when CI is tight."
   [data]
   {:data {:values data}
-   :mark {:type "bar" :width 20}
+   :mark {:type "bar" :width 20 :stroke "#333" :strokeWidth 1}
    :encoding {:x {:field "impl" :type "nominal"}
               :y {:field "ciLower" :type "quantitative"}
               :y2 {:field "ciUpper"}

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -1285,7 +1285,11 @@
             ci-layer (second (:layer chart))]
         (is (= "bar" (get-in ci-layer [:mark :type])))
         (is (= "ciLower" (get-in ci-layer [:encoding :y :field])))
-        (is (= "ciUpper" (get-in ci-layer [:encoding :y2 :field])))))
+        (is (= "ciUpper" (get-in ci-layer [:encoding :y2 :field])))
+        (is (= "#333" (get-in ci-layer [:mark :stroke]))
+            "CI box should have stroke for visibility when CI is tight")
+        (is (= 1 (get-in ci-layer [:mark :strokeWidth]))
+            "CI box should have 1px stroke width")))
 
     (testing "includes median layer with tick mark"
       (let [spec (charts/single-point-box-chart-spec


### PR DESCRIPTION
## Summary

Improve visibility of the CI box in single-point domain compare boxplots when the median confidence interval is very tight relative to the whisker range.

**Problem:** When the confidence interval around the median is very tight, the box portion of the boxplot becomes nearly invisible - appearing as just a small gap in the whisker line.

**Solution:** Add a stroke/border to the CI box in `box-plot-ci-layer` to make it visually distinct from the whisker line.

## Changes

- Add `:stroke "#333"` and `:strokeWidth 1` to the bar mark in `box-plot-ci-layer`
- This affects both `single-point-box-chart-spec` and `comparison-box-chart-spec` since they share the `box-plot-layer` function

## Commits

- `fix(viewer): add stroke to CI box for tight median visibility`
- `test(viewer): add CI box stroke assertions`