### PR TITLE
feat: Add elapsed-time-no-expr-value collector fn

### DIFF
--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -62,13 +62,16 @@
 (defn- collected-data-map
   [collection-map]
   (let [metric->values (collect/transform collection-map)
-        batch-size (:batch-size collection-map)]
+        batch-size (:batch-size collection-map)
+        expr-values (metric->values [:expr-value])]
     (util/->collected-metrics-map
      (merge
       collection-map
       {:metric->values metric->values
        :metrics-defs (have (:metrics-defs (:collector collection-map)))
-       :expr-value (arr/last-object (metric->values [:expr-value]))
+       :expr-value (if expr-values
+                     (arr/last-object expr-values)
+                     :criterium/not-collected)
        :type :criterium/metrics-samples
        :transform (if (= 1 batch-size)
                     identity-transforms

--- a/bases/criterium/src/criterium/collector/fns.clj
+++ b/bases/criterium/src/criterium/collector/fns.clj
@@ -79,6 +79,21 @@
     (->SampleStage elapsed-time-sample-m elapsed-time-xform :elapsed-time)
     {:criterium.collector/stage-type :terminal}))
 
+(defn- elapsed-time-only-xform
+  "Transform elapsed time sample, discarding expression value."
+  [sample ^long result-index]
+  (let [v (aget ^objects sample result-index)]
+    (aset ^objects sample result-index
+          {:elapsed-time (v 0)})
+    nil))
+
+(def elapsed-time-only
+  "Elapsed time collector that does not retain expression return values.
+  Useful for benchmarking functions that return large data structures."
+  (with-meta
+    (->SampleStage elapsed-time-sample-m elapsed-time-only-xform :elapsed-time-only)
+    {:criterium.collector/stage-type :terminal}))
+
 ;;; Sample Pipeline Stages
 
 ;; Stages can be composed.

--- a/bases/criterium/src/criterium/collector/fns.clj
+++ b/bases/criterium/src/criterium/collector/fns.clj
@@ -84,7 +84,8 @@
   [sample ^long result-index]
   (let [v (aget ^objects sample result-index)]
     (aset ^objects sample result-index
-          {:elapsed-time (v 0)})
+          {:elapsed-time (v 0)
+           :expr-value   :criterium/not-collected})
     nil))
 
 (def elapsed-time-only

--- a/bases/criterium/src/criterium/collector/metrics.clj
+++ b/bases/criterium/src/criterium/collector/metrics.clj
@@ -17,6 +17,13 @@
               :scale     1
               :type      :nominal
               :label     "Expr value"}]}
+   :elapsed-time-only
+   {:type   :quantitative
+    :values [{:path      [:elapsed-time]
+              :dimension :time
+              :scale     1e-9
+              :type      :quantitative
+              :label     "Elapsed Time"}]}
    :memory
    {:type   :quantitative
     :values [{:path      [:memory :heap :used]

--- a/bases/criterium/test/criterium/collector/fns_test.clj
+++ b/bases/criterium/test/criterium/collector/fns_test.clj
@@ -245,7 +245,8 @@
 
 ;; Tests elapsed-time-only output structure:
 ;; - contains :elapsed-time key
-;; - does NOT contain :expr-value key
+;; - contains :expr-value set to :criterium/not-collected (to distinguish from
+;;   expressions that genuinely return nil)
 ;; - correctly usable as a terminator with metric-id :elapsed-time-only
 (deftest elapsed-time-only-output-test
   (testing "elapsed-time-only collector"
@@ -253,7 +254,7 @@
                     (fn [] [])
                     (fn [_ _] [100 :large-value]))
           state    []]
-      (testing "produces output with :elapsed-time but not :expr-value"
+      (testing "produces output with :elapsed-time and :expr-value :criterium/not-collected"
         (let [^objects sample (make-array Object 1)
               p      (collector/collector
                       {:stages [] :terminator :elapsed-time-only})]
@@ -262,8 +263,8 @@
           (let [result (aget sample 0)]
             (is (contains? result :elapsed-time)
                 "Output should contain :elapsed-time")
-            (is (not (contains? result :expr-value))
-                "Output should NOT contain :expr-value"))))
+            (is (= :criterium/not-collected (:expr-value result))
+                "Output should have :expr-value :criterium/not-collected"))))
       (testing "compared to elapsed-time which retains :expr-value"
         (let [^objects sample (make-array Object 1)
               p      (collector/collector

--- a/bases/criterium/test/criterium/collector/fns_test.clj
+++ b/bases/criterium/test/criterium/collector/fns_test.clj
@@ -91,6 +91,24 @@
               (pr-str (filterv agent/allocation-freed? relevant-allocations)))
           (is (some? sample)
               "Make sure sample isn't collected until after garbage check")))
+      (testing "for elapsed-time-only metric"
+        (let [sample                (make-array Object 1)
+              p                     (collector/collector
+                                     {:stages [] :terminator :elapsed-time-only})
+              _                     (dotimes [_ 10]
+                                      (agent/with-allocation-tracing
+                                        ((:f p) sample measured state 1 0)))
+              ;; clear any allocations from warmup
+              _                     (reset! agent-core/records [])
+              [allocations res]     (agent/with-allocation-tracing
+                                      ((:f p) sample measured state 1 0))
+              relevant-allocations  (filterv (agent/allocation-on-thread?) allocations)
+              {:keys [freed-bytes]} (agent/allocations-summary relevant-allocations)]
+          (is (= [1 1] res))
+          (is (zero? freed-bytes)
+              (pr-str (filterv agent/allocation-freed? relevant-allocations)))
+          (is (some? sample)
+              "Make sure sample isn't collected until after garbage check")))
       (testing "for measured-args"
         (let [sample                (make-array Object 2)
               p                     (collector/collector
@@ -224,3 +242,36 @@
               (pr-str (filterv agent/allocation-freed? relevant-allocations)))
           (is (some? sample)
               "Make sure sample isn't collected until after garbage check"))))))
+
+;; Tests elapsed-time-only output structure:
+;; - contains :elapsed-time key
+;; - does NOT contain :expr-value key
+;; - correctly usable as a terminator with metric-id :elapsed-time-only
+(deftest elapsed-time-only-output-test
+  (testing "elapsed-time-only collector"
+    (let [measured (measured/measured
+                    (fn [] [])
+                    (fn [_ _] [100 :large-value]))
+          state    []]
+      (testing "produces output with :elapsed-time but not :expr-value"
+        (let [^objects sample (make-array Object 1)
+              p      (collector/collector
+                      {:stages [] :terminator :elapsed-time-only})]
+          ((:f p) sample measured state 1 0)
+          ((:x p) sample 0)
+          (let [result (aget sample 0)]
+            (is (contains? result :elapsed-time)
+                "Output should contain :elapsed-time")
+            (is (not (contains? result :expr-value))
+                "Output should NOT contain :expr-value"))))
+      (testing "compared to elapsed-time which retains :expr-value"
+        (let [^objects sample (make-array Object 1)
+              p      (collector/collector
+                      {:stages [] :terminator :elapsed-time})]
+          ((:f p) sample measured state 1 0)
+          ((:x p) sample 0)
+          (let [result (aget sample 0)]
+            (is (contains? result :elapsed-time)
+                "elapsed-time output should contain :elapsed-time")
+            (is (contains? result :expr-value)
+                "elapsed-time output should contain :expr-value")))))))

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -220,6 +220,8 @@ bench-plans/knuth-histogram
 ;; The `:metric-ids` option selects which metrics to collect.
 ;; Available metrics:
 ;; - `:elapsed-time` - Wall clock timing
+;; - `:elapsed-time-only` - Wall clock timing without retaining return values
+;;   (use when benchmarking functions with large return values to avoid memory exhaustion)
 ;; - `:memory` - Memory usage
 ;; - `:garbage-collector` - GC statistics
 ;; - `:thread-allocation` - Per-thread allocation (requires agent)

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -222,6 +222,11 @@ bench-plans/knuth-histogram
 ;; - `:elapsed-time` - Wall clock timing
 ;; - `:elapsed-time-only` - Wall clock timing without retaining return values
 ;;   (use when benchmarking functions with large return values to avoid memory exhaustion)
+
+^:kindly/hide-code
+(bench-display
+ (bench/bench (vec (range 10000)) :metric-ids [:elapsed-time-only]))
+
 ;; - `:memory` - Memory usage
 ;; - `:garbage-collector` - GC statistics
 ;; - `:thread-allocation` - Per-thread allocation (requires agent)


### PR DESCRIPTION
## Summary

Add a collector function that measures elapsed time without retaining the expression's return value.

**Problem:** When benchmarking functions that return large values, the current `elapsed-time` collector stores all return values in `:expr-value`, which can cause memory exhaustion.

**Solution:** New `elapsed-time-only` terminal collector that behaves identically to `elapsed-time` but omits the `:expr-value` field from results.

## Changes

- Add `elapsed-time-only` terminal collector in `criterium.collector.fns`
- Uses `:elapsed-time-only` as its metric ID with `:criterium/not-collected` sentinel for expr-value
- Same timing behavior as `elapsed-time` collector
- Usable via `:metric-ids [:elapsed-time-only]` in bench options
- Add `elapsed-time-only` metric definition in `criterium.metric`
- Document in `bench_options_notebook.clj` with description and code example

## Commits

- feat(collector): add elapsed-time-only terminal collector
- docs(notebook): document elapsed-time-only metric option
- fix(collector): use :criterium/not-collected for elapsed-time-only expr-value
- fix(collector): add elapsed-time-only metric definition and handle missing expr-value
- docs(notebook): add code example for elapsed-time-only metric

## Test plan

- [ ] Run `clojure -M:kaocha:dev:test :all --reporter dots` - all tests pass
- [ ] Verify elapsed-time-only collector works via REPL