### PR TITLE
perf(test): speed up test suite and eliminate boxed math warnings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,8 +15,8 @@ This is currently version 0.5.x (ALPHA) which represents a significant architect
 # Build agent and prepare dependencies (required once after checkout or deps.edn changes)
 make dev
 
-# Run tests with Kaocha
-clojure -M:kaocha:dev:test --reporter dots
+# Run tests with Kaocha (excludes slow tests)
+clojure -M:kaocha:dev:test :all --reporter dots
 
 # For agent development: Test with locally-built agent (macOS)
 clojure -M:kaocha:dev:test:with-agent-mac --reporter dots
@@ -26,6 +26,9 @@ clojure -M:kaocha:dev:test:with-agent-linux --reporter dots
 
 # Run tests for a namespace with Kaocha
 clojure -M:kaocha:dev:test --reporter dots --focus the.namespace.name
+
+# Run slow tests (marked with ^:slow metadata, skipped by default)
+clojure -M:kaocha:dev:test :slow --reporter dots
 
 # Run validation tests against R (requires R + Rserve installed)
 clojure -M:validation
@@ -234,7 +237,7 @@ Tests use Kaocha with the following structure:
 The test suite uses several strategies to maintain fast execution:
 
 **Slow Test Marking:**
-Tests that take significant time (>30s) are marked with `^:slow` metadata and excluded from default runs via `:skip-meta [:slow]` in `tests.edn`. Run slow tests explicitly with `--focus-meta :slow`.
+Tests that take significant time (>30s) are marked with `^:slow` metadata and excluded from default runs via `:skip-meta [:slow]` in `tests.edn`. Run slow tests explicitly using the `:slow` test suite: `clojure -M:kaocha:dev:test :slow`.
 
 **Minimal Iterations for API Tests:**
 Tests that validate API behavior (not benchmark accuracy) use reduced time limits:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,10 +19,10 @@ make dev
 clojure -M:kaocha:dev:test :all --reporter dots
 
 # For agent development: Test with locally-built agent (macOS)
-clojure -M:kaocha:dev:test:with-agent-mac --reporter dots
+clojure -M:kaocha:dev:test:with-agent-mac :all --reporter dots
 
 # For agent development: Test with locally-built agent (Linux)
-clojure -M:kaocha:dev:test:with-agent-linux --reporter dots
+clojure -M:kaocha:dev:test:with-agent-linux :all --reporter dots
 
 # Run tests for a namespace with Kaocha
 clojure -M:kaocha:dev:test --reporter dots --focus the.namespace.name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,12 +106,25 @@ jobs:
         set -x
         if [[ "${{ matrix.with-agent }}" == "true" ]]; then
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            clojure -M:kaocha:dev:test:with-agent-linux --reporter dots
+            clojure -M:kaocha:dev:test:with-agent-linux :all --reporter dots
           else
-            clojure -M:kaocha:dev:test:with-agent-mac --reporter dots
+            clojure -M:kaocha:dev:test:with-agent-mac :all --reporter dots
           fi
         else
-          clojure -M:kaocha:dev:test --reporter dots
+          clojure -M:kaocha:dev:test :all --reporter dots
+        fi
+
+    - name: slow tests
+      run: |
+        set -x
+        if [[ "${{ matrix.with-agent }}" == "true" ]]; then
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            clojure -M:kaocha:dev:test:with-agent-linux :slow --reporter dots
+          else
+            clojure -M:kaocha:dev:test:with-agent-mac :slow --reporter dots
+          fi
+        else
+          clojure -M:kaocha:dev:test :slow --reporter dots
         fi
 
     - name: Install R (Ubuntu)

--- a/bases/agent/test/criterium/agent_test.clj
+++ b/bases/agent/test/criterium/agent_test.clj
@@ -246,12 +246,12 @@
 
 (defn simple-computation
   "A simple function to trace."
-  [x]
+  ^long [^long x]
   (+ x 1))
 
 (defn nested-computation
   "A function that calls other functions."
-  [x]
+  ^long [^long x]
   (simple-computation (simple-computation x)))
 
 (deftest with-call-tracing-test

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -490,7 +490,8 @@
 (defn- compute-information-criteria
   "Compute AIC, BIC, and AICc for a fitted model."
   [dist n log-likelihood]
-  (let [k (get distribution-num-params dist 2)]
+  (let [k (long (get distribution-num-params dist 2))
+        n (long n)]
     {:aic (si/aic k log-likelihood)
      :bic (si/bic k n log-likelihood)
      :aicc (when (> n (inc k))
@@ -502,6 +503,8 @@
   [dist samples {:keys [n-bootstrap alpha]
                  :or {n-bootstrap 200 alpha 0.05}}]
   (let [n (count samples)
+        n-bootstrap (long n-bootstrap)
+        alpha (double alpha)
         bootstrap-size (max 50 (long (* n 0.8)))
         quantiles [(/ alpha 2.0) (- 1.0 (/ alpha 2.0))]
         ;; Bootstrap the MLE fitting
@@ -509,7 +512,7 @@
         rng-factory random/well-rng-1024a
         ;; Run bootstrap
         bootstrap-fits
-        (loop [i 0
+        (loop [i (long 0)
                results []]
           (if (>= i n-bootstrap)
             results
@@ -538,9 +541,9 @@
                 (when (>= n-boot 10)
                   [param-key
                    {:point-estimate (get-in original-fit [:params param-key])
-                    :ci-lower (nth sorted-vals (long (* n-boot (first quantiles))))
+                    :ci-lower (nth sorted-vals (long (* n-boot (double (first quantiles)))))
                     :ci-upper (nth sorted-vals (min (dec n-boot)
-                                                    (long (* n-boot (second quantiles)))))}])))))))
+                                                    (long (* n-boot (double (second quantiles))))))}])))))))
 
 (defn- fit-distributions-for-metric
   "Fit all applicable distributions to samples for a single metric.
@@ -589,7 +592,8 @@
         (into {}
               (for [[dist result] fit-results]
                 [dist (if (and (:aic result) best-aic)
-                        (assoc result :delta-aic (- (:aic result) best-aic))
+                        (assoc result :delta-aic (- (double (:aic result))
+                                                    (double best-aic)))
                         result)]))
         ;; Bootstrap parameter CIs for best model only
         parameter-cis (when best-model

--- a/bases/criterium/src/criterium/viewer/call_graph.clj
+++ b/bases/criterium/src/criterium/viewer/call_graph.clj
@@ -103,7 +103,7 @@
 (defn- format-location
   "Format file:line location, or return nil if not available."
   [file line]
-  (when (and file (pos? (or line 0)))
+  (when (and file (pos? (long (or line 0))))
     (str file ":" line)))
 
 (defn- clojure-invoke-method?
@@ -117,7 +117,7 @@
   [class-name]
   (when class-name
     (when-let [idx (str/last-index-of class-name "$")]
-      (-> (subs class-name (inc idx))
+      (-> (subs class-name (inc (long idx)))
           (str/replace "_" "-")
           (str/replace "BANG" "!")
           (str/replace "QMARK" "?")
@@ -155,7 +155,7 @@
           (let [display-name (format-method-name class method)
                 location (or (format-location file line) "")]
             (println (format "%-4d %-40s %10d  %s"
-                             (inc idx)
+                             (inc (long idx))
                              (if (> (count display-name) 40)
                                (str (subs display-name 0 37) "...")
                                display-name)

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -1554,18 +1554,17 @@
         (>= p 1.0) Double/POSITIVE_INFINITY
         :else
         ;; Newton-Raphson: x_{n+1} = x_n - (F(x_n) - p) / f(x_n)
-        (let [max-iter 50
-              tol 1e-10]
-          (loop [x (max (initial-guess p) 1e-10)
-                 iter 0]
+        (let [max-iter (long 50)
+              tol (double 1e-10)]
+          (loop [x (double (Math/max (initial-guess p) 1e-10))
+                 iter (long 0)]
             (if (>= iter max-iter)
               x
-              (let [fx (cdf-fn x)
-                    fpx (pdf-fn x)]
+              (let [fx (double (cdf-fn x))
+                    fpx (double (pdf-fn x))]
                 (if (< fpx 1e-100)
                   x
-                  (let [x-new (- x (/ (- fx p) fpx))
-                        x-new (max x-new 1e-10)]
+                  (let [x-new (double (Math/max (- x (/ (- fx p) fpx)) 1e-10))]
                     (if (< (Math/abs (- x-new x)) (* tol x))
                       x-new
                       (recur x-new (inc iter)))))))))))))
@@ -1582,18 +1581,17 @@
         (>= p 1.0) Double/POSITIVE_INFINITY
         :else
         ;; Newton-Raphson with mu as initial guess
-        (let [max-iter 50
-              tol 1e-10]
-          (loop [x mu
-                 iter 0]
+        (let [max-iter (long 50)
+              tol (double 1e-10)]
+          (loop [x (double mu)
+                 iter (long 0)]
             (if (>= iter max-iter)
               x
-              (let [fx (cdf-fn x)
-                    fpx (pdf-fn x)]
+              (let [fx (double (cdf-fn x))
+                    fpx (double (pdf-fn x))]
                 (if (< fpx 1e-100)
                   x
-                  (let [x-new (- x (/ (- fx p) fpx))
-                        x-new (max x-new 1e-10)]
+                  (let [x-new (double (Math/max (- x (/ (- fx p) fpx)) 1e-10))]
                     (if (< (Math/abs (- x-new x)) (* tol x))
                       x-new
                       (recur x-new (inc iter)))))))))))))
@@ -1641,7 +1639,7 @@
           is-best? (= dist (:best-model fit-result))
           data (->> grid
                     (mapv (fn [x]
-                            (let [p (pdf-fn x)
+                            (let [p (double (pdf-fn x))
                                   ;; Scale by Jacobian if KDE is on log-transformed data
                                   ;; Converts density-per-original-unit to density-per-log-unit
                                   scaled-p (if scale-by-jacobian?
@@ -1832,7 +1830,7 @@
         ;; For step function, we need points at each sample value
         data (mapv (fn [i x]
                      {"x" (util/transform-sample-> x transforms)
-                      "cdf" (/ (double (inc i)) n)})
+                      "cdf" (/ (double (inc (long i))) n)})
                    (range n)
                    sorted-samples)]
     {:data {:values data}
@@ -1945,10 +1943,10 @@
               ;; Extend range slightly for better visualization
               range-val (when (and min-val max-val)
                           (- (double max-val) (double min-val)))
-              grid-min (when range-val (- (double min-val) (* 0.05 range-val)))
-              grid-max (when range-val (+ (double max-val) (* 0.05 range-val)))
+              grid-min (when range-val (- (double min-val) (* 0.05 (double range-val))))
+              grid-max (when range-val (+ (double max-val) (* 0.05 (double range-val))))
               grid (when (and grid-min grid-max)
-                     (let [step (/ (- grid-max grid-min) 100.0)]
+                     (let [step (/ (- (double grid-max) (double grid-min)) 100.0)]
                        (vec (range grid-min grid-max step))))]
           (when (seq samples)
             (merge
@@ -1985,7 +1983,7 @@
         n (count sorted-samples)]
     (->> (mapv (fn [i x]
                  (let [;; Hazen plotting position: (i - 0.5) / n
-                       p (/ (- (double (inc i)) 0.5) (double n))
+                       p (/ (- (double (inc (long i))) 0.5) (double n))
                        theoretical (quantile-fn p)]
                    {"theoretical" (util/transform-sample-> theoretical transforms)
                     "observed" (util/transform-sample-> x transforms)}))
@@ -2155,9 +2153,9 @@
         samples-transforms (util/get-transforms data-map samples-id)
         ;; Subplot dimensions - smaller since we have multiple
         subplot-width (or (:subplot-width chart-options)
-                          (quot (or (:width chart-options) 400) 2))
+                          (quot (long (or (:width chart-options) 400)) 2))
         subplot-height (or (:subplot-height chart-options)
-                           (quot (or (:height chart-options) 300) 2))
+                           (quot (long (or (:height chart-options) 300)) 2))
         subplot-options {:width subplot-width :height subplot-height}]
     {:data {:values []}
      :vconcat
@@ -2303,7 +2301,7 @@
   [class-name]
   (when class-name
     (when-let [idx (str/last-index-of class-name "$")]
-      (-> (subs class-name (inc idx))
+      (-> (subs class-name (inc (long idx)))
           (str/replace "_" "-")
           (str/replace "BANG" "!")
           (str/replace "QMARK" "?")
@@ -2319,7 +2317,7 @@
   [class-name]
   (when class-name
     (if-let [idx (str/last-index-of class-name ".")]
-      (subs class-name (inc idx))
+      (subs class-name (inc (long idx)))
       class-name)))
 
 (defn- call-tree-display-name
@@ -2388,9 +2386,9 @@
   (let [width (or (:width opts) 700)
         height (or (:height opts) 500)
         flat-data (when call-tree (vec (flatten-call-tree-node call-tree)))
-        max-calls (if (seq flat-data)
-                    (apply max (map :call-count flat-data))
-                    1)]
+        max-calls (long (if (seq flat-data)
+                          (apply max (map :call-count flat-data))
+                          1))]
     {:$schema "https://vega.github.io/schema/vega/v5.json"
      :width width
      :height height
@@ -2492,18 +2490,20 @@
     - Color by class for visual grouping
     - tooltip showing method, call count, percentage"
   [call-tree total-calls opts]
-  (let [width (or (:width opts) 700)
-        height (or (:height opts) 400)
-        row-height 24
-        total-calls (double (if (pos? total-calls) total-calls 1))]
+  (let [width (long (or (:width opts) 700))
+        height (long (or (:height opts) 400))
+        width-d (double width)
+        height-d (double height)
+        row-height (double 24)
+        total-calls-d (double (if (pos? (long total-calls)) total-calls 1))]
     (letfn [(compute-flame-data
-              [node x0 node-width depth]
+              [node ^double x0 ^double node-width ^long depth]
               (when node
-                (let [call-count (or (:call-count node) 0)
+                (let [call-count (long (or (:call-count node) 0))
                       class-name (or (:class node) "<unknown>")
                       method (or (:method node) "<unknown>")
                       display-name (call-tree-display-name class-name method)
-                      percentage (* 100.0 (/ (double call-count) total-calls))
+                      percentage (* 100.0 (/ (double call-count) total-calls-d))
                       x1 (+ x0 node-width)
                       node-record {:name display-name
                                    :class class-name
@@ -2515,8 +2515,8 @@
                                    :depth depth
                                    :x0 x0
                                    :x1 x1
-                                   :y0 (* depth row-height)
-                                   :y1 (* (inc depth) row-height)}
+                                   :y0 (* (double depth) row-height)
+                                   :y1 (* (double (inc depth)) row-height)}
                       children (:children node)
                       ;; Children are sized proportionally within parent's width
                       children-total (double
@@ -2541,11 +2541,11 @@
                       (cons node-record child-data))
                     [node-record]))))]
       (let [flame-data (when call-tree
-                         (vec (compute-flame-data call-tree 0 width 0)))
-            max-depth (if (seq flame-data)
-                        (apply max (map :depth flame-data))
-                        0)
-            computed-height (max height (* (inc max-depth) row-height 1.2))]
+                         (vec (compute-flame-data call-tree 0.0 width-d 0)))
+            max-depth (long (if (seq flame-data)
+                              (apply max (map :depth flame-data))
+                              0))
+            computed-height (long (Math/max height-d (* (double (inc max-depth)) row-height 1.2)))]
         {:$schema "https://vega.github.io/schema/vega/v5.json"
          :width width
          :height computed-height
@@ -2633,7 +2633,7 @@
         height (or (:height opts) (+ 50 (* n bar-height)))
         data (mapv (fn [{:keys [class method file line total-calls]}]
                      (let [display-name (most-called-display-name class method)
-                           location (if (and file (pos? (or line 0)))
+                           location (if (and file (pos? (long (or line 0))))
                                       (str file ":" line)
                                       "")]
                        {"method" display-name

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -1556,7 +1556,7 @@
         ;; Newton-Raphson: x_{n+1} = x_n - (F(x_n) - p) / f(x_n)
         (let [max-iter (long 50)
               tol (double 1e-10)]
-          (loop [x (double (Math/max (initial-guess p) 1e-10))
+          (loop [x (Math/max (double (initial-guess p)) 1e-10)
                  iter (long 0)]
             (if (>= iter max-iter)
               x

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -2496,6 +2496,7 @@
         height-d (double height)
         row-height (double 24)
         total-calls-d (double (if (pos? (long total-calls)) total-calls 1))]
+    ;; Type hints eliminate boxed math warnings in this tight loop
     (letfn [(compute-flame-data
               [node ^double x0 ^double node-width ^long depth]
               (when node

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -45,7 +45,7 @@
                             :class-loader])]
         (is (= 1 v))))))
 
-(deftest kindly-viewer-integration-test
+(deftest ^:slow kindly-viewer-integration-test
   ;; Integration test for :kindly viewer with actual benchmark execution.
   ;; Verifies that :viewer :kindly produces Kindly-annotated output
   ;; suitable for Clay notebook rendering.

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -8,7 +8,7 @@
    [criterium.bench.impl :as bench-impl]
    [criterium.viewer.kindly :as kindly]))
 
-(deftest bench-test
+(deftest ^:slow bench-test
   (testing "bench"
     (bench-impl/last-bench! nil)
     (is (nil? (bench/last-bench)))
@@ -175,7 +175,7 @@
 ;; Validates integration of allocation tracing into the bench pipeline.
 ;; Agent may or may not be attached in test environment.
 
-(deftest with-allocation-trace-test
+(deftest ^:slow with-allocation-trace-test
   (testing ":with-allocation-trace option"
     (testing "returns expression value"
       (let [result (with-out-str
@@ -239,7 +239,7 @@
     (let [config (bench-config/config-map {:with-allocation-trace true})]
       (is (true? (:with-allocation-trace config))))))
 
-(deftest knuth-histogram-bench-plan-test
+(deftest ^:slow knuth-histogram-bench-plan-test
   ;; Integration test verifying the knuth-histogram bench plan produces
   ;; correct histogram output with Bayesian optimal binning.
   (testing "knuth-histogram bench plan"
@@ -274,7 +274,7 @@
           (is (re-find #"Histogram" out)
               "stdout should contain histogram output"))))))
 
-(deftest default-with-warmup-kde-modes-test
+(deftest ^:slow default-with-warmup-kde-modes-test
   ;; Integration test verifying that default-with-warmup includes KDE and modes
   ;; analysis, and that multimodal-warning view is present in the pipeline.
   ;; This test validates the full pipeline from bench to view output.

--- a/bases/criterium/test/criterium/collect_plan_test.clj
+++ b/bases/criterium/test/criterium/collect_plan_test.clj
@@ -28,7 +28,7 @@
       (is (every? vector? (vals (:metric->values (:samples data-map)))))
       (is (= 1 (:expr-value (:samples data-map)))))))
 
-(deftest full-test
+(deftest ^:slow full-test
   (testing "full sampling"
     (let [measured  (measured/measured
                      (fn [] [])

--- a/bases/criterium/test/criterium/core_test.clj
+++ b/bases/criterium/test/criterium/core_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer [deftest is]]
    [criterium.core :as core]))
 
-(deftest bench-test
+(deftest ^:slow bench-test
   (let [s (with-out-str
             (core/bench 1 :target-execution-time 1))]
     (is s)))

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -1571,12 +1571,12 @@
           (is (contains? foo-value :ci-upper) "should have :ci-upper from bootstrap CI")
           ;; Verify values are approximately correct
           ;; (p50 = mean, p10 = 0.9*mean, p90 = 1.1*mean)
-          (is (< (Math/abs (- (:median foo-value) 100.0)) 0.01) "foo median ~100")
-          (is (< (Math/abs (- (:p10 foo-value) 90.0)) 0.01) "foo p10 ~90")
-          (is (< (Math/abs (- (:p90 foo-value) 110.0)) 0.01) "foo p90 ~110")
-          (is (< (Math/abs (- (:median bar-value) 200.0)) 0.01) "bar median ~200")
-          (is (< (Math/abs (- (:p10 bar-value) 180.0)) 0.01) "bar p10 ~180")
-          (is (< (Math/abs (- (:p90 bar-value) 220.0)) 0.01) "bar p90 ~220")))
+          (is (< (Math/abs (- (double (:median foo-value)) 100.0)) 0.01) "foo median ~100")
+          (is (< (Math/abs (- (double (:p10 foo-value)) 90.0)) 0.01) "foo p10 ~90")
+          (is (< (Math/abs (- (double (:p90 foo-value)) 110.0)) 0.01) "foo p90 ~110")
+          (is (< (Math/abs (- (double (:median bar-value)) 200.0)) 0.01) "bar median ~200")
+          (is (< (Math/abs (- (double (:p10 bar-value)) 180.0)) 0.01) "bar p10 ~180")
+          (is (< (Math/abs (- (double (:p90 bar-value)) 220.0)) 0.01) "bar p90 ~220")))
       (testing "falls back to basic value when bootstrap stats not present"
         (let [d (domain/domain
                  {:coord {:n 100 :impl :foo}

--- a/bases/criterium/test/criterium/domain/test_util.clj
+++ b/bases/criterium/test/criterium/domain/test_util.clj
@@ -43,9 +43,10 @@
   "Create a BCa estimate structure for a given point value.
   Derives CI from +/- 5% of the point value."
   [point-val]
-  {:point-estimate point-val
-   :estimate-quantiles [{:value (* point-val 0.95) :alpha 0.025}
-                        {:value (* point-val 1.05) :alpha 0.975}]})
+  (let [pv (double point-val)]
+    {:point-estimate pv
+     :estimate-quantiles [{:value (* pv 0.95) :alpha 0.025}
+                          {:value (* pv 1.05) :alpha 0.975}]}))
 
 (defn mock-bench-result-with-bootstrap
   "Create a mock bench result with bootstrap stats for box plot testing.
@@ -60,7 +61,7 @@
         bootstrap-data
         (into {}
               (map (fn [[metric-id values]]
-                     (let [mean-val (:mean values 100.0)
+                     (let [mean-val (double (:mean values 100.0))
                            p10 (* mean-val 0.9)
                            p50 mean-val
                            p90 (* mean-val 1.1)]

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -492,7 +492,10 @@
 
 (defn- double-it ^long [^long x] (* x 2))
 (defn- triple-it ^long [^long x] (* x 3))
-(defn public-add "A public function for qualified symbol testing." [a b] (+ a b))
+(defn public-add
+  "A public function for qualified symbol testing."
+  ^long [^long a ^long b]
+  (+ a b))
 
 (deftest local-operator-ac4-test
   ;; AC4: Nested local function calls.

--- a/bases/criterium/test/criterium/sampled_fn_test.clj
+++ b/bases/criterium/test/criterium/sampled_fn_test.clj
@@ -11,7 +11,7 @@
   []
   (jvm/wait 10000))
 
-(deftest sampled-fn-test
+(deftest ^:slow sampled-fn-test
   (with-redefs
    [ten-micros (sampled-fn/sample-fn
                 ten-micros

--- a/bases/criterium/test/criterium/test_utils.clj
+++ b/bases/criterium/test/criterium/test_utils.clj
@@ -79,7 +79,7 @@
       (is (nil? (compare-doubles 0.3 x)))))
 
   (testing "ulp-based failure"
-    (let [x (+ 0.1 (* 3 (ulp 0.1)))]
+    (let [x (+ 0.1 (* 3.0 (double (ulp 0.1))))]
       (is (compare-doubles 0.3 x))))
 
   (testing "relative tolerance"
@@ -166,8 +166,8 @@
          batch-sums   (mapv #(reduce + %) batches)
          ;; Expected variance for sum of batch-size independent samples
          ;; Var(sum) = batch-size * expected-individual-variance
-         expected-var (* batch-size expected-individual-variance)
-         observed-var (stats/variance batch-sums)]
+         expected-var (* (double batch-size) expected-individual-variance)
+         observed-var (double (stats/variance batch-sums))]
      (/ observed-var expected-var))))
 
 (defn variance-ratio-uniform

--- a/bases/criterium/test/criterium/util/bootstrap_test.clj
+++ b/bases/criterium/test/criterium/util/bootstrap_test.clj
@@ -216,7 +216,7 @@
                         vec)]
     (mapv #(* (double %) batch-size) values)))
 
-(deftest analyse-bootstrap-test
+(deftest ^:slow analyse-bootstrap-test
   ;; Tests that bootstrap-stats stores raw values and transforms are
   ;; applied when viewing via the source-id chain.
   (let [batch-size     100

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -158,13 +158,13 @@
   (testing "dct-ii"
     (testing "first coefficient equals sum of inputs"
       (let [data (double-array [1.0 2.0 3.0 4.0])
-            result (kde/dct-ii data)]
+            ^doubles result (kde/dct-ii data)]
         (is (< (Math/abs (- (aget result 0) 10.0)) 0.001)
             "DC component should equal sum of inputs")))
 
     (testing "returns array of same size"
       (let [data (double-array [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0])
-            result (kde/dct-ii data)]
+            ^doubles result (kde/dct-ii data)]
         (is (= 8 (alength result)))))))
 
 (deftest linear-bin-test
@@ -173,7 +173,7 @@
     (testing "weights sum to 1"
       (let [data          [1.0 2.0 3.0 4.0 5.0]
             grid          (double-array [0.0 2.0 4.0 6.0])
-            weights       (kde/linear-bin data grid)
+            ^doubles weights (kde/linear-bin data grid)
             ^double total (reduce + weights)]
         (is (< (Math/abs (- total 1.0)) 0.0001)
             "weights should sum to 1")))
@@ -181,7 +181,7 @@
     (testing "data at grid point goes to that bin"
       (let [data    [2.0]
             grid    (double-array [0.0 2.0 4.0 6.0])
-            weights (kde/linear-bin data grid)]
+            ^doubles weights (kde/linear-bin data grid)]
         (is (> (aget weights 1) 0.9)
             "weight should be concentrated at matching grid point")))))
 

--- a/bases/criterium/test/criterium/util/probability_test.clj
+++ b/bases/criterium/test/criterium/util/probability_test.clj
@@ -8,8 +8,8 @@
 (deftest normal-quantile-test
   (is (pos? (probability/normal-quantile 0.5001)))
   (is (neg? (probability/normal-quantile 0.4999)))
-  (is (< 2e-8 (- (probability/normal-quantile 0.999)
-                 (probability/normal-quantile 0.001))))
+  (is (< 2e-8 (- (double (probability/normal-quantile 0.999))
+                 (double (probability/normal-quantile 0.001)))))
   (let [max-error 1.0e-7]
     (is (= 0.0 (probability/normal-quantile 0.5)))
     (is (test-max-error

--- a/bases/criterium/test/criterium/util/sampled_stats_test.clj
+++ b/bases/criterium/test/criterium/util/sampled_stats_test.clj
@@ -92,8 +92,9 @@
 
 (deftest stats-for-test-property-1
   ;; Uses a fixed seed for deterministic random values.
-  (let [batch-size 5000
-        num-samples 200
+  ;; Reduced from 5000*200=1M to 1000*100=100K samples for faster tests.
+  (let [batch-size 1000
+        num-samples 100
         values (take
                 (* batch-size num-samples)
                 (ziggurat/random-normal-zig

--- a/bases/criterium/test/criterium/util/sampled_stats_test.clj
+++ b/bases/criterium/test/criterium/util/sampled_stats_test.clj
@@ -105,10 +105,10 @@
                samples {:quantiles [0.05 0.95]})
         mean-hat (-> stats :mean)
         variance-hat (-> stats :variance)
-        mean (stats/mean values)
-        variance (stats/variance values)]
-    (test-max-error (* mean batch-size) mean-hat 1e-5)
-    (is (approx= (* variance batch-size) variance-hat 2e-1))))
+        mean (double (stats/mean values))
+        variance (double (stats/variance values))]
+    (test-max-error (* mean (double batch-size)) mean-hat 1e-5)
+    (is (approx= (* variance (double batch-size)) variance-hat 2e-1))))
 
 (defn random-values
   "Return a sequence of values with the given mean an standard deviation."
@@ -173,8 +173,8 @@
                {:quantiles [0.05 0.95]})
         mean-hat (-> stats :mean)
         variance-hat (-> stats :variance)
-        mean (stats/mean values)
-        variance (* (stats/variance values) 1)]
+        mean (double (stats/mean values))
+        variance (double (stats/variance values))]
     {:mean mean
      :variance variance
      :mean-hat mean-hat
@@ -187,16 +187,19 @@
    [^long batch-size (gen-bounded 10 1000)
     random-seed gen/nat]
    (let [num-samples    (long (quot 20000 batch-size))
-         mean           10
-         sigma          3
-         {:keys [^double mean ^double variance mean-hat variance-hat]}
-         (stats-values batch-size num-samples random-seed mean sigma)
-         mean-error     (abs-error (* batch-size mean) mean-hat)
-         variance-error (abs-error (* batch-size variance) variance-hat)
+         mean-arg       10.0
+         sigma          3.0
+         {:keys [mean variance mean-hat variance-hat]}
+         (stats-values batch-size num-samples random-seed mean-arg sigma)
+         mean           (double mean)
+         variance       (double variance)
+         batch-size-d   (double batch-size)
+         mean-error     (double (abs-error (* batch-size-d mean) mean-hat))
+         variance-error (double (abs-error (* batch-size-d variance) variance-hat))
          mean-tol       (max (* sigma 1e-1) 1e-2)
           ;; Use 3-sigma tolerance based on sample variance standard error:
           ;; SE(variance) ≈ variance * sqrt(2/(n-1))
-         variance-se    (* batch-size
+         variance-se    (* batch-size-d
                            variance
                            (Math/sqrt (/ 2.0 (dec num-samples))))
          variance-tol   (* 3.0 variance-se)]

--- a/bases/criterium/test/criterium/util/sampled_stats_test.clj
+++ b/bases/criterium/test/criterium/util/sampled_stats_test.clj
@@ -181,7 +181,7 @@
      :variance-hat variance-hat
      :samples samples}))
 
-(defspec stats-for-test-property
+(defspec ^:slow stats-for-test-property
   {:num-tests 10}
   (prop/for-all
    [^long batch-size (gen-bounded 10 1000)

--- a/bases/criterium/test/criterium/util/stats_test.clj
+++ b/bases/criterium/test/criterium/util/stats_test.clj
@@ -119,8 +119,8 @@
     (testing "is symmetric under reflection"
       (let [data     [1 2 3 4 5 10 15 20]
             reflected (mapv (fn [^long x] (- x)) (reverse data))
-            mc-orig (stats/medcouple (vec (sort data)))
-            mc-ref (stats/medcouple (vec (sort reflected)))]
+            mc-orig (double (stats/medcouple (vec (sort data))))
+            mc-ref (double (stats/medcouple (vec (sort reflected))))]
         (is (< (Math/abs (+ mc-orig mc-ref)) 1e-10)
             "mc(-x) should equal -mc(x)")))
 
@@ -128,9 +128,9 @@
       (let [data       [1 2 3 4 5 10 15 20]
             shifted    (mapv (fn [^long x] (+ x 100)) data)
             scaled     (mapv (fn [^long x] (* x 10)) data)
-            mc-orig (stats/medcouple (vec (sort data)))
-            mc-shifted (stats/medcouple (vec (sort shifted)))
-            mc-scaled (stats/medcouple (vec (sort scaled)))]
+            mc-orig (double (stats/medcouple (vec (sort data))))
+            mc-shifted (double (stats/medcouple (vec (sort shifted))))
+            mc-scaled (double (stats/medcouple (vec (sort scaled))))]
         (is (< (Math/abs (- mc-orig mc-shifted)) 1e-10)
             "Medcouple should be location invariant")
         (is (< (Math/abs (- mc-orig mc-scaled)) 1e-10)
@@ -142,7 +142,7 @@
       (prop/for-all
        [data (gen/vector gen/small-integer 3 100)]
        (let [sorted (vec (sort data))
-             mc     (stats/medcouple sorted)]
+             mc     (double (stats/medcouple sorted))]
          (and (<= -1.0 mc) (<= mc 1.0)))))))
 
 ;;; Adjusted boxplot outlier threshold tests

--- a/bases/criterium/test/criterium/util/t_digest/merging_digest_test.clj
+++ b/bases/criterium/test/criterium/util/t_digest/merging_digest_test.clj
@@ -180,7 +180,7 @@
                       0.99 (probability/normal-quantile 0.99)}
           digest     (md/compress digest)]
       (doseq [[q expected-val] expected-q]
-        (let [actual (md/quantile digest q)
+        (let [actual (double (md/quantile digest q))
               error  (Math/abs (/ (- actual (double expected-val)) std-dev))]
           (testing (format "quantile %.2f" q)
             (is (< error 0.2)
@@ -204,7 +204,7 @@
                         2.0   (probability/normal-cdf 2.0)}
           digest       (md/compress digest)]
       (doseq [[z expected-val] expected-cdf]
-        (let [actual (md/cdf digest z)
+        (let [actual (double (md/cdf digest z))
               error  (Math/abs (/ (- actual (double expected-val)) std-dev))]
           (testing (format "cdf %.2f" z)
             (is (< error 0.01)
@@ -220,7 +220,7 @@
           digest  (md/compress digest)]
       ;; NOTE we should calculate bounds for these using the t and chi-squared
       ;; distributions.
-      (is (> 0.05 (Math/abs (md/mean digest))))
+      (is (> 0.05 (Math/abs (double (md/mean digest)))))
       (is (approx= 1.0 (md/variance digest) 0.1)))))
 
 (deftest basic-operations
@@ -344,8 +344,8 @@
                  ^double dx (gen/double*
                              {:min       0.0   :max  100.0
                               :infinite? false :NaN? false})]
-                (let [cdf-x    (md/cdf d x)
-                      cdf-x+dx (md/cdf d (+ x dx))]
+                (let [cdf-x    (double (md/cdf d x))
+                      cdf-x+dx (double (md/cdf d (+ x dx)))]
                   (when-not (>= cdf-x+dx cdf-x)
                     (prn :x x :dx dx :cdf-x+dx cdf-x+dx :cdf-x cdf-x))
                   (>= cdf-x+dx cdf-x))))

--- a/bases/criterium/test/criterium/util/t_digest/merging_digest_test.clj
+++ b/bases/criterium/test/criterium/util/t_digest/merging_digest_test.clj
@@ -188,8 +188,9 @@
                         error q expected-val actual))))))))
 
 (deftest normal-distribution-cdf-test
+  ;; Reduced from 200K to 50K samples for faster tests while maintaining accuracy.
   (testing "accuracy with normal distribution"
-    (let [n            200000
+    (let [n            50000
           std-dev      1.0
           samples      (take n (ziggurat/random-normal-zig
                                 (well/well-rng-1024a)))

--- a/bases/criterium/test/criterium/util/t_digest/scale_test.clj
+++ b/bases/criterium/test/criterium/util/t_digest/scale_test.clj
@@ -58,8 +58,8 @@
   [scale]
   (prop/for-all [^double q      (gen-double {:min 1e-15 :max (- 0.5 (ulp 0.5))})
                  norm   (gen-double {:min 1.0 :max 1000.0})]
-                (let [k  (scale/k scale q norm)
-                      k' (- (scale/k scale (- 1.0 q) norm))]
+                (let [k  (double (scale/k scale q norm))
+                      k' (- (double (scale/k scale (- 1.0 q) norm)))]
       ;; k1 should be symmetric around q=0.5
                   (approx= k k' 1e-4 5))))
 
@@ -67,9 +67,9 @@
   [scale]
   (prop/for-all [^double q      (gen-double {:min 0.0 :max 0.5})
                  norm   (gen-double {:min 1.0 :max 1000.0})]
-                (let [k (scale/k scale q norm)]
+                (let [k (double (scale/k scale q norm))]
       ;; k1 should increase monotonically with q
-                  (> (scale/k scale (+ q 0.1) norm) k))))
+                  (> (double (scale/k scale (+ q 0.1) norm)) k))))
 
 (defspec k0-inverse-property-test
   (inverse-property scale/k0))

--- a/bases/criterium/test/criterium/viewer/call_graph_test.clj
+++ b/bases/criterium/test/criterium/viewer/call_graph_test.clj
@@ -307,7 +307,7 @@
           ;; Check first node (root) - uses short class name for readability
           (let [root (first flame-data)]
             (is (= "Core.main" (:name root)))
-            (is (= 0 (:x0 root)))
+            (is (= 0.0 (:x0 root)))
             (is (= 0 (:depth root)))))))
 
     (testing "respects width option"

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -1724,7 +1724,7 @@
         (is (every? #(contains? % "elapsed-time") data))
         (is (every? #(contains? % "pdf-density") data))
         ;; PDF values should be positive
-        (is (every? #(pos? (get % "pdf-density")) data))))
+        (is (every? #(pos? (double (get % "pdf-density"))) data))))
 
     (testing "uses line mark"
       (let [layer (charts/distribution-pdf-layer
@@ -2108,9 +2108,9 @@
             points (charts/qq-points samples quantile-fn identity-transforms)]
         ;; Hazen: (i - 0.5) / n for i = 1, 2, 3 and n = 3
         ;; p1 = 0.5/3 = 0.167, p2 = 1.5/3 = 0.5, p3 = 2.5/3 = 0.833
-        (is (< (Math/abs (- (/ 0.5 3.0) (get (nth points 0) "theoretical"))) 0.001))
-        (is (< (Math/abs (- 0.5 (get (nth points 1) "theoretical"))) 0.001))
-        (is (< (Math/abs (- (/ 2.5 3.0) (get (nth points 2) "theoretical"))) 0.001))))
+        (is (< (Math/abs (- (/ 0.5 3.0) (double (get (nth points 0) "theoretical")))) 0.001))
+        (is (< (Math/abs (- 0.5 (double (get (nth points 1) "theoretical")))) 0.001))
+        (is (< (Math/abs (- (/ 2.5 3.0) (double (get (nth points 2) "theoretical")))) 0.001))))
 
     (testing "preserves sorted sample values"
       (let [samples [3.0 1.0 2.0]  ; unsorted input
@@ -2124,7 +2124,8 @@
     (testing "applies transforms"
       (let [samples [1.0 2.0 3.0]
             quantile-fn identity
-            transforms {:sample-> (list #(* 1000.0 %)) :->sample [#(/ % 1000.0)]}
+            transforms {:sample-> (list #(* 1000.0 (double %)))
+                        :->sample [#(/ (double %) 1000.0)]}
             points (charts/qq-points samples quantile-fn transforms)]
         ;; Values should be transformed to ns from s
         (is (= 1000.0 (get (nth points 0) "observed")))))))
@@ -2200,8 +2201,8 @@
         ;; Range 1.0-5.0, margin = 0.05 * 4 = 0.2
         ;; Start = 1.0 - 0.2 = 0.8, End = 5.0 + 0.2 = 5.2
         (is (= 2 (count values)))
-        (is (< (Math/abs (- 0.8 (get (first values) "x"))) 0.001))
-        (is (< (Math/abs (- 5.2 (get (second values) "x"))) 0.001))))))
+        (is (< (Math/abs (- 0.8 (double (get (first values) "x")))) 0.001))
+        (is (< (Math/abs (- 5.2 (double (get (second values) "x")))) 0.001))))))
 
 (deftest distribution-qq-overlay-layers-test
   ;; Tests building Q-Q overlay layers for all fitted distributions.

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -1555,7 +1555,8 @@
   "Create minimal benchmark data with stats for testing domain-apply.
   Unlike print viewer, kindly stats view also requires :max-val in stats."
   [mean-ns]
-  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+        mean-ns (double mean-ns)]
     {:samples {:type :criterium/collected-metrics-samples
                :metrics-defs metrics-defs
                :metric->values {[:elapsed-time] [mean-ns]}
@@ -1572,10 +1573,10 @@
              :outliers-id nil
              :stats {:elapsed-time {:mean mean-ns
                                     :variance 1.0
-                                    :mean-plus-3sigma (+ mean-ns 3)
-                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :mean-plus-3sigma (+ mean-ns 3.0)
+                                    :mean-minus-3sigma (- mean-ns 3.0)
                                     :min-val mean-ns
-                                    :max-val (+ mean-ns 10)}}}}))
+                                    :max-val (+ mean-ns 10.0)}}}}))
 
 (deftest domain-apply-kindly-test
   ;; Tests the view/domain-apply* multimethod for :kindly viewer.

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -557,7 +557,8 @@
 (defn- make-bench-data
   "Create minimal benchmark data with stats for testing domain-apply."
   [mean-ns]
-  (let [metrics-defs (select-keys (criterium.collector.metrics/metrics) [:elapsed-time])]
+  (let [metrics-defs (select-keys (criterium.collector.metrics/metrics) [:elapsed-time])
+        mean-ns (double mean-ns)]
     {:samples {:type :criterium/collected-metrics-samples
                :metrics-defs metrics-defs
                :metric->values {[:elapsed-time] [mean-ns]}
@@ -574,10 +575,10 @@
              :outliers-id nil
              :stats {:elapsed-time {:mean mean-ns
                                     :variance 1.0
-                                    :mean-plus-3sigma (+ mean-ns 3)
-                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :mean-plus-3sigma (+ mean-ns 3.0)
+                                    :mean-minus-3sigma (- mean-ns 3.0)
                                     :min-val mean-ns
-                                    :max-val (+ mean-ns 10)}}}}))
+                                    :max-val (+ mean-ns 10.0)}}}}))
 
 (deftest domain-apply-pprint-test
   ;; Tests the pprint viewer for domain-apply.

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -1309,7 +1309,8 @@
 (defn- make-bench-data
   "Create minimal benchmark data with stats for testing domain-apply."
   [mean-ns]
-  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+        mean-ns (double mean-ns)]
     {:samples {:type :criterium/collected-metrics-samples
                :metrics-defs metrics-defs
                :metric->values {[:elapsed-time] [mean-ns]}
@@ -1326,8 +1327,8 @@
              :outliers-id nil
              :stats {:elapsed-time {:mean mean-ns
                                     :variance 1.0
-                                    :mean-plus-3sigma (+ mean-ns 3)
-                                    :mean-minus-3sigma (- mean-ns 3)
+                                    :mean-plus-3sigma (+ mean-ns 3.0)
+                                    :mean-minus-3sigma (- mean-ns 3.0)
                                     :min-val mean-ns}}}}))
 
 (deftest domain-apply-print-test

--- a/build/src/build/agent.clj
+++ b/build/src/build/agent.clj
@@ -97,9 +97,9 @@
   ([opts]
    (let [platform (current-platform)
          ^java.io.File agent-dir (agent-cpp-dir)
-         build-dir (or (:build-dir opts) (io/file agent-dir "build"))
+         ^java.io.File build-dir (or (:build-dir opts) (io/file agent-dir "build"))
          lib-name (library-name platform)
-         lib-file (io/file build-dir lib-name)]
+         ^java.io.File lib-file (io/file build-dir lib-name)]
      (when-not (.isDirectory agent-dir)
        (throw (ex-info "agent-cpp directory not found"
                        {:agent-dir (.getAbsolutePath agent-dir)})))

--- a/components/optimisation/test/criterium/optimisation/regression_test.clj
+++ b/components/optimisation/test/criterium/optimisation/regression_test.clj
@@ -23,11 +23,11 @@
 
     (testing "with doubled slope (y = 2x)"
       (let [xs     (range 1 11)
-            ys     (map #(* 2 %) xs)
+            ys     (map (fn [^long x] (* 2 x)) xs)
             result (opt/linear-regression xs ys)]
-        (is (< (Math/abs (- 0.0 (first (:coeffs result)))) 1e-10)
+        (is (< (Math/abs (- 0.0 (double (first (:coeffs result))))) 1e-10)
             "intercept should be ~0")
-        (is (< (Math/abs (- 2.0 (second (:coeffs result)))) 1e-10)
+        (is (< (Math/abs (- 2.0 (double (second (:coeffs result))))) 1e-10)
             "slope should be ~2")
         (is (> (:r-sqr result) 0.999)
             "R-squared should be ~1.0")))
@@ -36,7 +36,7 @@
       (let [xs     [1 2 3 4 5]
             ys     [2.1 3.9 6.2 7.8 10.1]
             result (opt/linear-regression xs ys)]
-        (is (< (Math/abs (- 2.0 (second (:coeffs result)))) 0.2)
+        (is (< (Math/abs (- 2.0 (double (second (:coeffs result))))) 0.2)
             "slope should be approximately 2")
         (is (> (:r-sqr result) 0.99)
             "R-squared should be high for near-linear data")

--- a/components/random/test/criterium/random/ziggurat_test.clj
+++ b/components/random/test/criterium/random/ziggurat_test.clj
@@ -17,7 +17,7 @@
 ;; Tests for ziggurat algorithm for generating normal random variates.
 ;; Verifies correct distribution and independence of samples when using WELL RNG.
 
-(defspec random-normal-zig-test-property 10
+(defspec ^:slow random-normal-zig-test-property 10
   (prop/for-all
    [random-seed gen/small-integer]
    (let [rng            (well/well-rng-1024a random-seed)
@@ -41,7 +41,7 @@
 ;; autocorrelation and correct marginal distribution. The ziggurat algorithm
 ;; consumes 2-3+ uniform values per output, which can amplify RNG correlations.
 
-(deftest ziggurat-well-rng-autocorrelation-test
+(deftest ^:slow ziggurat-well-rng-autocorrelation-test
   ;; Verify ziggurat produces independent normal samples when using WELL RNG.
   ;; With n=100,000, SE approx 1/sqrt(n) approx 0.003, so threshold of 0.02 is conservative.
   (testing "random-normal-zig with WELL RNG"

--- a/components/random/test/criterium/random/ziggurat_test.clj
+++ b/components/random/test/criterium/random/ziggurat_test.clj
@@ -25,10 +25,10 @@
                              ziggurat/random-normal-zig
                              (take 10000)
                              vec)
-         mean           (stats/mean values)
-         variance       (stats/variance values)
-         mean-error     (abs-error mean 0.0)
-         variance-error (abs-error variance 1.0)
+         mean           (double (stats/mean values))
+         variance       (double (stats/variance values))
+         mean-error     (double (abs-error mean 0.0))
+         variance-error (double (abs-error variance 1.0))
          mean-tol       1e-1
          variance-tol   1e-1]
      (is (< mean-error mean-tol))
@@ -65,8 +65,8 @@
               (format "variance ratio %.3f outside [0.9, 1.1]" ratio))))
 
       (testing "has correct marginal distribution"
-        (let [mean     (stats/mean samples)
-              variance (stats/variance samples)]
+        (let [mean     (double (stats/mean samples))
+              variance (double (stats/variance samples))]
           (is (< (Math/abs mean) 0.02)
               (format "mean %.4f exceeds tolerance 0.02" mean))
           (is (< (Math/abs (- variance 1.0)) 0.1)

--- a/components/stats/test/criterium/stats/interface_test.clj
+++ b/components/stats/test/criterium/stats/interface_test.clj
@@ -135,7 +135,9 @@
 (deftest confidence-interval-test
   (testing "confidence-interval"
     (testing "returns 95% confidence interval around mean"
-      (let [[low high] (stats/confidence-interval 100.0 25.0)]
+      (let [[low high] (stats/confidence-interval 100.0 25.0)
+            low (double low)
+            high (double high)]
         (is (< low 100.0))
         (is (> high 100.0))
         (is (< (- 100.0 low) 10.0))

--- a/components/utils/test/criterium/utils/helpers_test.clj
+++ b/components/utils/test/criterium/utils/helpers_test.clj
@@ -72,7 +72,7 @@
   (testing "postwalk"
     (testing "applies function to all nodes"
       (is (= [2 [3 4]]
-             (utils/postwalk #(if (number? %) (inc %) %) [1 [2 3]]))))
+             (utils/postwalk #(if (number? %) (inc (long %)) %) [1 [2 3]]))))
     (testing "preserves structure"
       (is (= {:a [1 2]}
              (utils/postwalk identity {:a [1 2]}))))))

--- a/tests.edn
+++ b/tests.edn
@@ -31,7 +31,41 @@
                                   "build/test"
                                   "projects/agent/test"
                                   "development/test"]
-           :skip-meta            [:slow :very-slow :requires-build-artifacts]}]
+           :skip-meta            [:slow :very-slow :requires-build-artifacts]}
+          {:kaocha.testable/type :kaocha.type/clojure.test
+           :id                   :slow
+           :ns-patterns          ["-test$"]
+           :source-paths         ["bases/criterium/src"
+                                  "bases/agent/src"
+                                  "bases/arg-gen/src"
+                                  "components/optimisation/src"
+                                  "components/random/src"
+                                  "components/stats/src"
+                                  "components/utils/src"
+                                  "build/src"
+                                  "projects/agent"]
+           :kaocha/source-paths  ["bases/criterium/src"
+                                  "bases/agent/src"
+                                  "bases/arg-gen/src"
+                                  "components/optimisation/src"
+                                  "components/random/src"
+                                  "components/stats/src"
+                                  "components/utils/src"
+                                  "build/src"
+                                  "projects/agent"]
+           :test-paths           ["bases/criterium/test"
+                                  "bases/blackhole/test"
+                                  "bases/agent/test"
+                                  "bases/arg-gen/test"
+                                  "components/optimisation/test"
+                                  "components/random/test"
+                                  "components/stats/test"
+                                  "components/utils/test"
+                                  "build/test"
+                                  "projects/agent/test"
+                                  "development/test"]
+           :focus-meta           [:slow]
+           :skip-meta            [:very-slow :requires-build-artifacts]}]
 
   :plugins                            [:kaocha.plugin/randomize
                                        :kaocha.plugin/filter


### PR DESCRIPTION
## Summary

- Mark slow tests with `^:slow` metadata and add `:slow` test suite to run them separately
- Reduce sample counts in statistical tests for faster execution while maintaining validity
- Eliminate all boxed math and reflection warnings from project source and test files
- Default test run now completes in under 30 seconds (was ~137s)

## Changes

- **Slow test marking**: Tests taking >30s marked `^:slow`, skipped by default via `:skip-meta [:slow]` in tests.edn. Run with `clojure -M:kaocha:dev:test :slow`
- **Sample count optimization**: Reduced sample counts in statistical property tests (1M→100K samples, 200K→50K samples) - sufficient for correctness validation
- **Boxed math fixes**: Added type hints (`^long`, `^double`) to source files (`metrics_samples.clj`, `call_graph.clj`, `common_charts.clj`) and all test files with boxed math warnings
- **Reflection fixes**: Added type hints to resolve reflection warnings in test utilities and build files

## Test plan

- [x] `clojure -M:kaocha:dev:test :all --reporter dots` completes in under 30 seconds
- [x] `clojure -M:kaocha:dev:test :slow --reporter dots` runs slow integration tests
- [x] No boxed math or reflection warnings from project files in test output
- [x] All tests pass