### PR TITLE
feat(domain): use bootstrapped median instead of mean for domain analysis

### DIFF
--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -93,8 +93,8 @@
   Example - all metrics (uses bootstrapped median):
   (extract domain)
   ;; => {:type :criterium/domain-extract
-  ;;     :metrics {:elapsed-time {:metric :median :data [...]}
-  ;;               :thread-allocation {:metric :median :data [...]}}}"
+  ;;     :metrics {:elapsed-time {:metric [:stats :elapsed-time :median] :data [...]}
+  ;;               :thread-allocation {:metric [:stats :thread-allocation :median] :data [...]}}}"
   ([domain]
    (extract domain nil {}))
   ([domain metric-path]
@@ -131,7 +131,7 @@
          ;; Extract using median helper (when metric-path is nil)
          extract-with-median
          (fn [metric-id]
-           {:metric :median
+           {:metric [:stats metric-id :median]
             :with-error-bounds (boolean with-error-bounds)
             :data (mapv (fn [{:keys [coord data]}]
                           (let [value (extract-metric-value data metric-id)]
@@ -320,7 +320,7 @@
              compare-with-median
              (fn [metric-id]
                (let [extract-bounds? with-error-bounds]
-                 {:metric :median
+                 {:metric [:stats metric-id :median]
                   :with-error-bounds (boolean extract-bounds?)
                   :data (into {}
                               (map (fn [[axis-val sub-domain]]

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -6,7 +6,7 @@
   (:require
    [criterium.bench.config :as bench-config]
    [criterium.domain.types :as types]
-   [criterium.util.helpers :as util]
+   [criterium.util.helpers :as helpers]
    [criterium.util.invariant :refer [have have?]]
    [criterium.view :as view]))
 
@@ -22,6 +22,34 @@
     (->> metrics-defs
          (filter (fn [[_k v]] (= :quantitative (:type v))))
          (map first))))
+
+;;; Metric Value Extraction Helpers
+
+(defn- extract-metric-value
+  "Extract the primary metric value from a benchmark data map.
+
+  Prefers bootstrapped median (quantile 0.5) when available, falls back to
+  mean from stats when bootstrap stats are unavailable.
+
+  Returns the transformed value, or nil if neither source has the metric."
+  [data-map metric-id]
+  (or (helpers/bootstrap-quantile-value data-map metric-id 0.5)
+      (helpers/stats-value data-map :stats metric-id :mean)))
+
+(defn- extract-error-bounds
+  "Extract error bounds for a metric from a benchmark data map.
+
+  Prefers bootstrap CI from quantile 0.5's estimate-quantiles when available,
+  falls back to ±3σ from stats when bootstrap stats are unavailable.
+
+  Returns [lower upper] tuple, or nil if no error bounds are available."
+  [data-map metric-id]
+  (if-let [bootstrap-ci (helpers/bootstrap-quantile-ci data-map metric-id 0.5)]
+    [(:ci-lower bootstrap-ci) (:ci-upper bootstrap-ci)]
+    (let [lower (helpers/stats-value data-map :stats metric-id :mean-minus-3sigma)
+          upper (helpers/stats-value data-map :stats metric-id :mean-plus-3sigma)]
+      (when (and lower upper)
+        [lower upper]))))
 
 (defn extract
   "Extract metric values from all runs in a domain.
@@ -100,18 +128,18 @@
              {:metric metric-path
               :with-error-bounds (boolean extract-bounds?)
               :data (mapv (fn [{:keys [coord data]}]
-                            (let [value (util/stats-value
+                            (let [value (helpers/stats-value
                                          data
                                          stats-id
                                          metric-id
                                          value-key)]
                               (if extract-bounds?
-                                (let [lower (util/stats-value
+                                (let [lower (helpers/stats-value
                                              data
                                              stats-id
                                              metric-id
                                              :mean-minus-3sigma)
-                                      upper (util/stats-value
+                                      upper (helpers/stats-value
                                              data
                                              stats-id
                                              metric-id
@@ -219,16 +247,16 @@
                               (map (fn [[axis-val sub-domain]]
                                      [axis-val
                                       (mapv (fn [{:keys [coord data]}]
-                                              (let [value (util/stats-value
+                                              (let [value (helpers/stats-value
                                                            data stats-id
                                                            metric-id value-key)]
                                                 {:coord coord
                                                  :value (if extract-bounds?
-                                                          (let [lower (util/stats-value
+                                                          (let [lower (helpers/stats-value
                                                                        data stats-id
                                                                        metric-id
                                                                        :mean-minus-3sigma)
-                                                                upper (util/stats-value
+                                                                upper (helpers/stats-value
                                                                        data stats-id
                                                                        metric-id
                                                                        :mean-plus-3sigma)]
@@ -258,17 +286,17 @@
                               (map (fn [[axis-val sub-domain]]
                                      [axis-val
                                       (mapv (fn [{:keys [coord data]}]
-                                              (let [mean-value (util/stats-value
+                                              (let [mean-value (helpers/stats-value
                                                                 data :stats
                                                                 metric-id :mean)
                                                     ;; Base value with mean
                                                     base-value
                                                     (if extract-bounds?
-                                                      (let [lower (util/stats-value
+                                                      (let [lower (helpers/stats-value
                                                                    data :stats
                                                                    metric-id
                                                                    :mean-minus-3sigma)
-                                                            upper (util/stats-value
+                                                            upper (helpers/stats-value
                                                                    data :stats
                                                                    metric-id
                                                                    :mean-plus-3sigma)]
@@ -278,7 +306,7 @@
                                                            :upper upper}))
                                                       mean-value)
                                                     ;; Bootstrap stats (when available)
-                                                    bootstrap (util/bootstrap-box-plot-stats
+                                                    bootstrap (helpers/bootstrap-box-plot-stats
                                                                data metric-id)]
                                                 {:coord coord
                                                  :value (if bootstrap
@@ -1158,8 +1186,8 @@
   [x]
   (let [options {:default-ns 'criterium.domain.analysis}]
     (if (sequential? x)
-      (apply (util/maybe-var-get (first x) options) (rest x))
-      ((util/maybe-var-get x options)))))
+      (apply (helpers/maybe-var-get (first x) options) (rest x))
+      ((helpers/maybe-var-get x options)))))
 
 (defn- resolve-domain-view-fn
   "Resolves a single domain view function specification.
@@ -1171,8 +1199,8 @@
     (have
      fn?
      (if (sequential? x)
-       (apply (util/maybe-var-get (first x) options) (rest x))
-       ((util/maybe-var-get x options)))
+       (apply (helpers/maybe-var-get (first x) options) (rest x))
+       ((helpers/maybe-var-get x options)))
      {:x x})))
 
 (defn ->domain-analyse

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -100,6 +100,14 @@
   ([domain metric-path]
    (extract domain metric-path {}))
   ([domain metric-path {:keys [with-error-bounds metric-ids]}]
+   ;; Validate metric-path structure when provided
+   (when metric-path
+     (have vector? metric-path
+           {:reason "metric-path must be a vector like [:stats :metric-id :value-key]"
+            :metric-path metric-path})
+     (have #(= 3 (count %)) metric-path
+           {:reason "metric-path must have exactly 3 elements: [stats-id metric-id value-key]"
+            :metric-path metric-path}))
    (let [runs (types/runs domain)
          impl-axis-key (types/impl-axis domain)
          impls (types/implementations domain)
@@ -256,6 +264,14 @@
   ([domain axis-key metric-path]
    (compare-by domain axis-key metric-path {}))
   ([domain axis-key metric-path {:keys [metric-ids with-error-bounds]}]
+   ;; Validate metric-path structure when provided
+   (when metric-path
+     (have vector? metric-path
+           {:reason "metric-path must be a vector like [:stats :metric-id :value-key]"
+            :metric-path metric-path})
+     (have #(= 3 (count %)) metric-path
+           {:reason "metric-path must have exactly 3 elements: [stats-id metric-id value-key]"
+            :metric-path metric-path}))
    (let [runs (types/runs domain)
          impls (:implementations domain)
          grouped (:data (group-by-axis domain axis-key))]

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -61,11 +61,16 @@
 
   metric-path is a vector like [:stats :elapsed-time :mean].
 
+  By default, extraction uses the bootstrapped median (quantile 0.5) when
+  available, falling back to mean from stats when bootstrap stats are
+  unavailable. When a metric-path is provided that explicitly requests
+  :mean (e.g., [:stats :elapsed-time :mean]), the mean is extracted directly.
+
   Options:
-    :with-error-bounds - When true and extracting :mean values, also
-                         extracts :mean-plus-3sigma and :mean-minus-3sigma
-                         as error bounds. Values become maps with :value,
-                         :lower, and :upper keys.
+    :with-error-bounds - When true, extracts error bounds for each value.
+                         Prefers bootstrap CI from quantile 0.5 when available,
+                         falls back to ±3σ from stats. Values become maps with
+                         :value, :lower, and :upper keys.
     :metric-ids        - When metric-path is nil, filter to only these
                          metric-ids (e.g., [:elapsed-time :thread-allocation]).
                          If nil, extracts all quantitative metrics.
@@ -85,11 +90,11 @@
   ;;     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean]
   ;;                              :data [[{:n 100} 1.23e-6] ...]}}}
 
-  Example - all metrics:
+  Example - all metrics (uses bootstrapped median):
   (extract domain)
   ;; => {:type :criterium/domain-extract
-  ;;     :metrics {:elapsed-time {:metric [:stats :elapsed-time :mean] :data [...]}
-  ;;               :thread-allocation {:metric [:stats :thread-allocation :mean] :data [...]}}}"
+  ;;     :metrics {:elapsed-time {:metric :median :data [...]}
+  ;;               :thread-allocation {:metric :median :data [...]}}}"
   ([domain]
    (extract domain nil {}))
   ([domain metric-path]
@@ -111,21 +116,34 @@
                (filter (set metric-ids) discovered)
                discovered)))
 
-         ;; Build metric-path for each metric-id (default to :mean)
-         metric-paths
-         (if metric-path
-           {(second metric-path) metric-path}
-           (into {}
-                 (map (fn [mid] [mid [:stats mid :mean]]))
-                 metric-ids-to-extract))
+         ;; When metric-path is nil, use median extraction with helper functions
+         ;; When metric-path is provided, use explicit path extraction
+         use-median? (nil? metric-path)
 
-         ;; Extract data for each metric
-         extract-single
-         (fn [metric-path]
-           (let [[stats-id metric-id value-key] metric-path
+         ;; Extract using median helper (when metric-path is nil)
+         extract-with-median
+         (fn [metric-id]
+           {:metric :median
+            :with-error-bounds (boolean with-error-bounds)
+            :data (mapv (fn [{:keys [coord data]}]
+                          (let [value (extract-metric-value data metric-id)]
+                            (if with-error-bounds
+                              (let [[lower upper] (extract-error-bounds
+                                                   data metric-id)]
+                                [coord (when value
+                                         {:value value
+                                          :lower lower
+                                          :upper upper})])
+                              [coord value])))
+                        runs)})
+
+         ;; Extract using explicit path (when metric-path is provided)
+         extract-with-path
+         (fn [mpath]
+           (let [[stats-id metric-id value-key] mpath
                  extract-bounds? (and with-error-bounds
                                       (= value-key :mean))]
-             {:metric metric-path
+             {:metric mpath
               :with-error-bounds (boolean extract-bounds?)
               :data (mapv (fn [{:keys [coord data]}]
                             (let [value (helpers/stats-value
@@ -152,9 +170,11 @@
                           runs)}))]
      (cond-> {:type :criterium/domain-extract
               :metrics (into {}
-                             (map (fn [[metric-id mpath]]
-                                    [metric-id (extract-single mpath)]))
-                             metric-paths)}
+                             (if use-median?
+                               (map (fn [mid] [mid (extract-with-median mid)]))
+                               (map (fn [mid]
+                                      [mid (extract-with-path metric-path)])))
+                             metric-ids-to-extract)}
        multi-impl? (assoc :impl-axis impl-axis-key
                           :implementations impls)))))
 

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -221,12 +221,17 @@
   run's :stats :metrics-defs, similar to extract. In multi-metric mode, the
   domain must have an :implementations key.
 
+  By default, comparison uses the bootstrapped median (quantile 0.5) when
+  available, falling back to mean from stats when bootstrap stats are
+  unavailable. When a metric-path is provided that explicitly requests
+  :mean (e.g., [:stats :elapsed-time :mean]), the mean is extracted directly.
+
   Options:
     :metric-ids        - When metric-path is nil, filter to only these metric-ids.
-    :with-error-bounds - When true and extracting :mean values, also
-                         extracts :mean-plus-3sigma and :mean-minus-3sigma
-                         as error bounds. Values become maps with :value,
-                         :lower, and :upper keys.
+    :with-error-bounds - When true, extracts error bounds for each value.
+                         Prefers bootstrap CI from quantile 0.5 when available,
+                         falls back to ±3σ from stats. Values become maps with
+                         :value, :lower, and :upper keys.
 
   In multi-metric mode, bootstrap quantile statistics (:median, :p10, :p90,
   :ci-lower, :ci-upper) are automatically included when available. This
@@ -288,43 +293,36 @@
                                             (types/runs sub-domain))]))
                               grouped)}
            impls (assoc :implementations impls)))
-       ;; Multi-metric mode
+       ;; Multi-metric mode - uses median extraction with bootstrap stats
        (let [first-run-data (:data (first runs))
              discovered (discover-quantitative-metrics
                          first-run-data)
              metric-ids-to-extract (if metric-ids
                                      (filter (set metric-ids) discovered)
                                      discovered)
-             ;; Function to extract both mean and bootstrap stats for a metric
-             compare-with-bootstrap
+             ;; Function to extract median and bootstrap stats for a metric
+             compare-with-median
              (fn [metric-id]
-               (let [metric-path [:stats metric-id :mean]
-                     extract-bounds? with-error-bounds]
-                 {:metric metric-path
+               (let [extract-bounds? with-error-bounds]
+                 {:metric :median
                   :with-error-bounds (boolean extract-bounds?)
                   :data (into {}
                               (map (fn [[axis-val sub-domain]]
                                      [axis-val
                                       (mapv (fn [{:keys [coord data]}]
-                                              (let [mean-value (helpers/stats-value
-                                                                data :stats
-                                                                metric-id :mean)
-                                                    ;; Base value with mean
+                                              (let [median-value (extract-metric-value
+                                                                  data metric-id)
+                                                    ;; Base value with median
                                                     base-value
                                                     (if extract-bounds?
-                                                      (let [lower (helpers/stats-value
-                                                                   data :stats
-                                                                   metric-id
-                                                                   :mean-minus-3sigma)
-                                                            upper (helpers/stats-value
-                                                                   data :stats
-                                                                   metric-id
-                                                                   :mean-plus-3sigma)]
-                                                        (when mean-value
-                                                          {:value mean-value
+                                                      (let [[lower upper]
+                                                            (extract-error-bounds
+                                                             data metric-id)]
+                                                        (when median-value
+                                                          {:value median-value
                                                            :lower lower
                                                            :upper upper}))
-                                                      mean-value)
+                                                      median-value)
                                                     ;; Bootstrap stats (when available)
                                                     bootstrap (helpers/bootstrap-box-plot-stats
                                                                data metric-id)]
@@ -341,7 +339,7 @@
                   :axis axis-key
                   :metrics (into {}
                                  (map (fn [metric-id]
-                                        [metric-id (compare-with-bootstrap metric-id)]))
+                                        [metric-id (compare-with-median metric-id)]))
                                  metric-ids-to-extract)}
            impls (assoc :implementations impls)))))))
 

--- a/bases/criterium/src/criterium/domain_plans.clj
+++ b/bases/criterium/src/criterium/domain_plans.clj
@@ -36,7 +36,8 @@
   Groups runs by :impl axis and compares all quantitative metrics.
   Requires map coordinates with an :impl key distinguishing implementations.
 
-  Extracts mean values with error bounds (±3σ) for bar chart visualization.
+  Extracts median values (with fallback to mean when bootstrap stats unavailable)
+  with error bounds for bar chart visualization.
   When bootstrap stats are available, also includes quantile statistics
   (median, p10, p90, CI) enabling box plot visualization.
 
@@ -54,7 +55,8 @@
   "Extract all quantitative metrics from all runs.
 
   Discovers available metrics automatically (elapsed-time, thread-allocation, etc.)
-  and extracts mean values for each.
+  and extracts median values for each (with fallback to mean when bootstrap stats
+  unavailable).
 
   Includes error bounds (±3σ) for each data point when viewed with portal or kindly.
 
@@ -65,10 +67,11 @@
           [:domain-extract-chart {}]]})
 
 (def extract-elapsed-time
-  "Extract elapsed time mean values from all runs.
+  "Extract elapsed time values from all runs using explicit mean path.
 
-  Simple plan for viewing elapsed time across a domain. For all available
-  metrics, use complexity-analysis or omit :metric-path from domain-extract-fn.
+  This plan explicitly extracts the mean value (not median) for elapsed-time.
+  For median-based extraction with bootstrap fallback, use extract-metrics or
+  complexity-analysis instead.
 
   Example:
     (analyse-domain extract-elapsed-time my-domain)"

--- a/bases/criterium/src/criterium/viewer/common/core.clj
+++ b/bases/criterium/src/criterium/viewer/common/core.clj
@@ -316,13 +316,17 @@
   (and (map? v) (contains? v :value)))
 
 (defn values-have-error-bounds?
-  "Returns true if any value in coll has :lower and :upper keys for error bounds."
+  "Returns true if any value in coll has error bounds.
+  Checks for :lower/:upper keys (from with-error-bounds option) or
+  :ci-lower/:ci-upper keys (from bootstrap stats)."
   [coll]
   (boolean
    (some (fn [v]
            (and (map? v)
-                (contains? v :lower)
-                (contains? v :upper)))
+                (or (and (contains? v :lower)
+                         (contains? v :upper))
+                    (and (contains? v :ci-lower)
+                         (contains? v :ci-upper)))))
          coll)))
 
 (defn has-box-plot-data?

--- a/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
@@ -607,8 +607,12 @@
                                           (/ ^double value
                                              ^double baseline-value))))]))
                         col-specs col-headers)))
-           row-keys)]
-      {:heading (str "Domain Comparison by " (name axis) ": " (pr-str metric))
+           row-keys)
+          type-prefix (metric-type-prefix metric)
+          heading-suffix (if type-prefix
+                           (str " (" type-prefix ")")
+                           "")]
+      {:heading (str "Domain Comparison by " (name axis) ": " (pr-str metric) heading-suffix)
        :coord-header coord-header
        :col-headers col-headers
        :rows table-rows})))
@@ -657,11 +661,15 @@
                                                      :impl impl}])
                                                  other-impls))))
                                metric-ids))
-        col-headers (mapv (fn [{:keys [type metric-id impl]}]
-                            (case type
-                              :baseline (str (name impl) " " (name metric-id))
-                              :value (str (name impl) " " (name metric-id))
-                              :factor (str (name impl) " ×")))
+        col-headers (mapv (fn [{:keys [type metric-id metric-path impl]}]
+                            (let [type-prefix (metric-type-prefix metric-path)
+                                  metric-name (if type-prefix
+                                                (str type-prefix " " (name metric-id))
+                                                (name metric-id))]
+                              (case type
+                                :baseline (str (name impl) " " metric-name)
+                                :value (str (name impl) " " metric-name)
+                                :factor (str (name impl) " ×"))))
                           col-specs)
         table-rows
         (mapv
@@ -806,15 +814,17 @@
                 metric-ids)
 
           ;; Build column headers: Implementation, then for each metric:
-          ;; median value, CI (when available), and factor
+          ;; median/mean value, CI (when available), and factor
           col-headers
           (into ["Implementation"]
                 (mapcat (fn [metric-id]
                           (let [{:keys [unit]} (get metric-scales metric-id)
+                                metric-path (get-in metrics-map [metric-id :metric])
+                                type-prefix (or (metric-type-prefix metric-path) "median")
                                 metric-name (name metric-id)
                                 value-header (if (seq unit)
-                                               (str "median " metric-name " (" unit ")")
-                                               (str "median " metric-name))
+                                               (str type-prefix " " metric-name " (" unit ")")
+                                               (str type-prefix " " metric-name))
                                 ci-header (str metric-name " CI")
                                 factor-header (str metric-name " ×")]
                             (if (get metric-has-ci metric-id)
@@ -831,10 +841,12 @@
                     (fn [metric-id]
                       (let [{:keys [unit ^double total-scale]}
                             (get metric-scales metric-id)
+                            metric-path (get-in metrics-map [metric-id :metric])
+                            type-prefix (or (metric-type-prefix metric-path) "median")
                             metric-name (name metric-id)
                             value-header (if (seq unit)
-                                           (str "median " metric-name " (" unit ")")
-                                           (str "median " metric-name))
+                                           (str type-prefix " " metric-name " (" unit ")")
+                                           (str type-prefix " " metric-name))
                             ci-header (str metric-name " CI")
                             factor-header (str metric-name " ×")
                             full-value (get value-lookup [impl metric-id])

--- a/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
@@ -15,6 +15,18 @@
       (when (#{:mean :median} value-key)
         (name value-key)))))
 
+(defn- get-error-lower
+  "Get lower error bound from value map.
+  Checks :lower first, falls back to :ci-lower from bootstrap stats."
+  [value]
+  (or (:lower value) (:ci-lower value)))
+
+(defn- get-error-upper
+  "Get upper error bound from value map.
+  Checks :upper first, falls back to :ci-upper from bootstrap stats."
+  [value]
+  (or (:upper value) (:ci-upper value)))
+
 ;;; Box plot data preparation
 
 (defn- prepare-comparison-box-data-multi-metric
@@ -327,19 +339,19 @@
                                             nil)
                                  impl-name (if impl-val
                                              (name impl-val)
-                                             default-impl-name)]
+                                             default-impl-name)
+                                 lower-bound (when (map? value)
+                                               (get-error-lower value))
+                                 upper-bound (when (map? value)
+                                               (get-error-upper value))]
                              (cond-> {"x" x-val
                                       "y" (when raw-value
                                             (* (double raw-value) total-scale))
                                       "impl" impl-name}
-                               (and has-error-bounds?
-                                    (map? value)
-                                    (contains? value :lower))
-                               (assoc "yLower" (* (double (:lower value)) total-scale))
-                               (and has-error-bounds?
-                                    (map? value)
-                                    (contains? value :upper))
-                               (assoc "yUpper" (* (double (:upper value)) total-scale)))))
+                               (and has-error-bounds? lower-bound)
+                               (assoc "yLower" (* (double lower-bound) total-scale))
+                               (and has-error-bounds? upper-bound)
+                               (assoc "yUpper" (* (double upper-bound) total-scale)))))
                          data)]
          {:metric-id metric-id
           :metric-path metric
@@ -413,19 +425,19 @@
                            (for [[impl-val entries] data
                                  {:keys [coord value]} entries
                                  :let [raw-value (core/get-numeric-value value)
-                                       x-val (get coord x-key)]
+                                       x-val (get coord x-key)
+                                       lower-bound (when (map? value)
+                                                     (get-error-lower value))
+                                       upper-bound (when (map? value)
+                                                     (get-error-upper value))]
                                  :when (some? raw-value)]
                              (cond-> {"x" x-val
                                       "y" (* (double raw-value) total-scale)
                                       "impl" (name impl-val)}
-                               (and has-error-bounds?
-                                    (map? value)
-                                    (contains? value :lower))
-                               (assoc "yLower" (* (double (:lower value)) total-scale))
-                               (and has-error-bounds?
-                                    (map? value)
-                                    (contains? value :upper))
-                               (assoc "yUpper" (* (double (:upper value)) total-scale)))))]
+                               (and has-error-bounds? lower-bound)
+                               (assoc "yLower" (* (double lower-bound) total-scale))
+                               (and has-error-bounds? upper-bound)
+                               (assoc "yUpper" (* (double upper-bound) total-scale)))))]
            {:metric-id metric-id
             :metric-path metric
             :x-title x-title
@@ -460,19 +472,19 @@
                         (for [[impl-val entries] data
                               {:keys [coord value]} entries
                               :let [raw-value (core/get-numeric-value value)
-                                    x-val (get coord x-key)]
+                                    x-val (get coord x-key)
+                                    lower-bound (when (map? value)
+                                                  (get-error-lower value))
+                                    upper-bound (when (map? value)
+                                                  (get-error-upper value))]
                               :when (some? raw-value)]
                           (cond-> {"x" x-val
                                    "y" (* (double raw-value) total-scale)
                                    "impl" (name impl-val)}
-                            (and has-error-bounds?
-                                 (map? value)
-                                 (contains? value :lower))
-                            (assoc "yLower" (* (double (:lower value)) total-scale))
-                            (and has-error-bounds?
-                                 (map? value)
-                                 (contains? value :upper))
-                            (assoc "yUpper" (* (double (:upper value)) total-scale)))))]
+                            (and has-error-bounds? lower-bound)
+                            (assoc "yLower" (* (double lower-bound) total-scale))
+                            (and has-error-bounds? upper-bound)
+                            (assoc "yUpper" (* (double upper-bound) total-scale)))))]
         [{:metric-id nil
           :metric-path metric
           :x-title x-title

--- a/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
@@ -302,10 +302,11 @@
         ;; Find the non-impl axis key
         first-metric-data (:data (val (first metrics)))
         first-coord (first (first first-metric-data))
+        ;; Always exclude :impl - it's added by domain-builder even for
+        ;; single-impl domains (where impl-axis-key is nil)
         non-impl-keys (when (map? first-coord)
-                        (if impl-axis-key
-                          (disj (set (keys first-coord)) impl-axis-key)
-                          (set (keys first-coord))))
+                        (disj (set (keys first-coord))
+                              (or impl-axis-key :impl)))
         axis-key (first non-impl-keys)]
     (mapv
      (fn [[metric-id {:keys [metric data]}]]

--- a/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
@@ -265,15 +265,26 @@
     :y-title - y-axis title with SI unit
     :has-error-bounds? - true if error bounds data is present
     :data - vector of {\"x\" number \"y\" number \"impl\" string} maps
-            (yLower/yUpper only present when error bounds exist)"
+            (yLower/yUpper only present when error bounds exist)
+
+  Handles both multi-impl and single-impl extracts. For single-impl,
+  the impl field uses the single implementation name or 'default'."
   [extract]
   (let [impl-axis-key (:impl-axis extract)
+        implementations (:implementations extract)
+        single-impl? (or (nil? implementations)
+                         (= 1 (count implementations)))
+        default-impl-name (if (and single-impl? (seq implementations))
+                            (name (first implementations))
+                            "default")
         metrics (:metrics extract)
         ;; Find the non-impl axis key
         first-metric-data (:data (val (first metrics)))
         first-coord (first (first first-metric-data))
         non-impl-keys (when (map? first-coord)
-                        (disj (set (keys first-coord)) impl-axis-key))
+                        (if impl-axis-key
+                          (disj (set (keys first-coord)) impl-axis-key)
+                          (set (keys first-coord))))
         axis-key (first non-impl-keys)]
     (mapv
      (fn [[metric-id {:keys [metric data]}]]
@@ -300,11 +311,16 @@
                          (fn [[coord value]]
                            (let [raw-value (core/get-numeric-value value)
                                  x-val (get coord axis-key)
-                                 impl-val (get coord impl-axis-key)]
+                                 impl-val (if impl-axis-key
+                                            (get coord impl-axis-key)
+                                            nil)
+                                 impl-name (if impl-val
+                                             (name impl-val)
+                                             default-impl-name)]
                              (cond-> {"x" x-val
                                       "y" (when raw-value
                                             (* (double raw-value) total-scale))
-                                      "impl" (name impl-val)}
+                                      "impl" impl-name}
                                (and has-error-bounds?
                                     (map? value)
                                     (contains? value :lower))

--- a/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/comparison.clj
@@ -6,6 +6,15 @@
   (:require
    [criterium.viewer.common.core :as core]))
 
+(defn- metric-type-prefix
+  "Extract metric type (mean/median) from metric path for y-axis titles.
+  Returns \"mean\" or \"median\" if found in path, nil otherwise."
+  [metric-path]
+  (when (and (vector? metric-path) (>= (count metric-path) 3))
+    (let [value-key (nth metric-path 2)]
+      (when (#{:mean :median} value-key)
+        (name value-key)))))
+
 ;;; Box plot data preparation
 
 (defn- prepare-comparison-box-data-multi-metric
@@ -300,8 +309,10 @@
              ;; Build axis titles
              x-title (name axis-key)
              metric-name (name metric-id)
-             base-title (if (or has-error-bounds? has-error-bound-format)
-                          (str "mean " metric-name)
+             type-prefix (when (or has-error-bounds? has-error-bound-format)
+                           (or (metric-type-prefix metric) "mean"))
+             base-title (if type-prefix
+                          (str type-prefix " " metric-name)
                           metric-name)
              y-title (if (seq unit)
                        (str base-title " (" unit ")")
@@ -389,8 +400,10 @@
                (core/compute-si-scaling metric all-values)
                ;; Build y-axis title
                metric-name (name metric-id)
-               base-title (if (or has-error-bounds? has-error-bound-format)
-                            (str "mean " metric-name)
+               type-prefix (when (or has-error-bounds? has-error-bound-format)
+                             (or (metric-type-prefix metric) "mean"))
+               base-title (if type-prefix
+                            (str type-prefix " " metric-name)
                             metric-name)
                y-title (if (seq unit)
                          (str base-title " (" unit ")")
@@ -434,8 +447,10 @@
             {:keys [^double total-scale unit]}
             (core/compute-si-scaling metric all-values)
             ;; Build y-axis title
-            base-title (if (or has-error-bounds? has-error-bound-format)
-                         (str "mean " (pr-str metric))
+            type-prefix (when (or has-error-bounds? has-error-bound-format)
+                          (or (metric-type-prefix metric) "mean"))
+            base-title (if type-prefix
+                         (str type-prefix " " (pr-str metric))
                          (pr-str metric))
             y-title (if (seq unit)
                       (str base-title " (" unit ")")

--- a/bases/criterium/src/criterium/viewer/common/domain/detection.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/detection.clj
@@ -61,6 +61,32 @@
                     axis-values (into #{} (map #(get % axis-key)) all-coords)]
                 (> (count axis-values) 1)))))))))
 
+(defn single-axis-multi-point-any-impl?
+  "Return true when extract has exactly one axis with multiple values,
+  regardless of implementation count (single or multiple implementations).
+
+  This detects the 'line chart' scenario for showing metric values
+  across a range of parameter values on a single axis."
+  [extract]
+  (let [impl-axis-key (:impl-axis extract)
+        metrics (:metrics extract)]
+    (when (seq metrics)
+      (let [;; Get all coordinates from first metric
+            first-metric-data (:data (val (first metrics)))
+            all-coords (map first first-metric-data)
+            ;; Get the non-impl axis keys from first coordinate
+            first-coord (first all-coords)
+            non-impl-keys (if (and (map? first-coord) impl-axis-key)
+                            (disj (set (keys first-coord)) impl-axis-key)
+                            (when (map? first-coord)
+                              (set (keys first-coord))))
+            ;; Single axis?
+            single-axis? (= 1 (count non-impl-keys))]
+        (when single-axis?
+          (let [axis-key (first non-impl-keys)
+                axis-values (into #{} (map #(get % axis-key)) all-coords)]
+            (> (count axis-values) 1)))))))
+
 (defn visualization-strategy
   "Determine the visualization strategy for domain extract data.
 
@@ -72,7 +98,7 @@
   [extract]
   (cond
     (single-point-multi-impl? extract) :single-point
-    (single-axis-multi-point? extract) :multi-point
+    (single-axis-multi-point-any-impl? extract) :multi-point
     :else :default-table))
 
 ;;; Domain comparison shape detection

--- a/bases/criterium/src/criterium/viewer/common/domain/detection.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/detection.clj
@@ -76,10 +76,11 @@
             all-coords (map first first-metric-data)
             ;; Get the non-impl axis keys from first coordinate
             first-coord (first all-coords)
-            non-impl-keys (if (and (map? first-coord) impl-axis-key)
-                            (disj (set (keys first-coord)) impl-axis-key)
-                            (when (map? first-coord)
-                              (set (keys first-coord))))
+            ;; Always exclude :impl - it's added by domain-builder even for
+            ;; single-impl domains (where impl-axis-key is nil)
+            non-impl-keys (when (map? first-coord)
+                            (disj (set (keys first-coord))
+                                  (or impl-axis-key :impl)))
             ;; Single axis?
             single-axis? (= 1 (count non-impl-keys))]
         (when single-axis?

--- a/bases/criterium/src/criterium/viewer/common/domain/extract.clj
+++ b/bases/criterium/src/criterium/viewer/common/domain/extract.clj
@@ -7,10 +7,34 @@
   (:require
    [criterium.viewer.common.core :as core]))
 
+(defn- format-value-with-ci
+  "Format a value with optional inline confidence interval.
+  Returns string like '1.23' or '1.23 (1.20-1.26)' when bounds present."
+  [value lower upper ^double total-scale]
+  (let [scaled-value (* (double value) total-scale)
+        base-str (format "%.3g" scaled-value)]
+    (if (and lower upper)
+      (let [scaled-lower (* (double lower) total-scale)
+            scaled-upper (* (double upper) total-scale)]
+        (format "%s (%.3g-%.3g)" base-str scaled-lower scaled-upper))
+      base-str)))
+
+(defn- metric-type-prefix
+  "Extract metric type (mean/median) from metric path for column header."
+  [metric-path]
+  (when (and (vector? metric-path) (>= (count metric-path) 3))
+    (let [value-key (nth metric-path 2)]
+      (when (#{:mean :median} value-key)
+        (name value-key)))))
+
 (defn prepare-domain-extract-table
   "Prepare domain-extract data for table rendering.
   Returns {:heading string :coord-header string :col-headers [string...]
            :rows [{col-header value...}...]} or nil if extract is nil.
+
+  Column headers include metric type (mean/median) when available.
+  Values with error bounds are formatted inline as 'value (lower-upper)'.
+
   Options:
     :header-sep - separator between impl and metric in multi-impl headers
                   (default \" \")"
@@ -22,11 +46,13 @@
           metric-ids (sort (keys metrics))
 
           ;; Collect all data points with their full coords
+          ;; Preserve original value for error bounds extraction
           all-data (for [[metric-id {:keys [metric data]}] metrics
                          [coord value] data]
                      {:metric-id metric-id
                       :metric metric
                       :coord coord
+                      :raw-value value
                       :value (core/get-numeric-value value)})
 
           ;; Collect all coordinates to detect uniform axes
@@ -80,16 +106,22 @@
                       (for [metric-id metric-ids]
                         {:metric-id metric-id}))
 
-          ;; Build lookup: {[row-key metric-id impl?] -> value}
-          lookup (reduce (fn [acc {:keys [metric-id coord value]}]
+          ;; Build lookup: {[row-key metric-id impl?] -> {:value V :lower L :upper U}}
+          ;; Store full value map for error bounds
+          lookup (reduce (fn [acc {:keys [metric-id coord raw-value value]}]
                            (let [row-key (row-key-fn coord)
-                                 impl-val (when
-                                           multi-impl?
+                                 impl-val (when multi-impl?
                                             (get coord impl-axis-key))
                                  lookup-key (if multi-impl?
                                               [row-key metric-id impl-val]
-                                              [row-key metric-id])]
-                             (assoc acc lookup-key value)))
+                                              [row-key metric-id])
+                                 entry (if (and (map? raw-value)
+                                                (contains? raw-value :value))
+                                         {:value value
+                                          :lower (:lower raw-value)
+                                          :upper (:upper raw-value)}
+                                         {:value value})]
+                             (assoc acc lookup-key entry)))
                          {}
                          all-data)
 
@@ -105,28 +137,32 @@
                                          :let [lk (if multi-impl?
                                                     [row-key metric-id impl]
                                                     [row-key metric-id])
-                                               v (get lookup lk)]
+                                               entry (get lookup lk)
+                                               v (:value entry)]
                                          :when (some? v)]
                                      v)]
                     [col-spec (core/compute-si-scaling metric-path col-values)])))
            col-specs)
 
-          ;; Build column headers
+          ;; Build column headers with metric type prefix
           col-headers
           (mapv (fn [col-spec]
                   (let [{:keys [metric-id impl]}
                         col-spec
                         {:keys [unit]} (get col-scales col-spec)
+                        metric-path (get-in metrics [metric-id :metric])
+                        type-prefix (metric-type-prefix metric-path)
                         metric-name (name metric-id)
-                        header-base (if (seq unit)
-                                      (str metric-name " (" unit ")")
-                                      metric-name)]
+                        header-base (cond-> ""
+                                      type-prefix (str type-prefix " ")
+                                      true (str metric-name)
+                                      (seq unit) (str " (" unit ")"))]
                     (if multi-impl?
                       (str (name impl) header-sep header-base)
                       header-base)))
                 col-specs)
 
-          ;; Build table rows
+          ;; Build table rows with inline CI
           table-rows
           (mapv (fn [row-key]
                   (into {coord-header
@@ -138,14 +174,13 @@
                                  lk (if multi-impl?
                                       [row-key metric-id impl]
                                       [row-key metric-id])
-                                 raw-value (get lookup lk)
+                                 {:keys [value lower upper]} (get lookup lk)
                                  {:keys [^double total-scale]}
                                  (get col-scales col-spec)
                                  header (nth col-headers idx)]
-                             [header (when raw-value
-                                       (format
-                                        "%.3g"
-                                        (* (double raw-value) total-scale)))]))
+                             [header (when value
+                                       (format-value-with-ci
+                                        value lower upper total-scale))]))
                          col-specs)))
                 row-keys)]
 
@@ -159,7 +194,10 @@
   Returns {:heading :col-headers :rows} where each row is one implementation.
 
   Columns include implementation name, then for each metric: value and factor.
-  Factor is relative to baseline (first implementation)."
+  Factor is relative to baseline (first implementation).
+
+  Column headers include metric type (mean/median) when available.
+  Values with error bounds are formatted inline as 'value (lower-upper)'."
   [extract]
   (when extract
     (let [impl-axis-key (:impl-axis extract)
@@ -168,17 +206,19 @@
           metrics (:metrics extract)
           metric-ids (sort (keys metrics))
 
-          ;; Build lookup: {[impl metric-id] -> raw-value}
+          ;; Build lookup: {[impl metric-id] -> {:value V :lower L :upper U}}
           lookup
           (reduce
            (fn [acc [metric-id {:keys [data]}]]
              (reduce
               (fn [acc2 [coord value]]
                 (let [impl-val (get coord impl-axis-key)
-                      raw-value (if (and (map? value) (contains? value :value))
-                                  (:value value)
-                                  value)]
-                  (assoc acc2 [impl-val metric-id] raw-value)))
+                      entry (if (and (map? value) (contains? value :value))
+                              {:value (:value value)
+                               :lower (:lower value)
+                               :upper (:upper value)}
+                              {:value value})]
+                  (assoc acc2 [impl-val metric-id] entry)))
               acc
               data))
            {}
@@ -190,24 +230,27 @@
                 (map (fn [metric-id]
                        (let [metric-path (get-in metrics [metric-id :metric])
                              all-values (keep (fn [impl]
-                                                (get lookup [impl metric-id]))
+                                                (:value (get lookup [impl metric-id])))
                                               implementations)]
                          [metric-id (core/compute-si-scaling metric-path all-values)])))
                 metric-ids)
 
-          ;; Build column headers: Implementation, then for each metric: value and ×
+          ;; Build column headers with metric type prefix
           col-headers
           (into ["Implementation"]
                 (mapcat (fn [metric-id]
                           (let [{:keys [unit]} (get metric-scales metric-id)
+                                metric-path (get-in metrics [metric-id :metric])
+                                type-prefix (metric-type-prefix metric-path)
                                 metric-name (name metric-id)
-                                value-header (if (seq unit)
-                                               (str metric-name " (" unit ")")
-                                               metric-name)]
+                                value-header (cond-> ""
+                                               type-prefix (str type-prefix " ")
+                                               true (str metric-name)
+                                               (seq unit) (str " (" unit ")"))]
                             [value-header (str metric-name " ×")]))
                         metric-ids))
 
-          ;; Build table rows: one per implementation
+          ;; Build table rows with inline CI
           table-rows
           (mapv
            (fn [impl]
@@ -216,21 +259,28 @@
                     (fn [metric-id]
                       (let [{:keys [unit ^double total-scale]}
                             (get metric-scales metric-id)
+                            metric-path (get-in metrics [metric-id :metric])
+                            type-prefix (metric-type-prefix metric-path)
                             metric-name (name metric-id)
-                            value-header (if (seq unit)
-                                           (str metric-name " (" unit ")")
-                                           metric-name)
+                            value-header (cond-> ""
+                                           type-prefix (str type-prefix " ")
+                                           true (str metric-name)
+                                           (seq unit) (str " (" unit ")"))
                             factor-header (str metric-name " ×")
-                            raw-value (get lookup [impl metric-id])
-                            baseline-value (get lookup [baseline-impl metric-id])
-                            formatted-value (when raw-value
-                                              (format "%.3g"
-                                                      (* (double raw-value)
-                                                         total-scale)))
-                            factor (when (and raw-value baseline-value
+                            impl-entry (get lookup [impl metric-id])
+                            impl-value (:value impl-entry)
+                            baseline-entry (get lookup [baseline-impl metric-id])
+                            baseline-value (:value baseline-entry)
+                            formatted-value (when impl-value
+                                              (format-value-with-ci
+                                               impl-value
+                                               (:lower impl-entry)
+                                               (:upper impl-entry)
+                                               total-scale))
+                            factor (when (and impl-value baseline-value
                                               (not (zero? (double baseline-value))))
                                      (format "%.2f"
-                                             (/ (double raw-value)
+                                             (/ (double impl-value)
                                                 (double baseline-value))))]
                         [[value-header formatted-value]
                          [factor-header factor]]))

--- a/bases/criterium/src/criterium/viewer/common/regression.clj
+++ b/bases/criterium/src/criterium/viewer/common/regression.clj
@@ -195,8 +195,9 @@
   "Prepare log-log transformed data points for scatter plot.
   Returns {:points [...] :axis-name string} or nil.
 
-  Points have keys: x (log(n)), y (log(time)), and optionally
-  yLower, yUpper for log-transformed error bounds.
+  Points have keys: x (log(n)), y (log(time)), origX (original n),
+  origY (original time), and optionally yLower, yUpper for
+  log-transformed error bounds.
   For multi-impl mode, points also have :impl key.
 
   The log-log-data comes from the :regressions map of a
@@ -212,15 +213,19 @@
               (vec
                (mapcat
                 (fn [impl-key]
-                  (let [{:keys [log-xs log-ys log-lowers log-uppers]}
+                  (let [{:keys [xs ys log-xs log-ys log-lowers log-uppers]}
                         (get by-impl impl-key)]
                     (when (and log-xs log-ys)
                       (map-indexed
                        (fn [i log-x]
-                         (let [log-y (nth log-ys i)]
+                         (let [log-y (nth log-ys i)
+                               orig-x (when xs (nth xs i nil))
+                               orig-y (when ys (nth ys i nil))]
                            (cond-> {"x" log-x
                                     "y" log-y
                                     "impl" (name impl-key)}
+                             orig-x (assoc "origX" orig-x)
+                             orig-y (assoc "origY" orig-y)
                              (and log-lowers (nth log-lowers i nil))
                              (assoc "yLower" (nth log-lowers i))
                              (and log-uppers (nth log-uppers i nil))
@@ -233,14 +238,18 @@
              :has-error-bounds? (boolean
                                  (some #(contains? % "yLower") all-points))}))
         ;; Single implementation mode
-        (let [{:keys [log-xs log-ys log-lowers log-uppers]} log-log-data]
+        (let [{:keys [xs ys log-xs log-ys log-lowers log-uppers]} log-log-data]
           (when (and log-xs log-ys)
             (let [points (vec
                           (map-indexed
                            (fn [i log-x]
-                             (let [log-y (nth log-ys i)]
+                             (let [log-y (nth log-ys i)
+                                   orig-x (when xs (nth xs i nil))
+                                   orig-y (when ys (nth ys i nil))]
                                (cond-> {"x" log-x
                                         "y" log-y}
+                                 orig-x (assoc "origX" orig-x)
+                                 orig-y (assoc "origY" orig-y)
                                  (and log-lowers (nth log-lowers i nil))
                                  (assoc "yLower" (nth log-lowers i))
                                  (and log-uppers (nth log-uppers i nil))

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -667,25 +667,61 @@
 
 (defn log-log-scatter-layer
   "Build scatter layer for log-log plot.
-  Points are in log space: x = log(n), y = log(time)."
+  Points are in log space: x = log(n), y = log(time).
+  Tooltips show both original and log-transformed values."
   [points {:keys [axis-name color-field color-value legend-options]}]
-  {:data {:values (vec points)}
-   :mark {:type "point" :size 60 :filled true}
-   :encoding (cond-> {:x {:field "x"
-                          :type "quantitative"
-                          :title (str "log(" axis-name ")")}
-                      :y {:field "y"
-                          :type "quantitative"
-                          :title "log(time)"}}
-               color-field
-               (assoc :color {:field color-field
-                              :type "nominal"
-                              :legend (merge {:title (if (= color-field "impl")
-                                                       "Implementation"
-                                                       "Model")}
-                                             legend-options)})
-               (and (nil? color-field) color-value)
-               (assoc :color {:value color-value}))})
+  (let [has-orig-values? (some #(contains? % "origX") points)
+        base-tooltip (if has-orig-values?
+                       [{:field "origX"
+                         :type "quantitative"
+                         :title axis-name
+                         :format ".4g"}
+                        {:field "origY"
+                         :type "quantitative"
+                         :title "time"
+                         :format ".4g"}
+                        {:field "x"
+                         :type "quantitative"
+                         :title (str "log(" axis-name ")")
+                         :format ".4f"}
+                        {:field "y"
+                         :type "quantitative"
+                         :title "log(time)"
+                         :format ".4f"}]
+                       [{:field "x"
+                         :type "quantitative"
+                         :title (str "log(" axis-name ")")
+                         :format ".4f"}
+                        {:field "y"
+                         :type "quantitative"
+                         :title "log(time)"
+                         :format ".4f"}])
+        tooltip (if color-field
+                  (into [{:field color-field
+                          :type "nominal"
+                          :title (if (= color-field "impl")
+                                   "Implementation"
+                                   "Model")}]
+                        base-tooltip)
+                  base-tooltip)]
+    {:data {:values (vec points)}
+     :mark {:type "point" :size 60 :filled true}
+     :encoding (cond-> {:x {:field "x"
+                            :type "quantitative"
+                            :title (str "log(" axis-name ")")}
+                        :y {:field "y"
+                            :type "quantitative"
+                            :title "log(time)"}
+                        :tooltip tooltip}
+                 color-field
+                 (assoc :color {:field color-field
+                                :type "nominal"
+                                :legend (merge {:title (if (= color-field "impl")
+                                                         "Implementation"
+                                                         "Model")}
+                                               legend-options)})
+                 (and (nil? color-field) color-value)
+                 (assoc :color {:value color-value}))}))
 
 (defn log-log-line-layer
   "Build fit line layer for log-log plot.

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -525,18 +525,35 @@
     :legend-options - legend config map or nil for default"
   [points {:keys [axis-name y-title color-field color-value legend-options]
            :or {color-value "steelblue"}}]
-  {:data {:values points}
-   :mark {:type "point" :size 60}
-   :encoding (cond-> {:x {:field "x" :type "quantitative" :title axis-name}
-                      :y {:field "y" :type "quantitative" :title y-title}}
-               color-field
-               (assoc :color {:field color-field :type "nominal"
-                              :legend (merge {:title (if (= color-field "impl")
-                                                       "Implementation"
-                                                       "Model")}
-                                             legend-options)})
-               (not color-field)
-               (assoc :color {:value color-value}))})
+  (let [base-tooltip [{:field "x"
+                       :type "quantitative"
+                       :title axis-name
+                       :format ".4g"}
+                      {:field "y"
+                       :type "quantitative"
+                       :title y-title
+                       :format ".4g"}]
+        tooltip (if color-field
+                  (into [{:field color-field
+                          :type "nominal"
+                          :title (if (= color-field "impl")
+                                   "Implementation"
+                                   "Model")}]
+                        base-tooltip)
+                  base-tooltip)]
+    {:data {:values points}
+     :mark {:type "point" :size 60}
+     :encoding (cond-> {:x {:field "x" :type "quantitative" :title axis-name}
+                        :y {:field "y" :type "quantitative" :title y-title}
+                        :tooltip tooltip}
+                 color-field
+                 (assoc :color {:field color-field :type "nominal"
+                                :legend (merge {:title (if (= color-field "impl")
+                                                         "Implementation"
+                                                         "Model")}
+                                               legend-options)})
+                 (not color-field)
+                 (assoc :color {:value color-value}))}))
 
 (defn regression-error-layer
   "Build error bar layer for regression points with error bounds."

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -15,6 +15,15 @@
    [criterium.viewer.common.core :as core]
    [criterium.viewer.common.domain.comparison :as comparison]))
 
+(defn- metric-type-prefix
+  "Extract metric type (mean/median) from metric path for y-axis titles.
+  Returns \"mean\" or \"median\" if found in path, nil otherwise."
+  [metric-path]
+  (when (and (vector? metric-path) (>= (count metric-path) 3))
+    (let [value-key (nth metric-path 2)]
+      (when (#{:mean :median} value-key)
+        (name value-key)))))
+
 ;;; Scatter plots
 
 (defn metric-layer
@@ -880,8 +889,10 @@
              (core/compute-si-scaling metric all-values)
              ;; Build y-axis title with unit
              metric-name (name metric-id)
-             base-title (if has-error-bounds?
-                          (str "mean " metric-name)
+             type-prefix (when has-error-bounds?
+                           (or (metric-type-prefix metric) "mean"))
+             base-title (if type-prefix
+                          (str type-prefix " " metric-name)
                           metric-name)
              y-title (if (seq unit)
                        (str base-title " (" unit ")")

--- a/bases/criterium/src/criterium/viewer/common_charts.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts.clj
@@ -522,10 +522,20 @@
   Options:
     :color-field - field name for color encoding (e.g., \"impl\" or nil for static color)
     :color-value - static color when color-field is nil (default \"steelblue\")
-    :legend-options - legend config map or nil for default"
+    :legend-options - legend config map or nil for default
+
+  When color-field is \"model\", adds a \"series\" field with value \"data\" to
+  each point since data points don't have model labels (only fit lines do)."
   [points {:keys [axis-name y-title color-field color-value legend-options]
            :or {color-value "steelblue"}}]
-  (let [base-tooltip [{:field "x"
+  (let [;; For single-impl mode (color-field="model"), data points need a series
+        ;; label since they don't have individual model values like fit lines do
+        single-impl-model-mode? (= color-field "model")
+        labeled-points (if single-impl-model-mode?
+                         (mapv #(assoc % "series" "data") points)
+                         points)
+        actual-color-field (if single-impl-model-mode? "series" color-field)
+        base-tooltip [{:field "x"
                        :type "quantitative"
                        :title axis-name
                        :format ".4g"}
@@ -533,42 +543,51 @@
                        :type "quantitative"
                        :title y-title
                        :format ".4g"}]
-        tooltip (if color-field
-                  (into [{:field color-field
+        tooltip (if actual-color-field
+                  (into [{:field actual-color-field
                           :type "nominal"
-                          :title (if (= color-field "impl")
-                                   "Implementation"
+                          :title (case actual-color-field
+                                   "impl" "Implementation"
+                                   "series" "Series"
                                    "Model")}]
                         base-tooltip)
                   base-tooltip)]
-    {:data {:values points}
+    {:data {:values labeled-points}
      :mark {:type "point" :size 60}
      :encoding (cond-> {:x {:field "x" :type "quantitative" :title axis-name}
                         :y {:field "y" :type "quantitative" :title y-title}
                         :tooltip tooltip}
-                 color-field
-                 (assoc :color {:field color-field :type "nominal"
-                                :legend (merge {:title (if (= color-field "impl")
-                                                         "Implementation"
+                 actual-color-field
+                 (assoc :color {:field actual-color-field :type "nominal"
+                                :legend (merge {:title (case actual-color-field
+                                                         "impl" "Implementation"
+                                                         "series" "Series"
                                                          "Model")}
                                                legend-options)})
-                 (not color-field)
+                 (not actual-color-field)
                  (assoc :color {:value color-value}))}))
 
 (defn regression-error-layer
-  "Build error bar layer for regression points with error bounds."
+  "Build error bar layer for regression points with error bounds.
+  When color-field is \"model\", adds a \"series\" field with value \"data\" to
+  match the scatter layer behavior."
   [points {:keys [color-field color-value]
            :or {color-value "steelblue"}}]
-  {:data {:values points}
-   :mark {:type "rule" :strokeWidth 1.5}
-   :encoding (cond-> {:x {:field "x" :type "quantitative"}
-                      :y {:field "yLower" :type "quantitative"}
-                      :y2 {:field "yUpper"}
-                      :opacity {:value 0.5}}
-               color-field
-               (assoc :color {:field color-field :type "nominal" :legend nil})
-               (not color-field)
-               (assoc :color {:value color-value}))})
+  (let [single-impl-model-mode? (= color-field "model")
+        labeled-points (if single-impl-model-mode?
+                         (mapv #(assoc % "series" "data") points)
+                         points)
+        actual-color-field (if single-impl-model-mode? "series" color-field)]
+    {:data {:values labeled-points}
+     :mark {:type "rule" :strokeWidth 1.5}
+     :encoding (cond-> {:x {:field "x" :type "quantitative"}
+                        :y {:field "yLower" :type "quantitative"}
+                        :y2 {:field "yUpper"}
+                        :opacity {:value 0.5}}
+                 actual-color-field
+                 (assoc :color {:field actual-color-field :type "nominal" :legend nil})
+                 (not actual-color-field)
+                 (assoc :color {:value color-value}))}))
 
 (defn regression-line-layer
   "Build fit line layer for regression models.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -385,6 +385,58 @@
         (is (= :impl (:impl-axis result)))
         (is (= [:vec :list] (:implementations result)))))))
 
+(deftest extract-nil-value-consistency-test
+  ;; Tests that extract handles nil values consistently between extraction modes.
+  ;; Both median mode (no metric-path) and explicit path mode should return
+  ;; nil when the metric value is nil, not a map with nil :value.
+  ;; Contracts: identical nil handling, error bounds not included for nil values.
+  (testing "extract nil value handling"
+    (testing "with explicit metric-path"
+      (testing "returns nil (not map) when value is nil with error bounds"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result
+                         {:elapsed-time {:mean-plus-3sigma 1.2
+                                         :mean-minus-3sigma 0.8}})})
+              result (analysis/extract d [:stats :elapsed-time :mean]
+                                       {:with-error-bounds true})
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          (is (nil? value)
+              "Should return nil, not {:value nil :lower 0.8 :upper 1.2}"))))
+    (testing "default median mode"
+      (testing "returns nil (not map) when value is nil with error bounds"
+        ;; mock-bench-result-with-defs creates :metrics-defs but no stats
+        ;; Use an empty metric to simulate missing median value
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-defs {:elapsed-time {}})})
+              result (analysis/extract d nil {:with-error-bounds true
+                                              :metric-ids [:elapsed-time]})
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          (is (nil? value)
+              "Should return nil, not {:value nil :lower nil :upper nil}"))))
+    (testing "both modes are consistent"
+      (let [;; Data with nil metric value but existing bounds info
+            path-data (mock-bench-result
+                       {:elapsed-time {:mean-plus-3sigma 1.2
+                                       :mean-minus-3sigma 0.8}})
+            ;; Median mode needs metrics-defs for discovery
+            median-data (mock-bench-result-with-defs {:elapsed-time {}})
+            path-result (analysis/extract
+                         (domain/domain {:coord {:n 100} :data path-data})
+                         [:stats :elapsed-time :mean]
+                         {:with-error-bounds true})
+            median-result (analysis/extract
+                           (domain/domain {:coord {:n 100} :data median-data})
+                           nil
+                           {:with-error-bounds true :metric-ids [:elapsed-time]})
+            [_c1 path-value] (first (get-in path-result [:metrics :elapsed-time :data]))
+            [_c2 median-value] (first (get-in median-result [:metrics :elapsed-time :data]))]
+        (is (= path-value median-value)
+            "Both modes should return identical nil handling")
+        (is (nil? path-value))
+        (is (nil? median-value))))))
+
 ;; Tests for domain group-by-axis function.
 ;; Validates partitioning runs by axis key values, returning a map
 ;; of axis-value to sub-domain.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -276,6 +276,115 @@
             result (analysis/extract d [:stats :elapsed-time :mean])]
         (is (not (contains? result :impl-axis)))))))
 
+(deftest extract-default-mode-test
+  ;; Tests extract when called without metric-path (default median extraction).
+  ;; Uses bootstrapped median when available, falls back to mean from stats.
+  ;; Contracts: discovers metrics, uses :median as metric key, handles error bounds.
+  (testing "extract without metric-path (default median mode)"
+    (testing "with bootstrap data available"
+      (testing "returns :median as the metric key"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-bootstrap
+                         {:elapsed-time {:mean 1.0}})})
+              result (analysis/extract d)]
+          (is (= :criterium/domain-extract (:type result)))
+          (is (= :median (get-in result [:metrics :elapsed-time :metric])))))
+      (testing "extracts bootstrapped median value"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-bootstrap
+                         {:elapsed-time {:mean 2.5}})})
+              result (analysis/extract d)
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          ;; mock-bench-result-with-bootstrap sets p50 = mean value
+          (is (= 2.5 value))))
+      (testing "discovers all quantitative metrics from first run"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-bootstrap
+                         {:elapsed-time {:mean 1.0}
+                          :thread-allocation {:mean 100.0}})})
+              result (analysis/extract d)]
+          (is (contains? (:metrics result) :elapsed-time))
+          (is (contains? (:metrics result) :thread-allocation)))))
+    (testing "without bootstrap data (fallback to mean)"
+      (testing "returns :median as metric key even when falling back"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.5}})})
+              result (analysis/extract d)]
+          (is (= :median (get-in result [:metrics :elapsed-time :metric])))))
+      (testing "extracts mean value as fallback"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-defs {:elapsed-time {:mean 3.5}})})
+              result (analysis/extract d)
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          (is (= 3.5 value)))))
+    (testing "with :metric-ids option"
+      (testing "filters to specified metrics only"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-bootstrap
+                         {:elapsed-time {:mean 1.0}
+                          :thread-allocation {:mean 100.0}
+                          :memory {:mean 1000.0}})})
+              result (analysis/extract d nil {:metric-ids [:elapsed-time :memory]})]
+          (is (contains? (:metrics result) :elapsed-time))
+          (is (contains? (:metrics result) :memory))
+          (is (not (contains? (:metrics result) :thread-allocation))))))
+    (testing "with :with-error-bounds option"
+      (testing "with bootstrap data returns bootstrap CI"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-bootstrap
+                         {:elapsed-time {:mean 1.0}})})
+              result (analysis/extract d nil {:with-error-bounds true})
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          (is (true? (get-in result [:metrics :elapsed-time :with-error-bounds])))
+          (is (map? value))
+          (is (contains? value :value))
+          (is (contains? value :lower))
+          (is (contains? value :upper))
+          ;; Bootstrap CI is ±5% in mock
+          (is (< (:lower value) (:value value)))
+          (is (> (:upper value) (:value value)))))
+      (testing "without bootstrap falls back to ±3σ"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-defs {:elapsed-time {:mean 2.0
+                                                                     :mean-minus-3sigma 1.7
+                                                                     :mean-plus-3sigma 2.3}})})
+              result (analysis/extract d nil {:with-error-bounds true})
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          (is (map? value))
+          (is (= 2.0 (:value value)))
+          (is (= 1.7 (:lower value)))
+          (is (= 2.3 (:upper value)))))
+      (testing "returns nil value when no error bounds available"
+        (let [d (domain/domain
+                 {:coord {:n 100}
+                  :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.0}})})
+              result (analysis/extract d nil {:with-error-bounds true})
+              [_coord value] (first (get-in result [:metrics :elapsed-time :data]))]
+          ;; Value should have :value but nil bounds
+          (is (map? value))
+          (is (= 1.0 (:value value)))
+          (is (nil? (:lower value)))
+          (is (nil? (:upper value))))))
+    (testing "preserves :impl-axis and :implementations"
+      (let [d (domain/domain
+               {:coord {:n 100 :impl :vec}
+                :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 1.0}})}
+               {:coord {:n 100 :impl :list}
+                :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 2.0}})}
+               {:impl-axis :impl
+                :implementations [:vec :list]})
+            result (analysis/extract d)]
+        (is (= :impl (:impl-axis result)))
+        (is (= [:vec :list] (:implementations result)))))))
+
 ;; Tests for domain group-by-axis function.
 ;; Validates partitioning runs by axis key values, returning a map
 ;; of axis-value to sub-domain.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -1847,3 +1847,63 @@
               foo-value (-> elapsed-data :foo first :value)]
           ;; Without bootstrap stats, value is just the mean
           (is (= 100.0 foo-value) "value should be the mean when no bootstrap"))))))
+
+;; Tests for metric-path validation in extract and compare-by functions.
+;; Validates that malformed paths produce clear error messages rather
+;; than silently producing nils through destructuring.
+
+(deftest metric-path-validation-test
+  ;; Tests that extract and compare-by validate metric-path structure.
+  ;; Contracts: clear error for non-vector, clear error for wrong element count.
+  (testing "extract"
+    (testing "rejects non-vector metric-path"
+      (let [d (domain/domain {:coord {:n 100}
+                              :data (mock-bench-result {:elapsed-time {:mean 1.0}})})]
+        (is (thrown? AssertionError (analysis/extract d :stats))
+            "keyword metric-path throws")
+        (is (thrown? AssertionError (analysis/extract d '(:stats :elapsed-time :mean)))
+            "list metric-path throws")))
+    (testing "rejects metric-path with wrong element count"
+      (let [d (domain/domain {:coord {:n 100}
+                              :data (mock-bench-result {:elapsed-time {:mean 1.0}})})]
+        (is (thrown? AssertionError (analysis/extract d [:stats :elapsed-time]))
+            "2-element path throws")
+        (is (thrown? AssertionError (analysis/extract d [:stats :elapsed-time :mean :extra]))
+            "4-element path throws")))
+    (testing "includes reason in error data"
+      (let [d (domain/domain {:coord {:n 100}
+                              :data (mock-bench-result {:elapsed-time {:mean 1.0}})})]
+        (try
+          (analysis/extract d :not-a-vector)
+          (is false "should throw")
+          (catch AssertionError e
+            (let [cause (.getCause e)
+                  data (ex-data cause)]
+              (is (= "metric-path must be a vector like [:stats :metric-id :value-key]"
+                     (get-in data [:data :reason])))))))))
+  (testing "compare-by"
+    (testing "rejects non-vector metric-path"
+      (let [d (domain/domain {:coord {:n 100 :impl :foo}
+                              :data (mock-bench-result {:elapsed-time {:mean 1.0}})})]
+        (is (thrown? AssertionError (analysis/compare-by d :impl :stats))
+            "keyword metric-path throws")
+        (is (thrown? AssertionError (analysis/compare-by d :impl '(:stats :elapsed-time :mean)))
+            "list metric-path throws")))
+    (testing "rejects metric-path with wrong element count"
+      (let [d (domain/domain {:coord {:n 100 :impl :foo}
+                              :data (mock-bench-result {:elapsed-time {:mean 1.0}})})]
+        (is (thrown? AssertionError (analysis/compare-by d :impl [:stats :elapsed-time]))
+            "2-element path throws")
+        (is (thrown? AssertionError (analysis/compare-by d :impl [:stats :elapsed-time :mean :extra]))
+            "4-element path throws")))
+    (testing "includes reason in error data"
+      (let [d (domain/domain {:coord {:n 100 :impl :foo}
+                              :data (mock-bench-result {:elapsed-time {:mean 1.0}})})]
+        (try
+          (analysis/compare-by d :impl [:stats :elapsed-time])
+          (is false "should throw")
+          (catch AssertionError e
+            (let [cause (.getCause e)
+                  data (ex-data cause)]
+              (is (= "metric-path must have exactly 3 elements: [stats-id metric-id value-key]"
+                     (get-in data [:data :reason]))))))))))

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -620,7 +620,7 @@
               result (analysis/compare-by d :impl nil)]
           (is (contains? (:metrics result) :elapsed-time))
           (is (contains? (:metrics result) :thread-allocation))))
-      (testing "each metric has :metric :median and :data grouped by impl"
+      (testing "each entry has :metric :median (multi-metric mode only)"
         (let [d (domain/domain
                  {:coord {:n 100 :impl :foo}
                   :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.0}})}

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -459,7 +459,7 @@
               result (analysis/compare-by d :impl nil)]
           (is (contains? (:metrics result) :elapsed-time))
           (is (contains? (:metrics result) :thread-allocation))))
-      (testing "each metric has :metric path and :data grouped by impl"
+      (testing "each metric has :metric :median and :data grouped by impl"
         (let [d (domain/domain
                  {:coord {:n 100 :impl :foo}
                   :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.0}})}
@@ -467,7 +467,8 @@
                   :data (mock-bench-result-with-defs {:elapsed-time {:mean 2.0}})})
               result (analysis/compare-by d :impl nil)
               elapsed-metric (get-in result [:metrics :elapsed-time])]
-          (is (= [:stats :elapsed-time :mean] (:metric elapsed-metric)))
+          (is (= :median (:metric elapsed-metric))
+              "multi-metric mode now uses :median extraction")
           (is (map? (:data elapsed-metric)))
           (is (contains? (:data elapsed-metric) :foo))
           (is (contains? (:data elapsed-metric) :bar))))
@@ -496,7 +497,53 @@
                                           {:metric-ids [:elapsed-time :memory]})]
           (is (contains? (:metrics result) :elapsed-time))
           (is (contains? (:metrics result) :memory))
-          (is (not (contains? (:metrics result) :thread-allocation))))))))
+          (is (not (contains? (:metrics result) :thread-allocation)))))
+      (testing "uses bootstrap median when available"
+        (let [d (domain/domain
+                 {:coord {:n 100 :impl :foo}
+                  :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 1.0}})}
+                 {:coord {:n 100 :impl :bar}
+                  :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 2.0}})})
+              result (analysis/compare-by d :impl nil)
+              foo-value (-> result
+                            (get-in [:metrics :elapsed-time :data :foo])
+                            first :value)]
+          (is (= :median (get-in result [:metrics :elapsed-time :metric])))
+          ;; With bootstrap data, value is the median (quantile 0.5 point estimate)
+          (is (map? foo-value) "value should be a map with bootstrap stats")
+          (is (= 1.0 (:value foo-value))
+              "primary value is the bootstrap median")))
+      (testing "falls back to mean when bootstrap unavailable"
+        (let [d (domain/domain
+                 {:coord {:n 100 :impl :foo}
+                  :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.5}})}
+                 {:coord {:n 100 :impl :bar}
+                  :data (mock-bench-result-with-defs {:elapsed-time {:mean 2.5}})})
+              result (analysis/compare-by d :impl nil)
+              foo-value (-> result
+                            (get-in [:metrics :elapsed-time :data :foo])
+                            first :value)]
+          (is (= :median (get-in result [:metrics :elapsed-time :metric])))
+          ;; Without bootstrap data, value is the mean directly (fallback)
+          (is (= 1.5 foo-value)
+              "falls back to mean when no bootstrap")))
+      (testing "extracts error bounds from bootstrap CI when available"
+        (let [d (domain/domain
+                 {:coord {:n 100 :impl :foo}
+                  :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 1.0}})}
+                 {:implementations [:foo]})
+              result (analysis/compare-by d :impl nil {:with-error-bounds true})
+              foo-value (-> result
+                            (get-in [:metrics :elapsed-time :data :foo])
+                            first :value)]
+          (is (:with-error-bounds (get-in result [:metrics :elapsed-time])))
+          (is (map? foo-value))
+          (is (contains? foo-value :lower))
+          (is (contains? foo-value :upper))
+          ;; Bootstrap CI is derived from quantile 0.5's estimate-quantiles
+          ;; test-util uses +/- 5% for CI
+          (is (< (:lower foo-value) (:value foo-value)))
+          (is (> (:upper foo-value) (:value foo-value))))))))
 
 ;; Tests for domain analysis pipeline functions.
 ;; Validates composable analysis transformers that operate on data-maps,

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -75,6 +75,55 @@
             bic-high-rss (analysis/compute-bic 5.0 10 2)]
         (is (< bic-low-rss bic-high-rss))))))
 
+;; Tests for metric value extraction helpers.
+;; Validates extract-metric-value and extract-error-bounds which prefer
+;; bootstrapped median/CI with fallback to mean/±3σ from stats.
+
+(deftest extract-metric-value-test
+  ;; Tests the extract-metric-value private helper.
+  ;; Prefers bootstrap median (quantile 0.5), falls back to stats mean.
+  (testing "extract-metric-value"
+    (testing "with bootstrap data present"
+      (testing "returns bootstrapped median"
+        (let [data (mock-bench-result-with-bootstrap
+                    {:elapsed-time {:mean 1.0}})]
+          ;; mock-bench-result-with-bootstrap sets p50 = mean value
+          (is (= 1.0 (#'analysis/extract-metric-value data :elapsed-time))))))
+    (testing "without bootstrap data"
+      (testing "falls back to stats mean"
+        (let [data (mock-bench-result {:elapsed-time {:mean 2.5}})]
+          (is (= 2.5 (#'analysis/extract-metric-value data :elapsed-time))))))
+    (testing "with neither bootstrap nor stats"
+      (testing "returns nil"
+        (let [data (mock-bench-result {:other-metric {:mean 1.0}})]
+          (is (nil? (#'analysis/extract-metric-value data :elapsed-time))))))))
+
+(deftest extract-error-bounds-test
+  ;; Tests the extract-error-bounds private helper.
+  ;; Prefers bootstrap CI from quantile 0.5, falls back to ±3σ.
+  (testing "extract-error-bounds"
+    (testing "with bootstrap data present"
+      (testing "returns bootstrap CI as [lower upper]"
+        (let [data (mock-bench-result-with-bootstrap
+                    {:elapsed-time {:mean 1.0}})
+              [lower upper] (#'analysis/extract-error-bounds data :elapsed-time)]
+          ;; mock-bench-result-with-bootstrap derives CI as ±5% of point estimate
+          (is (some? lower))
+          (is (some? upper))
+          (is (< lower upper)))))
+    (testing "without bootstrap data"
+      (testing "falls back to ±3σ from stats"
+        (let [data (mock-bench-result {:elapsed-time {:mean 1.0
+                                                      :mean-minus-3sigma 0.7
+                                                      :mean-plus-3sigma 1.3}})
+              [lower upper] (#'analysis/extract-error-bounds data :elapsed-time)]
+          (is (= 0.7 lower))
+          (is (= 1.3 upper)))))
+    (testing "with neither bootstrap nor stats bounds"
+      (testing "returns nil"
+        (let [data (mock-bench-result {:elapsed-time {:mean 1.0}})]
+          (is (nil? (#'analysis/extract-error-bounds data :elapsed-time))))))))
+
 ;; Tests for domain analysis function extract.
 ;; Validates extracting metric values across runs with coordinate-value pairs,
 ;; handling missing metrics, preserving order, and applying transforms.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -282,14 +282,16 @@
   ;; Contracts: discovers metrics, uses :median as metric key, handles error bounds.
   (testing "extract without metric-path (default median mode)"
     (testing "with bootstrap data available"
-      (testing "returns :median as the metric key"
+      (testing "returns :metric as path vector [:stats metric-id :median]"
         (let [d (domain/domain
                  {:coord {:n 100}
                   :data (mock-bench-result-with-bootstrap
                          {:elapsed-time {:mean 1.0}})})
               result (analysis/extract d)]
           (is (= :criterium/domain-extract (:type result)))
-          (is (= :median (get-in result [:metrics :elapsed-time :metric])))))
+          (is (= [:stats :elapsed-time :median]
+                 (get-in result [:metrics :elapsed-time :metric]))
+              "path format enables viewer SI scaling")))
       (testing "extracts bootstrapped median value"
         (let [d (domain/domain
                  {:coord {:n 100}
@@ -309,12 +311,13 @@
           (is (contains? (:metrics result) :elapsed-time))
           (is (contains? (:metrics result) :thread-allocation)))))
     (testing "without bootstrap data (fallback to mean)"
-      (testing "returns :median as metric key even when falling back"
+      (testing "returns :metric as path vector even when falling back"
         (let [d (domain/domain
                  {:coord {:n 100}
                   :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.5}})})
               result (analysis/extract d)]
-          (is (= :median (get-in result [:metrics :elapsed-time :metric])))))
+          (is (= [:stats :elapsed-time :median]
+                 (get-in result [:metrics :elapsed-time :metric])))))
       (testing "extracts mean value as fallback"
         (let [d (domain/domain
                  {:coord {:n 100}
@@ -383,7 +386,45 @@
                 :implementations [:vec :list]})
             result (analysis/extract d)]
         (is (= :impl (:impl-axis result)))
-        (is (= [:vec :list] (:implementations result)))))))
+        (is (= [:vec :list] (:implementations result))))))
+  (testing "viewer compatibility - :metric path structure"
+    ;; The viewer uses :metric to determine SI scaling (ns->s, bytes->KB, etc).
+    ;; It extracts metric type from (second metric-path) and stats type from
+    ;; (first metric-path). This test ensures :metric is always a valid path
+    ;; vector that viewers can process, not just a keyword like :median.
+    (testing "extract default mode returns valid path for viewer SI scaling"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-bench-result-with-bootstrap
+                       {:elapsed-time {:mean 1.0}
+                        :thread-allocation {:mean 100.0}})})
+            result (analysis/extract d)]
+        (doseq [metric-id [:elapsed-time :thread-allocation]]
+          (let [metric-path (get-in result [:metrics metric-id :metric])]
+            (is (vector? metric-path)
+                (str metric-id " :metric must be a vector, not a keyword"))
+            (is (= 3 (count metric-path))
+                (str metric-id " :metric path must have 3 elements"))
+            (is (= :stats (first metric-path))
+                (str metric-id " :metric path must start with :stats"))
+            (is (= metric-id (second metric-path))
+                (str metric-id " :metric path must contain metric-id at position 1"))
+            (is (= :median (nth metric-path 2))
+                (str metric-id " :metric path must end with :median"))))))
+    (testing "compare-by multi-metric mode returns valid path for viewer SI scaling"
+      (let [d (domain/domain
+               {:coord {:n 100 :impl :foo}
+                :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 1.0}})}
+               {:coord {:n 100 :impl :bar}
+                :data (mock-bench-result-with-bootstrap {:elapsed-time {:mean 2.0}})})
+            result (analysis/compare-by d :impl nil)
+            metric-path (get-in result [:metrics :elapsed-time :metric])]
+        (is (vector? metric-path)
+            ":metric must be a vector for viewer compatibility")
+        (is (= 3 (count metric-path))
+            ":metric path must have 3 elements for viewer SI scaling")
+        (is (= :stats (first metric-path))
+            ":metric path must start with :stats or :log-stats")))))
 
 (deftest extract-nil-value-consistency-test
   ;; Tests that extract handles nil values consistently between extraction modes.
@@ -620,7 +661,7 @@
               result (analysis/compare-by d :impl nil)]
           (is (contains? (:metrics result) :elapsed-time))
           (is (contains? (:metrics result) :thread-allocation))))
-      (testing "each entry has :metric :median (multi-metric mode only)"
+      (testing "each entry has :metric as path vector (multi-metric mode only)"
         (let [d (domain/domain
                  {:coord {:n 100 :impl :foo}
                   :data (mock-bench-result-with-defs {:elapsed-time {:mean 1.0}})}
@@ -628,8 +669,8 @@
                   :data (mock-bench-result-with-defs {:elapsed-time {:mean 2.0}})})
               result (analysis/compare-by d :impl nil)
               elapsed-metric (get-in result [:metrics :elapsed-time])]
-          (is (= :median (:metric elapsed-metric))
-              "multi-metric mode now uses :median extraction")
+          (is (= [:stats :elapsed-time :median] (:metric elapsed-metric))
+              "multi-metric mode uses [:stats metric-id :median] path format")
           (is (map? (:data elapsed-metric)))
           (is (contains? (:data elapsed-metric) :foo))
           (is (contains? (:data elapsed-metric) :bar))))
@@ -669,7 +710,8 @@
               foo-value (-> result
                             (get-in [:metrics :elapsed-time :data :foo])
                             first :value)]
-          (is (= :median (get-in result [:metrics :elapsed-time :metric])))
+          (is (= [:stats :elapsed-time :median]
+                 (get-in result [:metrics :elapsed-time :metric])))
           ;; With bootstrap data, value is the median (quantile 0.5 point estimate)
           (is (map? foo-value) "value should be a map with bootstrap stats")
           (is (= 1.0 (:value foo-value))
@@ -684,7 +726,8 @@
               foo-value (-> result
                             (get-in [:metrics :elapsed-time :data :foo])
                             first :value)]
-          (is (= :median (get-in result [:metrics :elapsed-time :metric])))
+          (is (= [:stats :elapsed-time :median]
+                 (get-in result [:metrics :elapsed-time :metric])))
           ;; Without bootstrap data, value is the mean directly (fallback)
           (is (= 1.5 foo-value)
               "falls back to mean when no bootstrap")))

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -1078,17 +1078,17 @@
                                                      :ci-upper 1.1e-6}}]}}
             result (comparison/prepare-comparison-line-data domain-comparison)
             data (:data (first result))
-            point (first data)]
-        ;; Should use :lower/:upper (0.8e-6, 1.2e-6) not :ci-lower/:ci-upper (0.9e-6, 1.1e-6)
-        ;; Note: values are scaled by SI factor, so we compare ratios
-        (let [y (get point "y")
-              y-lower (get point "yLower")
-              y-upper (get point "yUpper")
-              lower-ratio (/ y-lower y)
-              upper-ratio (/ y-upper y)]
-          ;; 0.8/1.0 = 0.8, 1.2/1.0 = 1.2
-          (is (< 0.79 lower-ratio 0.81))
-          (is (< 1.19 upper-ratio 1.21)))))
+            point (first data)
+            ;; Should use :lower/:upper (0.8e-6, 1.2e-6) not :ci-lower/:ci-upper (0.9e-6, 1.1e-6)
+            ;; Note: values are scaled by SI factor, so we compare ratios
+            y (double (get point "y"))
+            y-lower (get point "yLower")
+            y-upper (get point "yUpper")
+            lower-ratio (/ y-lower y)
+            upper-ratio (/ y-upper y)]
+        ;; 0.8/1.0 = 0.8, 1.2/1.0 = 1.2
+        (is (< 0.79 lower-ratio 0.81))
+        (is (< 1.19 upper-ratio 1.21))))
 
     (testing "extracts CI bounds from multi-metric comparison"
       (let [domain-comparison {:type :criterium/domain-comparison

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -325,6 +325,20 @@
         (testing "includes 'mean' in y-title for error-bound values"
           (is (str/starts-with? y-title "mean ")))))
 
+    (testing "uses 'median' in y-title when metric path contains :median"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :impl-axis :impl
+                            :implementations [:foo :bar]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :median]
+                                       :data [[{:n 100 :impl :foo} {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                                              [{:n 100 :impl :bar} {:value 2.0e-6 :lower 1.9e-6 :upper 2.1e-6}]
+                                              [{:n 200 :impl :foo} {:value 1.5e-6 :lower 1.4e-6 :upper 1.6e-6}]
+                                              [{:n 200 :impl :bar} {:value 2.5e-6 :lower 2.4e-6 :upper 2.6e-6}]]}}}
+            result (comparison/prepare-line-chart-data domain-extract)
+            {:keys [y-title]} (first result)]
+        (is (str/starts-with? y-title "median "))))
+
     (testing "does not prefix y-title with 'mean' for plain values"
       (let [domain-extract {:type :criterium/domain-extract
                             :impl-axis :impl
@@ -578,6 +592,19 @@
         (is (every? #(number? (get % "y")) data))
         (testing "includes 'mean' in y-title for error-bound values"
           (is (str/starts-with? y-title "mean ")))))
+
+    (testing "uses 'median' in y-title when metric path contains :median"
+      (let [domain-comparison {:type :criterium/domain-comparison
+                               :axis :n
+                               :metric [:stats :elapsed-time :median]
+                               :implementations [:foo :bar]
+                               :data {:foo [{:coord {:n 100} :value {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}}
+                                            {:coord {:n 200} :value {:value 1.5e-6 :lower 1.4e-6 :upper 1.6e-6}}]
+                                      :bar [{:coord {:n 100} :value {:value 2.0e-6 :lower 1.9e-6 :upper 2.1e-6}}
+                                            {:coord {:n 200} :value {:value 2.5e-6 :lower 2.4e-6 :upper 2.6e-6}}]}}
+            result (comparison/prepare-comparison-line-data domain-comparison)
+            {:keys [y-title]} (first result)]
+        (is (str/starts-with? y-title "median "))))
 
     (testing "does not prefix y-title with 'mean' for plain values"
       (let [domain-comparison {:type :criterium/domain-comparison

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -779,6 +779,67 @@
                  (get foo-data "p90"))
               "values should be in correct order"))))))
 
+;;; Tests for prepare-domain-comparison-tables helper.
+;;; Verifies multi-point comparison table preparation with factor display.
+
+(deftest prepare-domain-comparison-tables-metric-type-test
+  ;; Tests that factor tables show metric type (mean/median) in column headers.
+  (testing "prepare-domain-comparison-tables"
+    (testing "multi-metric with implementations shows metric type in headers"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:n 100} :value 1e-6}
+                                                {:coord {:n 200} :value 2e-6}]
+                                          :bar [{:coord {:n 100} :value 1.5e-6}
+                                                {:coord {:n 200} :value 2.5e-6}]}}
+                                  :thread-allocation
+                                  {:metric [:stats :thread-allocation :median]
+                                   :data {:foo [{:coord {:n 100} :value 100}
+                                                {:coord {:n 200} :value 200}]
+                                          :bar [{:coord {:n 100} :value 150}
+                                                {:coord {:n 200} :value 250}]}}}}
+            result (comparison/prepare-domain-comparison-tables comparison)
+            table (first result)
+            headers (:col-headers table)]
+        ;; Should have headers with metric type prefixes
+        (is (some #(str/includes? % "mean elapsed-time") headers)
+            "elapsed-time header should show 'mean' from metric path")
+        (is (some #(str/includes? % "median thread-allocation") headers)
+            "thread-allocation header should show 'median' from metric path")))
+
+    (testing "single-metric with implementations shows metric type in heading"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :median]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100} :value 1e-6}
+                                     {:coord {:n 200} :value 2e-6}]
+                               :bar [{:coord {:n 100} :value 1.5e-6}
+                                     {:coord {:n 200} :value 2.5e-6}]}}
+            result (comparison/prepare-domain-comparison-tables comparison)
+            table (first result)]
+        ;; Heading should include metric type
+        (is (str/includes? (:heading table) "(median)")
+            "heading should indicate median metric type")))
+
+    (testing "single-metric with mean shows mean in heading"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :n
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:n 100} :value 1e-6}
+                                     {:coord {:n 200} :value 2e-6}]
+                               :bar [{:coord {:n 100} :value 1.5e-6}
+                                     {:coord {:n 200} :value 2.5e-6}]}}
+            result (comparison/prepare-domain-comparison-tables comparison)
+            table (first result)]
+        ;; Heading should include metric type
+        (is (str/includes? (:heading table) "(mean)")
+            "heading should indicate mean metric type")))))
+
 ;;; Tests for prepare-domain-comparison-table-transposed helper.
 ;;; Verifies transposed table preparation with bootstrapped median values.
 
@@ -801,8 +862,25 @@
             result (comparison/prepare-domain-comparison-table-transposed comparison)
             rows (:rows result)]
         (is (= 2 (count rows)))
-        ;; The median column header should contain "median"
-        (is (some #(str/includes? % "median") (:col-headers result)))))
+        ;; The column header should contain metric type from path (mean in this case)
+        (is (some #(str/includes? % "mean") (:col-headers result)))))
+
+    (testing "shows median in header when metric path contains :median"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :median]
+                                   :data {:foo [{:coord {:impl :foo}
+                                                 :value {:median 1.0e-6
+                                                         :value 1.1e-6}}]
+                                          :bar [{:coord {:impl :bar}
+                                                 :value {:median 2.0e-6
+                                                         :value 2.2e-6}}]}}}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)
+            col-headers (:col-headers result)]
+        ;; The column header should contain "median" when metric path is :median
+        (is (some #(str/includes? % "median") col-headers))))
 
     (testing "includes CI columns when CI bounds present"
       (let [comparison {:type :criterium/domain-comparison
@@ -917,7 +995,7 @@
         ;; Factor should work with plain numeric values
         (is (= "2.00" (get bar-row factor-header)))))
 
-    (testing "handles single-metric mode"
+    (testing "handles single-metric mode with metric type from path"
       (let [comparison {:type :criterium/domain-comparison
                         :axis :impl
                         :metric [:stats :elapsed-time :mean]
@@ -929,4 +1007,20 @@
             result (comparison/prepare-domain-comparison-table-transposed comparison)]
         (is (map? result))
         (is (= 2 (count (:rows result))))
+        ;; Should show "mean" when metric path is :mean
+        (is (some #(str/includes? % "mean") (:col-headers result)))))
+
+    (testing "single-metric mode shows median when metric path is :median"
+      (let [comparison {:type :criterium/domain-comparison
+                        :axis :impl
+                        :metric [:stats :elapsed-time :median]
+                        :implementations [:foo :bar]
+                        :data {:foo [{:coord {:impl :foo}
+                                      :value {:median 1.0e-6}}]
+                               :bar [{:coord {:impl :bar}
+                                      :value {:median 2.0e-6}}]}}
+            result (comparison/prepare-domain-comparison-table-transposed comparison)]
+        (is (map? result))
+        (is (= 2 (count (:rows result))))
+        ;; Should show "median" when metric path is :median
         (is (some #(str/includes? % "median") (:col-headers result)))))))

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -407,6 +407,52 @@
           (is (not (contains? bar-100 "yLower")))
           (is (not (contains? bar-100 "yUpper"))))))))
 
+;;; Tests for prepare-line-chart-data with single implementation.
+;;; Verifies line chart data preparation handles single-impl extracts.
+
+(deftest prepare-line-chart-data-single-impl-test
+  (testing "prepare-line-chart-data with single implementation"
+    (testing "uses single implementation name"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :implementations [:my-impl]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :mean]
+                                       :data [[{:n 100} 1.0e-6]
+                                              [{:n 200} 1.5e-6]
+                                              [{:n 400} 2.0e-6]]}}}
+            result (comparison/prepare-line-chart-data domain-extract)
+            data (:data (first result))]
+        (is (= 3 (count data)))
+        (is (every? #(= "my-impl" (get % "impl")) data))
+        (is (= #{100 200 400} (set (map #(get % "x") data))))))
+
+    (testing "uses 'default' when no implementations key"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :mean]
+                                       :data [[{:n 100} 1.0e-6]
+                                              [{:n 200} 1.5e-6]]}}}
+            result (comparison/prepare-line-chart-data domain-extract)
+            data (:data (first result))]
+        (is (= 2 (count data)))
+        (is (every? #(= "default" (get % "impl")) data))))
+
+    (testing "handles error bounds for single impl"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :implementations [:default]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :mean]
+                                       :data [[{:n 100}
+                                               {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                                              [{:n 200}
+                                               {:value 1.5e-6 :lower 1.4e-6 :upper 1.6e-6}]]}}}
+            result (comparison/prepare-line-chart-data domain-extract)
+            first-metric (first result)
+            data (:data first-metric)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (every? #(contains? % "yLower") data))
+        (is (every? #(contains? % "yUpper") data))))))
+
 ;;; Edge case tests
 
 (deftest edge-cases-nil-values-test

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -1024,3 +1024,134 @@
         (is (= 2 (count (:rows result))))
         ;; Should show "median" when metric path is :median
         (is (some #(str/includes? % "median") (:col-headers result)))))))
+
+;;; Tests for CI bounds extraction from bootstrap stats.
+;;; Verifies that :ci-lower/:ci-upper are recognized as error bounds.
+
+(deftest prepare-comparison-line-data-ci-bounds-test
+  ;; Tests line chart data preparation recognizes bootstrap CI bounds.
+  ;; Bootstrap stats use :ci-lower/:ci-upper keys which should be extracted
+  ;; into yLower/yUpper chart fields.
+  (testing "prepare-comparison-line-data with bootstrap CI bounds"
+    (testing "extracts :ci-lower/:ci-upper into yLower/yUpper"
+      (let [domain-comparison {:type :criterium/domain-comparison
+                               :axis :n
+                               :metric [:stats :elapsed-time :median]
+                               :implementations [:foo :bar]
+                               :data {:foo [{:coord {:n 100}
+                                             :value {:value 1.0e-6
+                                                     :ci-lower 0.9e-6
+                                                     :ci-upper 1.1e-6}}
+                                            {:coord {:n 200}
+                                             :value {:value 1.5e-6
+                                                     :ci-lower 1.4e-6
+                                                     :ci-upper 1.6e-6}}]
+                                      :bar [{:coord {:n 100}
+                                             :value {:value 2.0e-6
+                                                     :ci-lower 1.8e-6
+                                                     :ci-upper 2.2e-6}}
+                                            {:coord {:n 200}
+                                             :value {:value 2.5e-6
+                                                     :ci-lower 2.3e-6
+                                                     :ci-upper 2.7e-6}}]}}
+            result (comparison/prepare-comparison-line-data domain-comparison)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (str/starts-with? (:y-title first-metric) "median "))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "yLower") data))
+          (is (every? #(contains? % "yUpper") data))
+          (doseq [d data]
+            (is (< (get d "yLower") (get d "y")))
+            (is (< (get d "y") (get d "yUpper")))))))
+
+    (testing "prefers :lower/:upper over :ci-lower/:ci-upper"
+      (let [domain-comparison {:type :criterium/domain-comparison
+                               :axis :n
+                               :metric [:stats :elapsed-time :mean]
+                               :implementations [:foo]
+                               :data {:foo [{:coord {:n 100}
+                                             :value {:value 1.0e-6
+                                                     :lower 0.8e-6
+                                                     :upper 1.2e-6
+                                                     :ci-lower 0.9e-6
+                                                     :ci-upper 1.1e-6}}]}}
+            result (comparison/prepare-comparison-line-data domain-comparison)
+            data (:data (first result))
+            point (first data)]
+        ;; Should use :lower/:upper (0.8e-6, 1.2e-6) not :ci-lower/:ci-upper (0.9e-6, 1.1e-6)
+        ;; Note: values are scaled by SI factor, so we compare ratios
+        (let [y (get point "y")
+              y-lower (get point "yLower")
+              y-upper (get point "yUpper")
+              lower-ratio (/ y-lower y)
+              upper-ratio (/ y-upper y)]
+          ;; 0.8/1.0 = 0.8, 1.2/1.0 = 1.2
+          (is (< 0.79 lower-ratio 0.81))
+          (is (< 1.19 upper-ratio 1.21)))))
+
+    (testing "extracts CI bounds from multi-metric comparison"
+      (let [domain-comparison {:type :criterium/domain-comparison
+                               :axis :n
+                               :implementations [:foo :bar]
+                               :metrics {:elapsed-time
+                                         {:metric [:stats :elapsed-time :median]
+                                          :data {:foo [{:coord {:n 100}
+                                                        :value {:value 1.0e-6
+                                                                :ci-lower 0.9e-6
+                                                                :ci-upper 1.1e-6}}
+                                                       {:coord {:n 200}
+                                                        :value {:value 1.5e-6
+                                                                :ci-lower 1.4e-6
+                                                                :ci-upper 1.6e-6}}]
+                                                 :bar [{:coord {:n 100}
+                                                        :value {:value 2.0e-6
+                                                                :ci-lower 1.8e-6
+                                                                :ci-upper 2.2e-6}}
+                                                       {:coord {:n 200}
+                                                        :value {:value 2.5e-6
+                                                                :ci-lower 2.3e-6
+                                                                :ci-upper 2.7e-6}}]}}}}
+            result (comparison/prepare-comparison-line-data domain-comparison)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "yLower") data))
+          (is (every? #(contains? % "yUpper") data)))))))
+
+(deftest prepare-line-chart-data-ci-bounds-test
+  ;; Tests line chart data preparation for domain extract recognizes bootstrap CI bounds.
+  (testing "prepare-line-chart-data with bootstrap CI bounds"
+    (testing "extracts :ci-lower/:ci-upper into yLower/yUpper"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :impl-axis :impl
+                            :implementations [:foo :bar]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :median]
+                                       :data [[{:n 100 :impl :foo}
+                                               {:value 1.0e-6
+                                                :ci-lower 0.9e-6
+                                                :ci-upper 1.1e-6}]
+                                              [{:n 100 :impl :bar}
+                                               {:value 2.0e-6
+                                                :ci-lower 1.8e-6
+                                                :ci-upper 2.2e-6}]
+                                              [{:n 200 :impl :foo}
+                                               {:value 1.5e-6
+                                                :ci-lower 1.4e-6
+                                                :ci-upper 1.6e-6}]
+                                              [{:n 200 :impl :bar}
+                                               {:value 2.5e-6
+                                                :ci-lower 2.3e-6
+                                                :ci-upper 2.7e-6}]]}}}
+            result (comparison/prepare-line-chart-data domain-extract)
+            first-metric (first result)]
+        (is (true? (:has-error-bounds? first-metric)))
+        (is (str/starts-with? (:y-title first-metric) "median "))
+        (let [data (:data first-metric)]
+          (is (every? #(contains? % "yLower") data))
+          (is (every? #(contains? % "yUpper") data))
+          (doseq [d data]
+            (when (and (get d "yLower") (get d "yUpper") (get d "y"))
+              (is (< (get d "yLower") (get d "y")))
+              (is (< (get d "y") (get d "yUpper"))))))))))

--- a/bases/criterium/test/criterium/viewer/common/domain/detection_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/detection_test.clj
@@ -121,6 +121,64 @@
     (testing "returns nil for nil extract"
       (is (nil? (detection/single-axis-multi-point? nil))))))
 
+;;; Tests for single-axis-multi-point-any-impl? helper.
+;;; Verifies detection of the line chart scenario for both single and
+;;; multiple implementations across a range of values on a single axis.
+
+(deftest single-axis-multi-point-any-impl?-test
+  (testing "single-axis-multi-point-any-impl?"
+    (testing "returns true when one axis with multiple values and multiple impls"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:foo :bar]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :impl :foo} 1.0e-6]
+                                       [{:n 100 :impl :bar} 2.0e-6]
+                                       [{:n 200 :impl :foo} 1.5e-6]
+                                       [{:n 200 :impl :bar} 2.5e-6]]}}}]
+        (is (true? (detection/single-axis-multi-point-any-impl? extract)))))
+
+    (testing "returns true when one axis with multiple values and single impl"
+      (let [extract {:type :criterium/domain-extract
+                     :implementations [:default]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100} 1.0e-6]
+                                       [{:n 200} 2.0e-6]]}}}]
+        (is (true? (detection/single-axis-multi-point-any-impl? extract)))))
+
+    (testing "returns true when no implementations key but multi-point axis"
+      (let [extract {:type :criterium/domain-extract
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100} 1.0e-6]
+                                       [{:n 200} 2.0e-6]]}}}]
+        (is (true? (detection/single-axis-multi-point-any-impl? extract)))))
+
+    (testing "returns false when one axis with single value"
+      (let [extract {:type :criterium/domain-extract
+                     :implementations [:default]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100} 1.0e-6]]}}}]
+        (is (not (detection/single-axis-multi-point-any-impl? extract)))))
+
+    (testing "returns false when multiple non-impl axes"
+      (let [extract {:type :criterium/domain-extract
+                     :impl-axis :impl
+                     :implementations [:foo :bar]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :m 10 :impl :foo} 1.0e-6]
+                                       [{:n 100 :m 10 :impl :bar} 2.0e-6]
+                                       [{:n 200 :m 20 :impl :foo} 1.5e-6]
+                                       [{:n 200 :m 20 :impl :bar} 2.5e-6]]}}}]
+        (is (not (detection/single-axis-multi-point-any-impl? extract)))))
+
+    (testing "returns nil for nil extract"
+      (is (nil? (detection/single-axis-multi-point-any-impl? nil))))))
+
 ;;; Tests for visualization-strategy helper.
 ;;; Verifies the helper returns correct strategy keywords based on extract shape.
 
@@ -149,14 +207,15 @@
                                        [{:n 200 :impl :bar} 2.5e-6]]}}}]
         (is (= :multi-point (detection/visualization-strategy extract)))))
 
-    (testing "returns :default-table for single implementation"
+    (testing "returns :multi-point for single implementation with multiple axis values"
+      ;; Single-impl multi-point now uses line chart visualization
       (let [extract {:type :criterium/domain-extract
                      :implementations [:default]
                      :metrics {:elapsed-time
                                {:metric [:stats :elapsed-time :mean]
                                 :data [[{:n 100} 1.0e-6]
                                        [{:n 200} 2.0e-6]]}}}]
-        (is (= :default-table (detection/visualization-strategy extract)))))
+        (is (= :multi-point (detection/visualization-strategy extract)))))
 
     (testing "returns :default-table for multiple non-impl axes"
       (let [extract {:type :criterium/domain-extract

--- a/bases/criterium/test/criterium/viewer/common/domain/detection_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/detection_test.clj
@@ -156,6 +156,17 @@
                                        [{:n 200} 2.0e-6]]}}}]
         (is (true? (detection/single-axis-multi-point-any-impl? extract)))))
 
+    (testing "returns true when coords have :impl but extract has no :impl-axis"
+      ;; This is the actual output from domain-builder for single-impl domains:
+      ;; coordinates include {:n X :impl :default} but extract has no :impl-axis
+      (let [extract {:type :criterium/domain-extract
+                     :implementations [:default]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :impl :default} 1.0e-6]
+                                       [{:n 200 :impl :default} 2.0e-6]]}}}]
+        (is (true? (detection/single-axis-multi-point-any-impl? extract)))))
+
     (testing "returns false when one axis with single value"
       (let [extract {:type :criterium/domain-extract
                      :implementations [:default]
@@ -215,6 +226,16 @@
                                {:metric [:stats :elapsed-time :mean]
                                 :data [[{:n 100} 1.0e-6]
                                        [{:n 200} 2.0e-6]]}}}]
+        (is (= :multi-point (detection/visualization-strategy extract)))))
+
+    (testing "returns :multi-point for single impl with :impl in coords but no :impl-axis"
+      ;; Real domain-builder output: coords have :impl but extract has no :impl-axis
+      (let [extract {:type :criterium/domain-extract
+                     :implementations [:default]
+                     :metrics {:elapsed-time
+                               {:metric [:stats :elapsed-time :mean]
+                                :data [[{:n 100 :impl :default} 1.0e-6]
+                                       [{:n 200 :impl :default} 2.0e-6]]}}}]
         (is (= :multi-point (detection/visualization-strategy extract)))))
 
     (testing "returns :default-table for multiple non-impl axes"

--- a/bases/criterium/test/criterium/viewer/common/domain/extract_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/extract_test.clj
@@ -49,7 +49,81 @@
           (is (= 10 (get first-row "n"))))))
 
     (testing "returns nil for nil extract"
-      (is (nil? (extract/prepare-domain-extract-table nil {}))))))
+      (is (nil? (extract/prepare-domain-extract-table nil {}))))
+
+    (testing "column headers include metric type prefix"
+      (testing "when metric path has :mean"
+        (let [domain-extract {:type :criterium/domain-extract
+                              :impl-axis :impl
+                              :implementations [:default]
+                              :metrics {:elapsed-time
+                                        {:metric [:stats :elapsed-time :mean]
+                                         :data [[{:n 10 :impl :default} 1.0e-6]]}}}
+              result (extract/prepare-domain-extract-table domain-extract {})
+              col-headers (:col-headers result)]
+          (is (some #(str/starts-with? % "mean ") col-headers))))
+
+      (testing "when metric path has :median"
+        (let [domain-extract {:type :criterium/domain-extract
+                              :impl-axis :impl
+                              :implementations [:default]
+                              :metrics {:elapsed-time
+                                        {:metric [:stats :elapsed-time :median]
+                                         :data [[{:n 10 :impl :default} 1.0e-6]]}}}
+              result (extract/prepare-domain-extract-table domain-extract {})
+              col-headers (:col-headers result)]
+          (is (some #(str/starts-with? % "median ") col-headers))))
+
+      (testing "no prefix for other value keys"
+        (let [domain-extract {:type :criterium/domain-extract
+                              :impl-axis :impl
+                              :implementations [:default]
+                              :metrics {:elapsed-time
+                                        {:metric [:stats :elapsed-time :min-val]
+                                         :data [[{:n 10 :impl :default} 1.0e-6]]}}}
+              result (extract/prepare-domain-extract-table domain-extract {})
+              col-headers (:col-headers result)]
+          (is (not (some #(or (str/starts-with? % "mean ")
+                              (str/starts-with? % "median "))
+                         col-headers))))))
+
+    (testing "values with error bounds are formatted inline"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :impl-axis :impl
+                            :implementations [:default]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :median]
+                                       :with-error-bounds true
+                                       :data [[{:n 10 :impl :default}
+                                               {:value 1.0e-6
+                                                :lower 0.9e-6
+                                                :upper 1.1e-6}]]}}}
+            result (extract/prepare-domain-extract-table domain-extract {})
+            first-row (first (:rows result))
+            value-header (first (filter #(str/includes? % "elapsed-time")
+                                        (:col-headers result)))
+            cell-value (get first-row value-header)]
+        ;; Value should contain CI in format "value (lower-upper)"
+        (is (string? cell-value))
+        (is (str/includes? cell-value "("))
+        (is (str/includes? cell-value "-"))))
+
+    (testing "values without error bounds are formatted plain"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :impl-axis :impl
+                            :implementations [:default]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :mean]
+                                       :data [[{:n 10 :impl :default} 1.0e-6]]}}}
+            result (extract/prepare-domain-extract-table domain-extract {})
+            first-row (first (:rows result))
+            value-header (first (filter #(str/includes? % "elapsed-time")
+                                        (:col-headers result)))
+            cell-value (get first-row value-header)]
+        ;; Value should not contain CI parentheses
+        (is (string? cell-value))
+        (is (not (str/includes? cell-value "("))
+            "Plain values should not have CI parentheses")))))
 
 ;;; Tests for prepare-domain-extract-table-transposed helper.
 ;;; Verifies transposed table generation for single-point multi-impl scenarios
@@ -129,4 +203,54 @@
                   col-headers))))
 
     (testing "returns nil for nil extract"
-      (is (nil? (extract/prepare-domain-extract-table-transposed nil))))))
+      (is (nil? (extract/prepare-domain-extract-table-transposed nil))))
+
+    (testing "column headers include metric type prefix"
+      (testing "when metric path has :mean"
+        (let [domain-extract {:type :criterium/domain-extract
+                              :impl-axis :impl
+                              :implementations [:foo :bar]
+                              :metrics {:elapsed-time
+                                        {:metric [:stats :elapsed-time :mean]
+                                         :data [[{:n 100 :impl :foo} 1.0e-6]
+                                                [{:n 100 :impl :bar} 2.0e-6]]}}}
+              result (extract/prepare-domain-extract-table-transposed domain-extract)
+              col-headers (:col-headers result)]
+          (is (some #(str/starts-with? % "mean ") col-headers))))
+
+      (testing "when metric path has :median"
+        (let [domain-extract {:type :criterium/domain-extract
+                              :impl-axis :impl
+                              :implementations [:foo :bar]
+                              :metrics {:elapsed-time
+                                        {:metric [:stats :elapsed-time :median]
+                                         :data [[{:n 100 :impl :foo} 1.0e-6]
+                                                [{:n 100 :impl :bar} 2.0e-6]]}}}
+              result (extract/prepare-domain-extract-table-transposed domain-extract)
+              col-headers (:col-headers result)]
+          (is (some #(str/starts-with? % "median ") col-headers)))))
+
+    (testing "values with error bounds are formatted inline"
+      (let [domain-extract {:type :criterium/domain-extract
+                            :impl-axis :impl
+                            :implementations [:foo :bar]
+                            :metrics {:elapsed-time
+                                      {:metric [:stats :elapsed-time :median]
+                                       :with-error-bounds true
+                                       :data [[{:n 100 :impl :foo}
+                                               {:value 1.0e-6
+                                                :lower 0.9e-6
+                                                :upper 1.1e-6}]
+                                              [{:n 100 :impl :bar}
+                                               {:value 2.0e-6
+                                                :lower 1.8e-6
+                                                :upper 2.2e-6}]]}}}
+            result (extract/prepare-domain-extract-table-transposed domain-extract)
+            foo-row (first (:rows result))
+            value-header (first (filter #(str/starts-with? % "median ")
+                                        (:col-headers result)))
+            cell-value (get foo-row value-header)]
+        ;; Value should contain CI in format "value (lower-upper)"
+        (is (string? cell-value))
+        (is (str/includes? cell-value "("))
+        (is (str/includes? cell-value "-"))))))

--- a/bases/criterium/test/criterium/viewer/common/regression_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/regression_test.clj
@@ -45,7 +45,35 @@
                     {:axis :n :impl-axis :impl})]
         (is (= 2 (count (:points result))))
         (is (some #(= "vec" (get % "impl")) (:points result)))
-        (is (some #(= "list" (get % "impl")) (:points result)))))))
+        (is (some #(= "list" (get % "impl")) (:points result)))))
+    (testing "includes original values for tooltips when present"
+      (let [log-log-data {:xs [10 20]
+                          :ys [100 200]
+                          :log-xs [(Math/log 10) (Math/log 20)]
+                          :log-ys [(Math/log 100) (Math/log 200)]}
+            result (regression/prepare-log-log-points
+                    log-log-data
+                    {:axis :n})]
+        (is (= 2 (count (:points result))))
+        (is (= 10 (get (first (:points result)) "origX")))
+        (is (= 100 (get (first (:points result)) "origY")))
+        (is (= 20 (get (second (:points result)) "origX")))
+        (is (= 200 (get (second (:points result)) "origY")))))
+    (testing "includes original values in multi-impl mode"
+      (let [log-log-data {:by-impl {:vec {:xs [10]
+                                          :ys [100]
+                                          :log-xs [(Math/log 10)]
+                                          :log-ys [(Math/log 100)]}
+                                    :list {:xs [10]
+                                           :ys [200]
+                                           :log-xs [(Math/log 10)]
+                                           :log-ys [(Math/log 200)]}}}
+            result (regression/prepare-log-log-points
+                    log-log-data
+                    {:axis :n :impl-axis :impl})]
+        (is (= 2 (count (:points result))))
+        (is (every? #(contains? % "origX") (:points result)))
+        (is (every? #(contains? % "origY") (:points result)))))))
 
 (deftest prepare-log-log-fit-line-test
   ;; Tests prepare-log-log-fit-line which generates fit line points.

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -1752,7 +1752,32 @@
         (is (map? spec))
         ;; Check that color encoding exists in scatter layer
         (let [scatter-layer (first (:layer spec))]
-          (is (contains? (get-in scatter-layer [:encoding :color]) :field)))))))
+          (is (contains? (get-in scatter-layer [:encoding :color]) :field)))))
+    (testing "includes tooltips with log values"
+      (let [spec (charts/log-log-chart-spec
+                  sample-log-log-points
+                  sample-log-log-line-points
+                  {:axis-name "n"})
+            scatter-layer (first (:layer spec))
+            tooltip (get-in scatter-layer [:encoding :tooltip])]
+        (is (vector? tooltip))
+        (is (some #(= "log(n)" (:title %)) tooltip))
+        (is (some #(= "log(time)" (:title %)) tooltip))))
+    (testing "includes original values in tooltips when present"
+      (let [points [{"x" 2.3 "y" 4.6 "origX" 10 "origY" 100}
+                    {"x" 3.0 "y" 6.0 "origX" 20 "origY" 200}]
+            spec (charts/log-log-chart-spec
+                  points
+                  sample-log-log-line-points
+                  {:axis-name "n"})
+            scatter-layer (first (:layer spec))
+            tooltip (get-in scatter-layer [:encoding :tooltip])]
+        (is (vector? tooltip))
+        ;; Should have original values first, then log values
+        (is (some #(= "n" (:title %)) tooltip))
+        (is (some #(= "time" (:title %)) tooltip))
+        (is (some #(= "log(n)" (:title %)) tooltip))
+        (is (some #(= "log(time)" (:title %)) tooltip))))))
 
 (deftest log-log-residual-spec-test
   ;; Tests the log-log-residual-spec function for structure correctness.

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -305,6 +305,21 @@
             (is (< (get d "valueLower") (get d "value")))
             (is (< (get d "value") (get d "valueUpper")))))))
 
+    (testing "uses 'median' in y-title when metric path contains :median"
+      (let [extract-with-median
+            {:type :criterium/domain-extract
+             :impl-axis :impl
+             :implementations [:foo :bar]
+             :metrics {:elapsed-time
+                       {:metric [:stats :elapsed-time :median]
+                        :data [[{:n 100 :impl :foo}
+                                {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                               [{:n 100 :impl :bar}
+                                {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]]}}}
+            result (charts/prepare-single-point-bar-data extract-with-median)
+            first-metric (first result)]
+        (is (re-find #"median" (:y-title first-metric)))))
+
     (testing "graceful degradation for mixed values"
       ;; When some values have bounds and some don't
       (let [extract-mixed

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -746,6 +746,109 @@
             (str "domain-line-chart-spec validation failed: "
                  (pr-str (:errors result))))))))
 
+;;; Single-impl line chart tests.
+;;; Verifies line chart generation for single-implementation extracts.
+
+(def single-impl-extract
+  "Sample single-impl multi-point extract for line chart testing."
+  {:type :criterium/domain-extract
+   :implementations [:default]
+   :metrics {:elapsed-time
+             {:metric [:stats :elapsed-time :mean]
+              :data [[{:n 100} 1.0e-6]
+                     [{:n 200} 1.5e-6]
+                     [{:n 400} 2.0e-6]]}}})
+
+(def single-impl-extract-with-bounds
+  "Sample single-impl extract with error bounds for line chart testing."
+  {:type :criterium/domain-extract
+   :implementations [:default]
+   :metrics {:elapsed-time
+             {:metric [:stats :elapsed-time :mean]
+              :data [[{:n 100} {:value 1.0e-6 :lower 0.9e-6 :upper 1.1e-6}]
+                     [{:n 200} {:value 1.5e-6 :lower 1.3e-6 :upper 1.7e-6}]
+                     [{:n 400} {:value 2.0e-6 :lower 1.8e-6 :upper 2.2e-6}]]}}})
+
+(deftest domain-line-chart-spec-single-impl-test
+  ;; Tests line chart spec for single-implementation extracts.
+  ;; Verifies correct Vega-Lite structure and data handling.
+  (testing "domain-line-chart-spec with single implementation"
+    (testing "produces valid structure"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract
+                  {:width 400 :height 300})]
+        (is (map? spec))
+        (is (contains? spec :vconcat))
+        (is (vector? (:vconcat spec)))
+        (is (= 1 (count (:vconcat spec))))))
+
+    (testing "includes line mark with points"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (= {:type "line" :point true} (:mark chart)))))
+
+    (testing "chart data uses single impl name"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            data (get-in chart [:data :values])]
+        (is (= 3 (count data)))
+        (is (every? #(= "default" (get % "impl")) data))))))
+
+(deftest domain-line-chart-spec-single-impl-with-bounds-test
+  ;; Tests line chart spec for single-impl with error bounds.
+  (testing "domain-line-chart-spec single-impl with error bounds"
+    (testing "produces layered structure"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))]
+        (is (contains? chart :layer))
+        (is (= 2 (count (:layer chart))))))
+
+    (testing "includes confidence band layer with area mark"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            band-layer (first (:layer chart))]
+        (is (= "area" (get-in band-layer [:mark :type])))
+        (is (= 0.2 (get-in band-layer [:mark :opacity])))))
+
+    (testing "data includes bounds"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract-with-bounds
+                  {:width 400 :height 300})
+            chart (first (:vconcat spec))
+            band-layer (first (:layer chart))
+            data (get-in band-layer [:data :values])]
+        (is (every? #(contains? % "yLower") data))
+        (is (every? #(contains? % "yUpper") data))))))
+
+(deftest domain-line-chart-spec-single-impl-schema-validation-test
+  ;; Validates single-impl line chart against Vega-Lite v6 schema.
+  (testing "domain-line-chart-spec single-impl"
+    (testing "produces valid Vega-Lite spec"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract
+                  {:width 400 :height 300})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "single-impl line chart validation failed: "
+                 (pr-str (:errors result))))))
+
+    (testing "with error bounds produces valid Vega-Lite spec"
+      (let [spec (charts/domain-line-chart-spec
+                  single-impl-extract-with-bounds
+                  {:width 400 :height 300})
+            result (schema/validate-vega-lite-spec spec)]
+        (is (:valid? result)
+            (str "single-impl line chart with bounds failed: "
+                 (pr-str (:errors result))))))))
+
 ;;; Comparison line chart tests.
 ;;; Verifies line chart generation from domain-comparison data.
 

--- a/bases/criterium/test/criterium/viewer/common_charts_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts_test.clj
@@ -196,6 +196,38 @@
             (str "regression-chart-spec validation failed: "
                  (pr-str (:errors result))))))))
 
+(deftest regression-chart-spec-tooltip-test
+  ;; Verifies regression chart scatter points include tooltips showing x and y values.
+  (testing "regression-chart-spec"
+    (testing "includes tooltips with x and y values"
+      (let [points [{"x" 100 "y" 1e6}
+                    {"x" 200 "y" 2e6}]
+            line-pts [{"x" 100 "y" 1e6 "model" "O(n)"}
+                      {"x" 200 "y" 2e6 "model" "O(n)"}]
+            opts {:axis-name "n"
+                  :y-title "Time (ns)"
+                  :color-field "model"}
+            spec (charts/regression-chart-spec points line-pts opts)
+            scatter-layer (first (:layer spec))
+            tooltip (get-in scatter-layer [:encoding :tooltip])]
+        (is (vector? tooltip))
+        (is (some #(= "n" (:title %)) tooltip))
+        (is (some #(= "Time (ns)" (:title %)) tooltip))))
+    (testing "includes color field in tooltip when multi-impl"
+      (let [points [{"x" 100 "y" 1e6 "impl" "foo"}
+                    {"x" 200 "y" 2e6 "impl" "bar"}]
+            line-pts [{"x" 100 "y" 1e6 "impl" "foo"}
+                      {"x" 200 "y" 2e6 "impl" "bar"}]
+            opts {:axis-name "n"
+                  :y-title "Time (ns)"
+                  :color-field "impl"}
+            spec (charts/regression-chart-spec points line-pts opts)
+            scatter-layer (first (:layer spec))
+            tooltip (get-in scatter-layer [:encoding :tooltip])]
+        (is (vector? tooltip))
+        (is (some #(= "Implementation" (:title %)) tooltip))
+        (is (some #(= "n" (:title %)) tooltip))))))
+
 (deftest regression-residual-spec-schema-validation-test
   ;; Validates regression-residual-spec output against Vega-Lite v6 schema.
   ;; Tests residual plot with loess smoothing.

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -658,13 +658,33 @@
             (is (= :kind/vega-lite (:kindly/kind (meta chart))))
             (is (string? (:$schema chart)))))))
 
-    (testing "outputs nothing for default-table strategy"
+    (testing "outputs line chart for single-impl multi-point extract"
+      ;; Single-impl with multiple axis values now renders line chart
       (reset! kindly/accumulated [])
       (let [data-map {:extract {:type :criterium/domain-extract
+                                :implementations [:default]
                                 :metrics {:elapsed-time
                                           {:metric [:stats :elapsed-time :mean]
                                            :data [[{:n 100} 1e6]
                                                   [{:n 1000} 1e7]]}}}}]
+        (view/domain-extract-chart* :kindly {} data-map)
+        (let [result (kindly/flush)]
+          (is (= :kind/fragment (:kindly/kind (meta result))))
+          (is (= 1 (count result)) "Expected chart only")
+          (let [[chart] result]
+            (is (= :kind/vega-lite (:kindly/kind (meta chart))))
+            (is (string? (:$schema chart)))))))
+
+    (testing "outputs nothing for default-table strategy (multi-axis)"
+      ;; Multi-axis scenarios fall into default-table with no chart
+      (reset! kindly/accumulated [])
+      (let [data-map {:extract {:type :criterium/domain-extract
+                                :impl-axis :impl
+                                :implementations [:foo :bar]
+                                :metrics {:elapsed-time
+                                          {:metric [:stats :elapsed-time :mean]
+                                           :data [[{:n 100 :m 10 :impl :foo} 1e6]
+                                                  [{:n 1000 :m 20 :impl :bar} 1e7]]}}}}]
         (view/domain-extract-chart* :kindly {} data-map)
         (is (nil? (kindly/flush)))))
 


### PR DESCRIPTION
## Summary

Update domain complexity analysis, domain model fitting, and domain comparison to use the bootstrapped median rather than the mean for more robust results against outliers.

## Changes

- **Add median extraction helpers**: New `extract-metric-value` and `extract-error-bounds` private functions in `criterium.domain.analysis` that prioritize bootstrapped median with fallback to mean from stats
- **Update `extract` function**: Uses bootstrapped median by default when called without explicit metric-path; preserves explicit path extraction for backwards compatibility
- **Update `compare-by` function**: Multi-metric mode now uses bootstrapped median via the new helpers; single-metric mode (explicit path) unchanged
- **Add metric-path validation**: Both `extract` and `compare-by` now validate metric-path structure when provided, preventing silent nils from malformed paths
- **Update docstrings**: `domain_plans.clj` documentation updated to reflect median-based extraction

## Behavior

- **Primary**: Use bootstrapped median from `[:bootstrap-stats :bootstrap metric-id :quantiles 0.5 :point-estimate]`
- **Fallback**: When bootstrap stats unavailable, fall back to mean from `[:stats metric-id :mean]`
- **Error bounds**: Use bootstrap CI from quantile 0.5's `estimate-quantiles`, fallback to `mean-plus-3sigma`/`mean-minus-3sigma`
- **API**: `:with-error-bounds` option name unchanged

## Test plan

- [x] Tests for median extraction with bootstrap data
- [x] Tests for fallback to mean when no bootstrap
- [x] Tests for error bounds fallback to ±3σ
- [x] Tests for consistent nil value handling
- [x] Tests for metric-path validation
- [x] All existing tests pass