### PR TITLE
fix: :elapsed-time-only should create :elapsed-time metric

### DIFF
--- a/bases/criterium/src/criterium/collector/fns.clj
+++ b/bases/criterium/src/criterium/collector/fns.clj
@@ -90,9 +90,12 @@
 
 (def elapsed-time-only
   "Elapsed time collector that does not retain expression return values.
-  Useful for benchmarking functions that return large data structures."
+  Useful for benchmarking functions that return large data structures.
+
+  Produces :elapsed-time metric (same as elapsed-time collector)."
   (with-meta
-    (->SampleStage elapsed-time-sample-m elapsed-time-only-xform :elapsed-time-only)
+    (assoc (->SampleStage elapsed-time-sample-m elapsed-time-only-xform :elapsed-time-only)
+           :metric-id :elapsed-time)
     {:criterium.collector/stage-type :terminal}))
 
 ;;; Sample Pipeline Stages

--- a/bases/criterium/src/criterium/collector/fns.clj
+++ b/bases/criterium/src/criterium/collector/fns.clj
@@ -44,7 +44,7 @@
      :result-index-sym result-index-sym}))
 
 (defrecord ^:private SampleStage
-  [m x id])
+  [m x id metric-id])
 
 ;;; Terminal function
 
@@ -76,7 +76,7 @@
 
 (def elapsed-time
   (with-meta
-    (->SampleStage elapsed-time-sample-m elapsed-time-xform :elapsed-time)
+    (->SampleStage elapsed-time-sample-m elapsed-time-xform :elapsed-time nil)
     {:criterium.collector/stage-type :terminal}))
 
 (defn- elapsed-time-only-xform
@@ -94,8 +94,8 @@
 
   Produces :elapsed-time metric (same as elapsed-time collector)."
   (with-meta
-    (assoc (->SampleStage elapsed-time-sample-m elapsed-time-only-xform :elapsed-time-only)
-           :metric-id :elapsed-time)
+    (->SampleStage elapsed-time-sample-m elapsed-time-only-xform
+                   :elapsed-time-only :elapsed-time)
     {:criterium.collector/stage-type :terminal}))
 
 ;;; Sample Pipeline Stages
@@ -122,7 +122,7 @@
     nil))
 
 (def measured-args
-  (->SampleStage measured-args-sample-m measured-args-xform :measured-args))
+  (->SampleStage measured-args-sample-m measured-args-xform :measured-args nil))
 
 ;;;; Class Loader
 
@@ -146,7 +146,7 @@
                   (aget ^objects sample result-index))})))
 
 (def class-loader
-  (->SampleStage class-loader-sample-m class-loader-xform :class-loader))
+  (->SampleStage class-loader-sample-m class-loader-xform :class-loader nil))
 
 ;;;; Compilation
 
@@ -170,7 +170,7 @@
                   (aget ^objects sample result-index))})))
 
 (def compilation
-  (->SampleStage compilation-sample-m compilation-xform :compilation))
+  (->SampleStage compilation-sample-m compilation-xform :compilation nil))
 
 ;;;; Memory
 
@@ -200,7 +200,7 @@
                           (aget ^objects sample result-index))})))
 
 (def memory
-  (->SampleStage memory-sample-m memory-xform :memory))
+  (->SampleStage memory-sample-m memory-xform :memory nil))
 
 ;;;; Finalization
 
@@ -231,7 +231,7 @@
                   (aget ^objects sample result-index))})))
 
 (def finalization
-  (->SampleStage finalization-sample-m finalization-xform :finalization))
+  (->SampleStage finalization-sample-m finalization-xform :finalization nil))
 
 ;;;; Garbage-collector
 
@@ -261,7 +261,7 @@
 
 (def garbage-collector
   (->SampleStage
-   garbage-collector-sample-m garbage-collector-xform :garbage-collector))
+   garbage-collector-sample-m garbage-collector-xform :garbage-collector nil))
 
 ;;;; Thread Memory Allocation
 
@@ -289,4 +289,4 @@
 
 (def thread-allocation
   (->SampleStage
-   thread-allocation-sample-m thread-allocation-xform :thread-allocation))
+   thread-allocation-sample-m thread-allocation-xform :thread-allocation nil))

--- a/bases/criterium/src/criterium/collector/impl.clj
+++ b/bases/criterium/src/criterium/collector/impl.clj
@@ -17,10 +17,13 @@
 
 (defn metric-ids
   "Return a sequence of all metrics produced by a pipeline with the
-  given pipeline config."
+  given pipeline config.
+
+  Each stage can specify a :metric-id that differs from its :id.
+  When present, :metric-id is used; otherwise :id is used."
   [{:keys [stages terminator] :as _pipline-config}]
   {:pre [stages terminator]}
-  (mapv :id (conj stages terminator)))
+  (mapv #(or (:metric-id %) (:id %)) (conj stages terminator)))
 
 ;;; Pipeline construction
 

--- a/bases/criterium/src/criterium/collector/metrics.clj
+++ b/bases/criterium/src/criterium/collector/metrics.clj
@@ -17,13 +17,6 @@
               :scale     1
               :type      :nominal
               :label     "Expr value"}]}
-   :elapsed-time-only
-   {:type   :quantitative
-    :values [{:path      [:elapsed-time]
-              :dimension :time
-              :scale     1e-9
-              :type      :quantitative
-              :label     "Elapsed Time"}]}
    :memory
    {:type   :quantitative
     :values [{:path      [:memory :heap :used]

--- a/bases/criterium/test/criterium/collector/fns_test.clj
+++ b/bases/criterium/test/criterium/collector/fns_test.clj
@@ -247,7 +247,7 @@
 ;; - contains :elapsed-time key
 ;; - contains :expr-value set to :criterium/not-collected (to distinguish from
 ;;   expressions that genuinely return nil)
-;; - correctly usable as a terminator with metric-id :elapsed-time-only
+;; - produces :elapsed-time metric ID (not :elapsed-time-only)
 (deftest elapsed-time-only-output-test
   (testing "elapsed-time-only collector"
     (let [measured (measured/measured
@@ -265,6 +265,13 @@
                 "Output should contain :elapsed-time")
             (is (= :criterium/not-collected (:expr-value result))
                 "Output should have :expr-value :criterium/not-collected"))))
+      (testing "has metrics-defs with :elapsed-time key, not :elapsed-time-only"
+        (let [p (collector/collector
+                 {:stages [] :terminator :elapsed-time-only})]
+          (is (contains? (:metrics-defs p) :elapsed-time)
+              "metrics-defs should contain :elapsed-time")
+          (is (not (contains? (:metrics-defs p) :elapsed-time-only))
+              "metrics-defs should NOT contain :elapsed-time-only")))
       (testing "compared to elapsed-time which retains :expr-value"
         (let [^objects sample (make-array Object 1)
               p      (collector/collector

--- a/bases/criterium/test/criterium/collector_test.clj
+++ b/bases/criterium/test/criterium/collector_test.clj
@@ -86,6 +86,31 @@
                     {:stages     (all-stages)
                      :terminator ::unknown}))))))
 
+;; Tests that metric-ids uses :metric-id when present, falling back to :id.
+;; The elapsed-time-only terminator has :id :elapsed-time-only but :metric-id
+;; :elapsed-time, so metric-ids should return :elapsed-time.
+(deftest metric-ids-test
+  (testing "metric-ids"
+    (testing "returns :id when :metric-id is not present"
+      (let [config {:stages     [:class-loader]
+                    :terminator :elapsed-time}]
+        (is (= [:class-loader :elapsed-time]
+               (collector-impl/metric-ids
+                (collector-impl/maybe-var-get-config config))))))
+    (testing "returns :metric-id when present (elapsed-time-only case)"
+      (let [config {:stages     []
+                    :terminator :elapsed-time-only}]
+        (is (= [:elapsed-time]
+               (collector-impl/metric-ids
+                (collector-impl/maybe-var-get-config config)))
+            "elapsed-time-only should produce :elapsed-time metric"))
+      (let [config {:stages     [:class-loader]
+                    :terminator :elapsed-time-only}]
+        (is (= [:class-loader :elapsed-time]
+               (collector-impl/metric-ids
+                (collector-impl/maybe-var-get-config config)))
+            "stages + elapsed-time-only should produce stage ids + :elapsed-time")))))
+
 (deftest collector-test
   (testing "collector"
     (testing "builds a pipeline"

--- a/components/random/src/criterium/random/ziggurat.clj
+++ b/components/random/src/criterium/random/ziggurat.clj
@@ -93,7 +93,7 @@
 
   Object
   (toString [_]
-    (str "#<NormalRng>")))
+    "#<NormalRng>"))
 
 (defn next-gaussian!
   "Generate the next random gaussian in N(0,1), mutating the RNG state.


### PR DESCRIPTION
## Summary

Fix collector metric naming: `:elapsed-time-only` collector now produces `:elapsed-time` metrics.

Previously, the `:elapsed-time-only` collector produced metrics keyed under `:elapsed-time-only`, but its transform output used `:elapsed-time` keys, causing a mismatch. The fix introduces a `:metric-id` field to collector stages that specifies the metric key produced, distinct from the stage `:id` used for collector lookup.

## Changes

- Add `:metric-id` field to `SampleStage` record as explicit fourth field
- Update `impl/metric-ids` to use `:metric-id` when present, falling back to `:id`
- Set `:metric-id :elapsed-time` on the `elapsed-time-only` stage
- Remove redundant `:elapsed-time-only` entry from metrics definitions
- Add tests verifying `:metric-id` precedence and correct metric output

## Commits

- `ac27b33` refactor(collector): add :metric-id field to SampleStage record
- `7163c7c` test(collector): verify elapsed-time-only produces :elapsed-time metric
- `4b69251` fix(collector): elapsed-time-only produces :elapsed-time metric