### PR TITLE
feat: improve warmup to be more representative

### DIFF
--- a/bases/arg-gen/resources/clj-kondo.exports/criterium/arg-gen/clj_kondo/hooks.clj
+++ b/bases/arg-gen/resources/clj-kondo.exports/criterium/arg-gen/clj_kondo/hooks.clj
@@ -3,7 +3,7 @@
    [clj-kondo.hooks-api :as api]))
 
 (defn measured
-  "Rewrite atg-gen measured forms."
+  "Rewrite arg-gen measured forms."
   [{:keys [node]}]
   (let [[_measured & more]         (:children node)
         [_options bindings & body] (if (api/map-node? (first more))
@@ -14,5 +14,20 @@
                                      (api/token-node 'let)
                                      bindings
                                      body))]
-    ;; un-comment below to debug changes
+    {:node (with-meta new-node (meta node))}))
+
+(defn args-fn
+  "Rewrite arg-gen args-fn forms.
+  Transforms (args-fn opts? [bindings...] body) to (let [bindings...] body)
+  for clj-kondo analysis."
+  [{:keys [node]}]
+  (let [[_args-fn & more]          (:children node)
+        [_options bindings & body] (if (api/map-node? (first more))
+                                     more
+                                     (into [nil] more))
+        new-node                   (api/list-node
+                                    (list*
+                                     (api/token-node 'let)
+                                     bindings
+                                     body))]
     {:node (with-meta new-node (meta node))}))

--- a/bases/arg-gen/resources/clj-kondo.exports/criterium/arg-gen/config.edn
+++ b/bases/arg-gen/resources/clj-kondo.exports/criterium/arg-gen/config.edn
@@ -1,3 +1,4 @@
 {:hooks
  {:analyze-call
-  {criterium.arg-gen/measured clj-kondo.hooks/measured}}}
+  {criterium.arg-gen/measured clj-kondo.hooks/measured
+   criterium.arg-gen/args-fn  clj-kondo.hooks/args-fn}}}

--- a/bases/arg-gen/src/criterium/arg_gen.clj
+++ b/bases/arg-gen/src/criterium/arg_gen.clj
@@ -27,9 +27,10 @@
                 :rng          rng
                 :size-seq     size-seq})))
 
-(defn args-fn
+(defn make-args-fn-from-state
   "Return a zero-arg function that generates arguments from gen.
-  Each call advances the RNG and size sequence in args-fn-state."
+  Each call advances the RNG and size sequence in args-fn-state.
+  Internal helper - used by macros via eval."
   [gen args-fn-state]
   (fn []
     (let [{:keys [rng size-seq]} @args-fn-state
@@ -50,16 +51,16 @@
     (fn [[a b]] (+ a b))
     {})"
   [gen f {:keys [size seed] :or {size 100 seed nil}}]
-  (let [args-fn-state (args-fn-state size seed)]
+  (let [state (args-fn-state size seed)]
     (measured/measured
-     (args-fn gen args-fn-state)
+     (make-args-fn-from-state gen state)
      f)))
 
 (defn arg-metas-from-example
   "Return a vector of type hints for the generated state elements."
   [binding-gens]
   (let [example-size  2
-        example-form  `((args-fn
+        example-form  `((make-args-fn-from-state
                          ~binding-gens
                          (args-fn-state ~example-size nil)))
         example-state (eval example-form)
@@ -113,3 +114,78 @@
     (do
       (assert (map? bindings) "First arg must be options map or bindings vector")
       `(measured* ~bindings ~@body))))
+
+(defmacro args-fn*
+  "Return a zero-arg function that generates arguments using test.check.
+
+  Takes a `let`-style bindings vector where each right-hand side is a
+  test.check generator. The body expression determines the return value
+  shape, typically a vector of arguments.
+
+  Earlier binding pairs are visible to later pairs. Multiple body
+  expressions execute in sequence as with `do`.
+
+  Each call to the returned function generates new values, advancing
+  the internal RNG and size sequence.
+
+  Example:
+
+  (args-fn* {:size 50 :seed 42}
+    [a gen/large-integer
+     b gen/large-integer]
+    [a b])"
+  [{:keys [size seed]
+    :or   {size 100 seed nil}
+    :as   _options}
+   bindings & body]
+  (let [pairs        (partition 2 bindings)
+        binding-vars (mapv first pairs)
+        binding-gens (reduce
+                      (fn [curr [sym code]]
+                        `(gen/bind ~code (fn [~sym] ~curr)))
+                      `(gen/return ~binding-vars)
+                      (reverse pairs))]
+    `(let [state# (args-fn-state ~size ~seed)
+           gen#   ~binding-gens]
+       (fn []
+         (let [~binding-vars ((make-args-fn-from-state gen# state#))]
+           (do ~@body))))))
+
+(defmacro args-fn
+  "Return a zero-arg function that generates arguments using test.check.
+
+  Takes an optional options map followed by a `let`-style bindings vector
+  where each right-hand side is a test.check generator. The body expression
+  determines the return value shape, typically a vector of arguments.
+
+  Options:
+    :size - Maximum size for generators (default 100)
+    :seed - Random seed for reproducibility (default nil, uses timestamp)
+
+  Earlier binding pairs are visible to later pairs.
+
+  Examples:
+
+  ;; Without options
+  (args-fn [a gen/large-integer
+            b gen/large-integer]
+    [a b])
+
+  ;; With options
+  (args-fn {:size 50 :seed 42}
+    [a gen/large-integer
+     b gen/large-integer]
+    [a b])
+
+  ;; Dependent bindings
+  (args-fn {:size 100}
+    [n (gen/choose 10 100)
+     v (gen/vector gen/small-integer n)]
+    [v])"
+  [bindings-or-options & args]
+  (if (vector? bindings-or-options)
+    `(args-fn* nil ~bindings-or-options ~@args)
+    (do
+      (assert (map? bindings-or-options)
+              "First arg must be options map or bindings vector")
+      `(args-fn* ~bindings-or-options ~@args))))

--- a/bases/arg-gen/src/criterium/arg_gen.clj
+++ b/bases/arg-gen/src/criterium/arg_gen.clj
@@ -1,5 +1,28 @@
 (ns criterium.arg-gen
-  "Argument generation"
+  "Argument generation using test.check generators.
+
+  Provides macros for creating benchmarks with generated arguments and
+  for creating zero-arg functions that generate varied inputs.
+
+  Primary use cases:
+  - `measured`: Create a Measured with generated arguments for benchmarking
+  - `args-fn`: Create a warmup-args-fn for use with :warmup-args-fn option
+
+  The `args-fn` macro is particularly useful for creating warmup functions
+  that generate varied inputs, enabling more representative JIT optimization
+  during the warmup phase.
+
+  Example:
+  (require '[criterium.arg-gen :as arg-gen]
+           '[criterium.bench :refer [bench]]
+           '[clojure.test.check.generators :as gen])
+
+  ;; Use varied warmup inputs for better JIT optimization
+  (let [coll (vec (range 1000))]
+    (bench (sort coll)
+           :warmup-args-fn (arg-gen/args-fn {:size 200}
+                             [v (gen/vector gen/small-integer)]
+                             [v])))"
   (:require [clojure.test.check.generators :as gen]
             [clojure.test.check.random :as random]
             [clojure.test.check.rose-tree :as rose]

--- a/bases/arg-gen/test/criterium/arg_gen_test.clj
+++ b/bases/arg-gen/test/criterium/arg_gen_test.clj
@@ -56,3 +56,89 @@
           (is (every? (comp integer? first) vs))
           (is (= '([0] [0] [0] [3] [4] [5] [-6] [3] [6] [6])
                  vs)))))))
+
+;; Tests for arg-gen/args-fn macro.
+;; Validates that args-fn creates zero-arg functions that generate
+;; arguments using test.check generators for use as warmup-args-fn.
+(deftest args-fn-test
+  (testing "arg-gen/args-fn"
+    (testing "with single binding"
+      (let [f (arg-gen/args-fn [x gen/small-integer] [x])]
+        (testing "returns a function"
+          (is (fn? f)))
+        (testing "generates integer values"
+          (let [[x] (f)]
+            (is (integer? x))))))
+
+    (testing "with multiple independent bindings"
+      (let [f (arg-gen/args-fn
+               [a gen/small-integer
+                b gen/string-alphanumeric]
+               [a b])]
+        (testing "generates values for each binding"
+          (let [[a b] (f)]
+            (is (integer? a))
+            (is (string? b))))))
+
+    (testing "with dependent bindings"
+      (let [f (arg-gen/args-fn
+               [n (gen/choose 5 10)
+                v (gen/vector gen/small-integer n)]
+               [v])]
+        (testing "generates values respecting dependency"
+          (let [[v] (f)]
+            (is (vector? v))
+            (is (<= 5 (count v) 10))
+            (is (every? integer? v))))))
+
+    (testing "generates different values on each call"
+      (let [f  (arg-gen/args-fn [x gen/large-integer] [x])
+            vs (repeatedly 10 f)]
+        (testing "values vary across calls"
+          (is (< 1 (count (distinct vs)))
+              "should generate at least some different values"))))
+
+    (testing "with :size option"
+      (let [f (arg-gen/args-fn {:size 3}
+                               [i gen/small-integer]
+                               [i])]
+        (testing "respects size constraint"
+          (let [vs (repeatedly 20 f)]
+            (is (every? #(<= -3 (first %) 3) vs)
+                "values should be bounded by size")))))
+
+    (testing "with :seed option"
+      (let [f (arg-gen/args-fn {:seed 12345}
+                               [i gen/small-integer]
+                               [i])]
+        (testing "generates reproducible values"
+          (let [vs (vec (repeatedly 10 f))]
+            (is (= [[0] [0] [0] [3] [4] [5] [-6] [3] [6] [6]]
+                   vs))))))
+
+    (testing "with :size and :seed options"
+      (let [f1 (arg-gen/args-fn {:size 50 :seed 999}
+                                [x gen/small-integer]
+                                [x])
+            f2 (arg-gen/args-fn {:size 50 :seed 999}
+                                [x gen/small-integer]
+                                [x])]
+        (testing "same options produce same sequence"
+          (is (= (vec (repeatedly 10 f1))
+                 (vec (repeatedly 10 f2)))))))
+
+    (testing "without options map"
+      (let [f (arg-gen/args-fn [x gen/boolean] [x])]
+        (testing "works with bindings vector as first arg"
+          (is (fn? f))
+          (let [[x] (f)]
+            (is (boolean? x))))))
+
+    (testing "independent state per invocation"
+      (let [f1 (arg-gen/args-fn {:seed 42} [x gen/small-integer] [x])
+            f2 (arg-gen/args-fn {:seed 42} [x gen/small-integer] [x])]
+        (testing "separate invocations have independent state"
+          (is (= (f1) (f2))
+              "first call should match")
+          (is (= (f1) (f2))
+              "second call should match"))))))

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -220,8 +220,8 @@
       :warmup-args-fn - Function returning arguments for warmup phase (optional).
                      When specified, warmup uses varied inputs from this function
                      instead of the expression's captured arguments, enabling
-                     more representative JIT optimization. Takes precedence over
-                     any warmup-args-fn on the Measured instance.
+                     more representative JIT optimization. This option is baked
+                     into the Measured at macro expansion time.
       :with-allocation-trace - When true, collect allocation trace and display
                      allocation analysis (summary, hotspots, by-type). Requires
                      the native agent to be attached. (optional)

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -220,7 +220,8 @@
       :warmup-args-fn - Function returning arguments for warmup phase (optional).
                      When specified, warmup uses varied inputs from this function
                      instead of the expression's captured arguments, enabling
-                     more representative JIT optimization.
+                     more representative JIT optimization. Takes precedence over
+                     any warmup-args-fn on the Measured instance.
       :with-allocation-trace - When true, collect allocation trace and display
                      allocation analysis (summary, hotspots, by-type). Requires
                      the native agent to be attached. (optional)

--- a/bases/criterium/src/criterium/bench.clj
+++ b/bases/criterium/src/criterium/bench.clj
@@ -217,6 +217,10 @@
       :limit-time-s - Time limit in seconds (optional)
       :collect-plan - Sampling strategy (optional)
       :time-fn     - Custom timing function (optional)
+      :warmup-args-fn - Function returning arguments for warmup phase (optional).
+                     When specified, warmup uses varied inputs from this function
+                     instead of the expression's captured arguments, enabling
+                     more representative JIT optimization.
       :with-allocation-trace - When true, collect allocation trace and display
                      allocation analysis (summary, hotspots, by-type). Requires
                      the native agent to be attached. (optional)
@@ -241,6 +245,11 @@
          :metric-ids [:elapsed-time :memory]
          :limit-time-s 5)
 
+  ;; With warmup using varied inputs
+  (let [coll (vec (range 1000))]
+    (bench (sort coll)
+           :warmup-args-fn (fn [] [(vec (shuffle (range 5000)))])))
+
   (bench (+ 1 1)
          :viewer :portal
          :benchmark (criterium.benchmark/->benchmark
@@ -258,8 +267,8 @@
   - Local bindings from enclosing scope can be used in the expression"
   [expr & options]
   (let [options-map (apply hash-map options)
-        expr-options (select-keys options-map [:time-fn])
-        options (dissoc options-map :time-fn)]
+        expr-options (select-keys options-map [:time-fn :warmup-args-fn])
+        options (dissoc options-map :time-fn :warmup-args-fn)]
     `(bench-measured
       (options->bench-plan ~options)
       (measured/expr ~expr ~expr-options))))

--- a/bases/criterium/src/criterium/bench/config.clj
+++ b/bases/criterium/src/criterium/bench/config.clj
@@ -74,7 +74,8 @@
                         :bench-plan
                         :verbose
                         :viewer
-                        :with-allocation-trace})
+                        :with-allocation-trace
+                        :warmup-args-fn})
         limit-time-s (:limit-time-s options-map)
         analyse (:analyse options-map)
         view (:view options-map)

--- a/bases/criterium/src/criterium/collect.clj
+++ b/bases/criterium/src/criterium/collect.clj
@@ -252,7 +252,7 @@
          elapsed-time 0
          min-time     Long/MAX_VALUE
          collections  []]
-    (let [args         (measured/args measured)
+    (let [args         (measured/warmup-args measured)
           collected    (collector/collect collector measured args batch-size)
           t            (metric/elapsed-time collected)
           elapsed-time (unchecked-add elapsed-time t)]

--- a/bases/criterium/src/criterium/domain.clj
+++ b/bases/criterium/src/criterium/domain.clj
@@ -150,8 +150,8 @@
     :viewer        - Output format (:print, :pprint, :kindly, :portal, :none).
                      Overrides any :viewer in the domain-plan.
     :reporter      - Progress reporter (default: dot-reporter, nil for silent)
-    :bench-options - Options passed to bench-measured. Notably :warmup-args-fn
-                     can be used to provide varied warmup inputs for all runs.
+    :bench-options - Options passed to bench-measured (e.g., :limit-time-s, :metric-ids).
+                     Note: :warmup-args-fn is not supported here; use domain-expr options instead.
     :time-axis     - Axis key for time estimation (default: first axis)
 
   Returns the analysis data-map (same as analyse-domain).

--- a/bases/criterium/src/criterium/domain.clj
+++ b/bases/criterium/src/criterium/domain.clj
@@ -68,16 +68,20 @@
 ;;; Domain Expression Macro
 
 (defn- transform-impl-expr
-  "Transform an implementation expression into (fn [{:keys [syms]}] (measured/expr body)).
-  Type hints on axis binding symbols transfer to the destructured keys."
-  [expr axis-syms]
+  "Transform an implementation expression into (fn [{:keys [syms]}] (measured/expr body options)).
+  Type hints on axis binding symbols transfer to the destructured keys.
+  Options are passed through to measured/expr (e.g., :warmup-args-fn)."
+  [expr axis-syms options]
   (let [keys-with-hints (mapv (fn [sym]
                                 (if-let [hint (-> sym meta :tag)]
                                   (with-meta (symbol (name sym)) {:tag hint})
                                   (symbol (name sym))))
                               axis-syms)]
-    `(fn [{:keys ~keys-with-hints}]
-       (measured/expr ~expr))))
+    (if options
+      `(fn [{:keys ~keys-with-hints}]
+         (measured/expr ~expr ~options))
+      `(fn [{:keys ~keys-with-hints}]
+         (measured/expr ~expr)))))
 
 (defmacro domain-expr
   "Create a domain specification map from a concise expression syntax.
@@ -99,25 +103,37 @@
                   m (linear-range 1 10 3)]
       (matrix-mult (random-matrix n m)))
 
+    ;; With options (e.g., shared warmup-args-fn for JIT warmup)
+    (domain-expr [n (log-range 10 1000 5)]
+      {:sort (sort (random-seq n))
+       :sort-by (sort-by identity (random-seq n))}
+      {:warmup-args-fn (fn [] [(vec (shuffle (range 5000)))])})
+
   The binding vector defines axes as [sym range-expr ...] pairs.
   Axis symbols are available in implementation expressions.
 
   Each implementation becomes a function (fn [axis-map] measured) that
   receives axis values and returns a Measured for that coordinate.
-  Type hints on axis bindings transfer to the destructured keys."
-  [bindings body]
-  (let [axis-pairs (partition 2 bindings)
-        axis-syms (mapv first axis-pairs)
-        axes-map (into {}
-                       (map (fn [[sym range-expr]]
-                              [(keyword sym) range-expr]))
-                       axis-pairs)
-        impls (if (map? body) body {:default body})
-        impl-entries (map (fn [[impl-key expr]]
-                            [impl-key (transform-impl-expr expr axis-syms)])
-                          impls)]
-    `{:axes ~axes-map
-      :implementations ~(into {} impl-entries)}))
+  Type hints on axis bindings transfer to the destructured keys.
+
+  Options:
+    :warmup-args-fn - Function returning arguments for warmup phase.
+                      Applied to all implementations for consistent JIT warmup."
+  ([bindings body]
+   `(domain-expr ~bindings ~body nil))
+  ([bindings body options]
+   (let [axis-pairs (partition 2 bindings)
+         axis-syms (mapv first axis-pairs)
+         axes-map (into {}
+                        (map (fn [[sym range-expr]]
+                               [(keyword sym) range-expr]))
+                        axis-pairs)
+         impls (if (map? body) body {:default body})
+         impl-entries (map (fn [[impl-key expr]]
+                             [impl-key (transform-impl-expr expr axis-syms options)])
+                           impls)]
+     `{:axes ~axes-map
+       :implementations ~(into {} impl-entries)})))
 
 ;;; High-level API
 

--- a/bases/criterium/src/criterium/domain.clj
+++ b/bases/criterium/src/criterium/domain.clj
@@ -150,7 +150,8 @@
     :viewer        - Output format (:print, :pprint, :kindly, :portal, :none).
                      Overrides any :viewer in the domain-plan.
     :reporter      - Progress reporter (default: dot-reporter, nil for silent)
-    :bench-options - Options passed to bench-measured
+    :bench-options - Options passed to bench-measured. Notably :warmup-args-fn
+                     can be used to provide varied warmup inputs for all runs.
     :time-axis     - Axis key for time estimation (default: first axis)
 
   Returns the analysis data-map (same as analyse-domain).

--- a/bases/criterium/src/criterium/measured.clj
+++ b/bases/criterium/src/criterium/measured.clj
@@ -20,8 +20,8 @@
   more representative JIT optimization.
 
   Priority rule for warmup arguments:
-  1. Options-level :warmup-args-fn (in bench macro or bench-measured)
-  2. Measured-level warmup-args-fn (from measured constructor)
+  1. The bench macro's :warmup-args-fn option (baked into Measured at compile time)
+  2. Measured-level warmup-args-fn (from measured constructor or with-warmup-args-fn)
   3. Fall back to regular args-fn
 
   While Criterium automatically creates Measured instances for expressions,

--- a/bases/criterium/src/criterium/measured.clj
+++ b/bases/criterium/src/criterium/measured.clj
@@ -160,8 +160,18 @@
    (impl/measured-expr* expr options &env)))
 
 (defmacro callable
-  "Return a Measured for the given no arg function."
+  "Return a Measured for a function.
+
+  With one argument, the function takes no arguments.
+
+  With two arguments, the first is a setup function that returns a
+  sequence of arguments to pass to the function.
+
+  With three arguments, the third is a warmup-args-fn that returns
+  arguments to use during warmup instead of the setup function."
   ([f]
    (impl/measured-callable f))
   ([sf f]
-   (impl/measured-callable sf f)))
+   (impl/measured-callable sf f))
+  ([sf f warmup-args-fn]
+   (impl/measured-callable sf f warmup-args-fn)))

--- a/bases/criterium/src/criterium/measured.clj
+++ b/bases/criterium/src/criterium/measured.clj
@@ -43,20 +43,30 @@
   than the timer granularity.
 
   expr-fn, if specified, returns a symbolic representation of the measured,
-  for inspection purposes (unused internally)."
-  ^criterium.measured.impl.Measured
-  [args-fn f & [expr-fn]]
-  (impl/measured args-fn f expr-fn))
+  for inspection purposes (unused internally).
+
+  warmup-args-fn, if specified, provides arguments for warmup phase instead
+  of args-fn. This allows warmup with more varied inputs to get more
+  representative JIT optimization."
+  (^criterium.measured.impl.Measured [args-fn f]
+   (impl/measured args-fn f))
+  (^criterium.measured.impl.Measured [args-fn f expr-fn]
+   (impl/measured args-fn f expr-fn))
+  (^criterium.measured.impl.Measured [args-fn f expr-fn warmup-args-fn]
+   (impl/measured args-fn f expr-fn warmup-args-fn)))
 
 (defn with-args-fn
   "Return a new Measured with the args-fn replaced.
-  Preserves the measurement function and symbolic representation.
+  Preserves the measurement function, symbolic representation, and warmup-args-fn.
 
   This is useful for running the same measured expression with different
   input generators, e.g., when benchmarking across a parameter space."
   ^criterium.measured.impl.Measured
   [measured new-args-fn]
-  (impl/measured new-args-fn (.-f ^Measured measured) (:expr-fn measured)))
+  (impl/measured new-args-fn
+                 (.-f ^Measured measured)
+                 (:expr-fn measured)
+                 (:warmup-args-fn measured)))
 
 (defn args
   "Generate the input state for a measured.
@@ -66,6 +76,17 @@
   optimizations."
   [measured]
   ((:args-fn measured)))
+
+(defn warmup-args
+  "Generate warmup input state for a measured.
+
+  Returns warmup-args-fn result if present, otherwise falls back to args-fn.
+  This allows warmup to use more varied inputs for better JIT optimization
+  while measurement uses the actual benchmark inputs."
+  [measured]
+  (if-let [warmup-args-fn (:warmup-args-fn measured)]
+    (warmup-args-fn)
+    ((:args-fn measured))))
 
 (defn invoke
   "Invoke the given Measured.

--- a/bases/criterium/src/criterium/measured.clj
+++ b/bases/criterium/src/criterium/measured.clj
@@ -6,11 +6,23 @@
   - A function to execute and measure
   - An arguments generator to prevent constant folding
   - Optional symbolic representation for debugging
+  - Optional warmup arguments generator for JIT optimization
 
   The Measured implements a timed, batch invocation interface that:
   - Supports multiple evaluations per timing sample for fast expressions
   - Guarantees zero garbage allocation during measurement
   - Prevents constant folding optimization of inputs
+
+  Warmup Customization:
+  Functions may have different complexities based on their inputs. If warmup
+  always uses the same arguments, JIT may over-specialize for those inputs.
+  The warmup-args-fn field enables using varied inputs during warmup for
+  more representative JIT optimization.
+
+  Priority rule for warmup arguments:
+  1. Options-level :warmup-args-fn (in bench macro or bench-measured)
+  2. Measured-level warmup-args-fn (from measured constructor)
+  3. Fall back to regular args-fn
 
   While Criterium automatically creates Measured instances for expressions,
   you can also construct custom ones for special measurement needs."
@@ -67,6 +79,20 @@
                  (.-f ^Measured measured)
                  (:expr-fn measured)
                  (:warmup-args-fn measured)))
+
+(defn with-warmup-args-fn
+  "Return a new Measured with the warmup-args-fn set or replaced.
+  Preserves the measurement function, args-fn, and symbolic representation.
+
+  This is useful for adding varied warmup inputs to an existing Measured,
+  for example when running domain analysis where all implementations should
+  share the same warmup strategy."
+  ^criterium.measured.impl.Measured
+  [measured new-warmup-args-fn]
+  (impl/measured (:args-fn measured)
+                 (.-f ^Measured measured)
+                 (:expr-fn measured)
+                 new-warmup-args-fn))
 
 (defn args
   "Generate the input state for a measured.

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -345,4 +345,16 @@
          {})
        (fn ~'measured-expr []
          ~(list 'quote
-                `(time (~f))))))))
+                `(time (~f)))))))
+  ([args-f f warmup-args-fn]
+   (let [args (gensym "args")]
+     `(measured
+       (fn ~'measured-args [] (~args-f))
+       ~(measured-expr-fn
+         [args]
+         `(apply ~f [~args])
+         {})
+       (fn ~'measured-expr []
+         ~(list 'quote
+                `(time (~f))))
+       ~warmup-args-fn))))

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -8,7 +8,8 @@
 (defrecord Measured
   [^clojure.lang.IFn args-fn
    ^clojure.lang.IFn f
-   expr-fn])
+   expr-fn
+   ^clojure.lang.IFn warmup-args-fn])
 
 (alter-meta! #'->Measured assoc :private true)
 (alter-meta! #'map->Measured assoc :private true)
@@ -35,12 +36,17 @@
 
   expr-fn, if specified, returns a symbolic representation of the measured,
   for inspection purposes (unused internally).
+
+  warmup-args-fn, if specified, provides arguments for warmup phase instead
+  of args-fn. This allows warmup with more varied inputs to get more
+  representative JIT optimization.
   "
-  ^Measured
-  [args-fn
-   f
-   & [expr-fn]]
-  (->Measured args-fn f expr-fn))
+  (^Measured [args-fn f]
+   (->Measured args-fn f nil nil))
+  (^Measured [args-fn f expr-fn]
+   (->Measured args-fn f expr-fn nil))
+  (^Measured [args-fn f expr-fn warmup-args-fn]
+   (->Measured args-fn f expr-fn warmup-args-fn)))
 
 (defn- s-expression?
   "Predicate for expr being an S-expression."

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -297,13 +297,18 @@
 
   The env parameter is the macro's &env, used to identify local bindings.
   Local bindings are captured at the call-site and passed through the
-  measurement pipeline alongside hoisted constants."
+  measurement pipeline alongside hoisted constants.
+
+  Options:
+    :time-fn - Custom timing function
+    :warmup-args-fn - Function to generate arguments for warmup phase"
   [expr options env]
   (let [{:keys [expr arg-vals] :as _f} (factor-expr expr env)
         arg-syms (keys arg-vals)
         local-arg-syms (identify-local-args arg-vals env)
         arg-metas (capture-arg-types
                    arg-syms arg-vals local-arg-syms env)
+        warmup-args-fn (:warmup-args-fn options)
         options (update
                  options
                  :arg-metas merge-metas arg-metas)]
@@ -316,7 +321,8 @@
       (fn ~'measured-expr []
         ~(list 'quote
                `(~'let [~@(reduce into [] arg-vals)]
-                       (~'time ~expr)))))))
+                       (~'time ~expr))))
+      ~warmup-args-fn)))
 
 (defn measured-callable
   ([f]

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -311,3 +311,56 @@
         ;; For a simple (+ 1 1) benchmark, distribution should be unimodal
         ;; so we don't test for warning output here
         ))))
+
+;;; warmup-args-fn option tests
+;; Tests for the :warmup-args-fn option in the bench macro.
+;; Validates that warmup uses provided warmup-args-fn during JIT warmup
+;; while measurement uses the expression's captured arguments.
+
+(deftest ^:slow warmup-args-fn-option-test
+  (testing ":warmup-args-fn option"
+    (testing "bench macro accepts :warmup-args-fn option"
+      (let [warmup-calls (atom 0)
+            warmup-args-fn (fn []
+                             (swap! warmup-calls inc)
+                             [42])]
+        (with-out-str
+          (bench/bench (identity 1)
+                       :warmup-args-fn warmup-args-fn
+                       :limit-time-s 0.1))
+        (is (pos? @warmup-calls)
+            "warmup-args-fn should be called during warmup")))
+
+    (testing "warmup uses warmup-args-fn when provided"
+      (let [warmup-calls (atom 0)
+            measurement-value 100
+            warmup-args-fn (fn []
+                             (swap! warmup-calls inc)
+                             [999])]
+        (with-out-str
+          (let [result (bench/bench (identity measurement-value)
+                                    :warmup-args-fn warmup-args-fn
+                                    :limit-time-s 0.1)]
+            (is (= measurement-value result)
+                "measurement should use expr's captured args, not warmup args")
+            (is (pos? @warmup-calls)
+                "warmup-args-fn should be called during warmup")))))
+
+    (testing "without warmup-args-fn, uses default args-fn"
+      (with-out-str
+        (let [result (bench/bench (identity 42) :limit-time-s 0.1)]
+          (is (= 42 result)
+              "bench should work without warmup-args-fn"))))))
+
+(deftest warmup-args-fn-config-test
+  ;; Tests that :warmup-args-fn is recognized as a valid bench option.
+  (testing ":warmup-args-fn in config"
+    (testing "config-map accepts :warmup-args-fn"
+      (let [warmup-fn (fn [] [1])
+            config (bench-config/config-map {:warmup-args-fn warmup-fn})]
+        (is (map? config)
+            "config-map should accept :warmup-args-fn without error")))
+
+    (testing "unknown options still throw"
+      (is (thrown? Exception
+                   (bench-config/config-map {:unknown-option true}))))))

--- a/bases/criterium/test/criterium/collect_test.clj
+++ b/bases/criterium/test/criterium/collect_test.clj
@@ -106,3 +106,44 @@
                 (result [:expr-value])
                 conj
                 [])))))))
+
+;;; warmup tests
+
+;; Tests that warmup uses warmup-args-fn (not args-fn) when it's present
+;; on a Measured. Validates that the collection pipeline respects the
+;; warmup-args-fn contract.
+(deftest warmup-uses-warmup-args-fn-test
+  (testing "warmup"
+    (testing "uses warmup-args-fn when present"
+      (let [measurement-args-calls (atom 0)
+            warmup-args-calls      (atom 0)
+            m                      (measured/measured
+                                    (fn []
+                                      (swap! measurement-args-calls inc)
+                                      [:measurement])
+                                    (fn [_ _] [1 1])
+                                    nil
+                                    (fn []
+                                      (swap! warmup-args-calls inc)
+                                      [:warmup]))
+            collector              (collector/collector
+                                    {:stages     []
+                                     :terminator :elapsed-time})
+            _                      (collect/warmup collector m 3 1)]
+        (is (pos? @warmup-args-calls)
+            "warmup-args-fn should be called during warmup")
+        (is (zero? @measurement-args-calls)
+            "measurement args-fn should NOT be called during warmup")))
+    (testing "falls back to args-fn when warmup-args-fn is nil"
+      (let [measurement-args-calls (atom 0)
+            m                      (measured/measured
+                                    (fn []
+                                      (swap! measurement-args-calls inc)
+                                      [:measurement])
+                                    (fn [_ _] [1 1]))
+            collector              (collector/collector
+                                    {:stages     []
+                                     :terminator :elapsed-time})
+            _                      (collect/warmup collector m 3 1)]
+        (is (pos? @measurement-args-calls)
+            "args-fn should be called when warmup-args-fn is nil")))))

--- a/bases/criterium/test/criterium/domain_test.clj
+++ b/bases/criterium/test/criterium/domain_test.clj
@@ -93,7 +93,27 @@
       (let [spec    (domain/domain-expr [^long n [10 100]] (+ n 1))
             impl-fn (get-in spec [:implementations :default])]
         (is (fn? impl-fn))
-        (is (measured/measured? (impl-fn {:n 10})))))))
+        (is (measured/measured? (impl-fn {:n 10})))))
+    (testing "with options"
+      (testing "passes :warmup-args-fn to all implementations"
+        (let [warmup-fn (fn [] [:warmup-val])
+              spec      (domain/domain-expr
+                         [n [10 100]]
+                         {:impl-a (sort (vec (range n)))
+                          :impl-b (sort-by identity (vec (range n)))}
+                         {:warmup-args-fn warmup-fn})
+              m-a       ((get-in spec [:implementations :impl-a]) {:n 10})
+              m-b       ((get-in spec [:implementations :impl-b]) {:n 10})]
+          (is (= [:warmup-val] (measured/warmup-args m-a)))
+          (is (= [:warmup-val] (measured/warmup-args m-b)))))
+      (testing "with single expression applies :warmup-args-fn"
+        (let [warmup-fn (fn [] [:single-warmup])
+              spec      (domain/domain-expr
+                         [n [10 100]]
+                         (sort (vec (range n)))
+                         {:warmup-args-fn warmup-fn})
+              m         ((get-in spec [:implementations :default]) {:n 10})]
+          (is (= [:single-warmup] (measured/warmup-args m))))))))
 
 ;; Tests for the extract-metrics domain plan.
 ;; Validates plan structure and integration with analyse-domain.

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -40,6 +40,46 @@
       (is (= [1 [:arg :arg]] (invoke m 3)))
       (is (= 3 @eval-count)))))
 
+(deftest warmup-args-fn-test
+  ;; Tests for the warmup-args-fn field in Measured record.
+  ;; Validates the 4-arity constructor and warmup-args function behavior.
+  (testing "warmup-args-fn"
+    (testing "4-arity constructor creates measured with warmup-args-fn"
+      (let [m (measured/measured
+               (fn [] [:measurement])
+               (fn [_args _n] [0 nil])
+               nil
+               (fn [] [:warmup]))]
+        (is (measured/measured? m))
+        (is (= [:measurement] (measured/args m)))
+        (is (= [:warmup] (measured/warmup-args m)))))
+    (testing "warmup-args falls back to args-fn when warmup-args-fn is nil"
+      (let [m (measured/measured
+               (fn [] [:fallback])
+               (fn [_args _n] [0 nil]))]
+        (is (= [:fallback] (measured/args m)))
+        (is (= [:fallback] (measured/warmup-args m)))))
+    (testing "warmup-args-fn can generate varied inputs"
+      (let [warmup-call-count (volatile! 0)
+            m (measured/measured
+               (fn [] [42])
+               (fn [[x] _n] [0 x])
+               nil
+               (fn []
+                 (vswap! warmup-call-count inc-long)
+                 [(rand-int 1000)]))]
+        (is (= [42] (measured/args m)))
+        (measured/warmup-args m)
+        (measured/warmup-args m)
+        (is (= 2 @warmup-call-count))))
+    (testing "3-arity constructor creates measured without warmup-args-fn"
+      (let [m (measured/measured
+               (fn [] [:args])
+               (fn [_args _n] [0 nil])
+               (fn [] ::expr))]
+        (is (= ::expr (measured/symbolic m)))
+        (is (= [:args] (measured/warmup-args m)))))))
+
 (deftest with-args-fn-test
   ;; Tests for with-args-fn which creates a new measured with a replaced args-fn.
   ;; Validates that the measurement function is preserved while args-fn is swapped.
@@ -71,7 +111,16 @@
                          (fn [[x] _n] [0 x])
                          nil)
             _modified-m (measured/with-args-fn original-m (fn [] [99]))]
-        (is (= [0 1] (invoke original-m)))))))
+        (is (= [0 1] (invoke original-m)))))
+    (testing "preserves warmup-args-fn"
+      (let [original-m (measured/measured
+                        (fn [] [:original-args])
+                        (fn [_args _n] [0 nil])
+                        nil
+                        (fn [] [:warmup-args]))
+            modified-m (measured/with-args-fn original-m (fn [] [:new-args]))]
+        (is (= [:new-args] (measured/args modified-m)))
+        (is (= [:warmup-args] (measured/warmup-args modified-m)))))))
 
 (defn random-seq
   [n]

--- a/bases/notebooks/src/criterium/index.clj
+++ b/bases/notebooks/src/criterium/index.clj
@@ -17,6 +17,7 @@
 ;;
 ;; - [Basic Usage](./criterium.basic_usage_notebook.html) - Introduction to benchmarking with criterium
 ;; - [Bench Options](./criterium.bench_options_notebook.html) - Predefined bench plans and viewer options
+;; - [Warmup](./criterium.warmup_notebook.html) - JIT warmup customization with varied inputs
 ;; - [Argument Generation](./criterium.arg_gen_notebook.html) - Benchmarking with test.check generated inputs
 ;; - [Sampled Functions](./criterium.sampled_fn_notebook.html) - Memory-efficient function sampling with t-digest aggregation
 ;; - [Instrumented Functions](./criterium.instrument_fn_notebook.html) - Instrument functions for continuous performance sampling

--- a/bases/notebooks/src/criterium/warmup_notebook.clj
+++ b/bases/notebooks/src/criterium/warmup_notebook.clj
@@ -99,27 +99,29 @@
  (bench/options->bench-plan)
  sort-measured)
 
-;; ### Using arg-gen/measured with :warmup-args-fn option
+;; ### Using with-warmup-args-fn
 ;;
-;; When the measurement itself uses generated arguments, you can override
-;; warmup with the bench option:
+;; Add warmup behavior to an existing Measured with `with-warmup-args-fn`:
 
 (bench/bench-measured
- (bench/options->bench-plan :warmup-args-fn (arg-gen/args-fn {:size 200}
-                                                             [v (gen/vector gen/small-integer)]
-                                                             [v]))
- (arg-gen/measured {:size 100 :seed 42}
-                   [v (gen/vector gen/small-integer)]
-                   (sort v)))
+ (bench/options->bench-plan)
+ (measured/with-warmup-args-fn
+   (arg-gen/measured {:size 100 :seed 42}
+                     [v (gen/vector gen/small-integer)]
+                     (sort v))
+   (arg-gen/args-fn {:size 200}
+                    [v (gen/vector gen/small-integer)]
+                    [v])))
 
 ;; ## Priority Rules
 ;;
 ;; Warmup arguments are resolved in this order:
-;; 1. Options-level `:warmup-args-fn` (in bench macro or bench-measured)
-;; 2. Measured-level warmup-args-fn (from measured constructor)
+;; 1. The bench macro's `:warmup-args-fn` option (baked into Measured at compile time)
+;; 2. Measured-level warmup-args-fn (from constructor or `with-warmup-args-fn`)
 ;; 3. Fall back to regular args-fn
 ;;
-;; This allows overriding warmup behavior at any level.
+;; Note: `:warmup-args-fn` only works as a bench macro option, not with
+;; `bench-measured`. For pre-built Measured instances, use `with-warmup-args-fn`.
 
 ;; ## Domain Analysis with Shared Warmup
 ;;
@@ -143,17 +145,17 @@
   {:warmup-args-fn (fn [] [(vec (shuffle (range 500)))])})
  :reporter nil)
 
-;; ### Using :bench-options for Domain Warmup
+;; ### Single Implementation with Warmup
 ;;
-;; Alternatively, use `:bench-options` with `:warmup-args-fn`:
+;; The third argument to domain-expr also works with single implementations:
 
 (domain/bench
  (domain/domain-expr
   [n (builder/log-range 100 1000 3)]
-  (sort (random-seq n)))
- :bench-options {:warmup-args-fn (arg-gen/args-fn {:size 200}
-                                                  [v (gen/vector gen/small-integer)]
-                                                  [v])}
+  (sort (random-seq n))
+  {:warmup-args-fn (arg-gen/args-fn {:size 200}
+                                    [v (gen/vector gen/small-integer)]
+                                    [v])})
  :reporter nil)
 
 ;; ## When to Use Varied Warmup

--- a/bases/notebooks/src/criterium/warmup_notebook.clj
+++ b/bases/notebooks/src/criterium/warmup_notebook.clj
@@ -1,0 +1,186 @@
+(ns
+ ^{:kindly/options {:kinds-that-hide-code #{:kind/hidden}}}
+ criterium.warmup-notebook
+  "Understanding and customizing JIT warmup for representative benchmarks."
+  (:require
+   [clojure.test.check.generators :as gen]
+   [criterium.arg-gen :as arg-gen]
+   [criterium.bench :as bench]
+   [criterium.domain :as domain]
+   [criterium.domain.builder :as builder]
+   [criterium.measured :as measured]
+   [scicloj.kindly.v4.kind :as kind]))
+
+(kind/hidden
+ (bench/set-default-viewer! :kindly))
+
+;; # JIT Warmup and Varied Inputs
+;;
+;; The JVM's JIT compiler optimizes frequently executed code paths based on the
+;; inputs it observes. If warmup always uses the same arguments, the JIT may
+;; over-specialize for those specific inputs, leading to benchmarks that don't
+;; reflect real-world performance.
+;;
+;; The `:warmup-args-fn` feature lets you provide varied inputs during warmup,
+;; resulting in more representative JIT optimizations.
+
+;; ## Why Varied Warmup Matters
+;;
+;; Consider sorting a collection. The optimal sorting strategy can depend on:
+;; - Collection size
+;; - Pre-sortedness of data
+;; - Data distribution (mostly uniform vs many duplicates)
+;;
+;; If warmup uses only a single input, the JIT may optimize for that specific
+;; case, potentially producing misleading benchmark results.
+
+;; ## Basic Usage
+;;
+;; Use `:warmup-args-fn` with the bench macro to specify a function that
+;; generates varied inputs during warmup:
+
+(let [coll (vec (range 1000))]
+  (bench/bench (sort coll)
+               :warmup-args-fn (fn [] [(vec (shuffle (range 5000)))])))
+
+;; The warmup phase calls `warmup-args-fn` repeatedly to generate fresh inputs.
+;; Measurement continues to use the original arguments (`coll`).
+
+;; ## Using arg-gen for Warmup Functions
+;;
+;; The `arg-gen/args-fn` macro creates warmup functions using test.check
+;; generators. This provides varied, reproducible inputs:
+
+(let [coll (vec (range 1000))]
+  (bench/bench (sort coll)
+               :warmup-args-fn (arg-gen/args-fn {:size 200 :seed 42}
+                                                [v (gen/vector gen/small-integer)]
+                                                [v])))
+
+;; ### Options
+;;
+;; - `:size` - Maximum size for generators (default 100)
+;; - `:seed` - Random seed for reproducibility (default nil, uses timestamp)
+
+;; ### Multiple Arguments
+;;
+;; Use dependent bindings for functions with multiple arguments:
+
+(defn lookup-key
+  "Look up a key in a map."
+  [m k]
+  (get m k))
+
+(let [m (zipmap (range 1000) (range 1000))
+      k 500]
+  (bench/bench (lookup-key m k)
+               :warmup-args-fn (arg-gen/args-fn {:size 100}
+                                                [n (gen/choose 100 5000)
+                                                 m (gen/fmap #(zipmap (range %) (range %))
+                                                             (gen/return n))
+                                                 k (gen/choose 0 n)]
+                                                [m k])))
+
+;; ## Warmup on Measured Instances
+;;
+;; You can set warmup-args-fn when creating Measured instances directly.
+
+;; ### Using measured/callable
+
+;; The `callable` macro accepts warmup-args-fn as a third argument:
+
+(def sort-measured
+  (measured/callable
+   (fn [] [(vec (range 1000))])     ; args-fn for measurement
+   sort                              ; function to measure
+   (fn [] [(vec (shuffle (range 5000)))]))) ; warmup-args-fn
+
+(bench/bench-measured
+ (bench/options->bench-plan)
+ sort-measured)
+
+;; ### Using arg-gen/measured with :warmup-args-fn option
+;;
+;; When the measurement itself uses generated arguments, you can override
+;; warmup with the bench option:
+
+(bench/bench-measured
+ (bench/options->bench-plan :warmup-args-fn (arg-gen/args-fn {:size 200}
+                                                             [v (gen/vector gen/small-integer)]
+                                                             [v]))
+ (arg-gen/measured {:size 100 :seed 42}
+                   [v (gen/vector gen/small-integer)]
+                   (sort v)))
+
+;; ## Priority Rules
+;;
+;; Warmup arguments are resolved in this order:
+;; 1. Options-level `:warmup-args-fn` (in bench macro or bench-measured)
+;; 2. Measured-level warmup-args-fn (from measured constructor)
+;; 3. Fall back to regular args-fn
+;;
+;; This allows overriding warmup behavior at any level.
+
+;; ## Domain Analysis with Shared Warmup
+;;
+;; When comparing implementations across a parameter space, you often want
+;; consistent JIT warmup for all implementations.
+
+;; ### Using :warmup-args-fn in domain-expr
+;;
+;; Pass options as the third argument to `domain-expr`:
+
+(defn random-seq
+  "Generate a random sequence of n integers."
+  ^clojure.lang.PersistentVector [n]
+  (mapv rand-int (repeat n 1000)))
+
+(domain/bench
+ (domain/domain-expr
+  [n (builder/log-range 100 1000 3)]
+  {:sort    (sort (random-seq n))
+   :sort-by (sort-by identity (random-seq n))}
+  {:warmup-args-fn (fn [] [(vec (shuffle (range 500)))])})
+ :reporter nil)
+
+;; ### Using :bench-options for Domain Warmup
+;;
+;; Alternatively, use `:bench-options` with `:warmup-args-fn`:
+
+(domain/bench
+ (domain/domain-expr
+  [n (builder/log-range 100 1000 3)]
+  (sort (random-seq n)))
+ :bench-options {:warmup-args-fn (arg-gen/args-fn {:size 200}
+                                                  [v (gen/vector gen/small-integer)]
+                                                  [v])}
+ :reporter nil)
+
+;; ## When to Use Varied Warmup
+;;
+;; Consider using varied warmup inputs when:
+;;
+;; - **Input-dependent algorithms**: Sorting, searching, compression
+;; - **Polymorphic dispatch**: Code handling multiple types
+;; - **Branch-heavy code**: Where JIT may specialize on observed branches
+;; - **Cache-sensitive operations**: Where data locality matters
+;;
+;; For simple arithmetic or pure functions with uniform behavior,
+;; varied warmup provides less benefit.
+
+;; ## Best Practices
+;;
+;; 1. **Match warmup complexity**: Warmup inputs should exercise the same
+;;    code paths as measurement inputs
+;;
+;; 2. **Use appropriate generator sizes**: The `:size` option should produce
+;;    inputs representative of your workload
+;;
+;; 3. **Consider reproducibility**: Use `:seed` when comparing benchmark runs
+;;    across sessions
+;;
+;; 4. **Don't over-vary**: Extremely varied warmup may prevent JIT from
+;;    finding stable optimizations
+
+(kind/hidden
+ (bench/set-default-viewer! :print))

--- a/bases/notebooks/src/criterium/warmup_notebook.clj
+++ b/bases/notebooks/src/criterium/warmup_notebook.clj
@@ -39,9 +39,9 @@
 ;; Use `:warmup-args-fn` with the bench macro to specify a function that
 ;; generates varied inputs during warmup:
 
-(let [coll (vec (range 1000))]
+(let [coll (vec (range 100))]
   (bench/bench (sort coll)
-               :warmup-args-fn (fn [] [(vec (shuffle (range 5000)))])))
+               :warmup-args-fn (fn [] [(vec (shuffle (range 200)))])))
 
 ;; The warmup phase calls `warmup-args-fn` repeatedly to generate fresh inputs.
 ;; Measurement continues to use the original arguments (`coll`).
@@ -51,9 +51,9 @@
 ;; The `arg-gen/args-fn` macro creates warmup functions using test.check
 ;; generators. This provides varied, reproducible inputs:
 
-(let [coll (vec (range 1000))]
+(let [coll (vec (range 100))]
   (bench/bench (sort coll)
-               :warmup-args-fn (arg-gen/args-fn {:size 200 :seed 42}
+               :warmup-args-fn (arg-gen/args-fn {:size 50 :seed 42}
                                                 [v (gen/vector gen/small-integer)]
                                                 [v])))
 
@@ -71,11 +71,11 @@
   [m k]
   (get m k))
 
-(let [m (zipmap (range 1000) (range 1000))
-      k 500]
+(let [m (zipmap (range 100) (range 100))
+      k 50]
   (bench/bench (lookup-key m k)
-               :warmup-args-fn (arg-gen/args-fn {:size 100}
-                                                [n (gen/choose 100 5000)
+               :warmup-args-fn (arg-gen/args-fn {:size 30}
+                                                [n (gen/choose 50 200)
                                                  m (gen/fmap #(zipmap (range %) (range %))
                                                              (gen/return n))
                                                  k (gen/choose 0 n)]
@@ -91,9 +91,9 @@
 
 (def sort-measured
   (measured/callable
-   (fn [] [(vec (range 1000))])     ; args-fn for measurement
+   (fn [] [(vec (range 100))])      ; args-fn for measurement
    sort                              ; function to measure
-   (fn [] [(vec (shuffle (range 5000)))]))) ; warmup-args-fn
+   (fn [] [(vec (shuffle (range 200)))]))) ; warmup-args-fn
 
 (bench/bench-measured
  (bench/options->bench-plan)
@@ -106,10 +106,10 @@
 (bench/bench-measured
  (bench/options->bench-plan)
  (measured/with-warmup-args-fn
-   (arg-gen/measured {:size 100 :seed 42}
+   (arg-gen/measured {:size 30 :seed 42}
                      [v (gen/vector gen/small-integer)]
                      (sort v))
-   (arg-gen/args-fn {:size 200}
+   (arg-gen/args-fn {:size 50}
                     [v (gen/vector gen/small-integer)]
                     [v])))
 
@@ -139,10 +139,10 @@
 
 (domain/bench
  (domain/domain-expr
-  [n (builder/log-range 100 1000 3)]
+  [n (builder/log-range 50 200 3)]
   {:sort    (sort (random-seq n))
    :sort-by (sort-by identity (random-seq n))}
-  {:warmup-args-fn (fn [] [(vec (shuffle (range 500)))])})
+  {:warmup-args-fn (fn [] [(vec (shuffle (range 100)))])})
  :reporter nil)
 
 ;; ### Single Implementation with Warmup
@@ -151,9 +151,9 @@
 
 (domain/bench
  (domain/domain-expr
-  [n (builder/log-range 100 1000 3)]
+  [n (builder/log-range 50 200 3)]
   (sort (random-seq n))
-  {:warmup-args-fn (arg-gen/args-fn {:size 200}
+  {:warmup-args-fn (arg-gen/args-fn {:size 50}
                                     [v (gen/vector gen/small-integer)]
                                     [v])})
  :reporter nil)


### PR DESCRIPTION
## Summary

Add `warmup-args-fn` support to enable more representative JIT warmup by using varied inputs during warmup phase rather than the same arguments used for measurement.

Functions may have different complexities based on their input arguments. If warmup always uses the same arguments, JIT may over-specialize for those inputs. This feature allows specifying a different args-fn for warmup to get more representative JIT optimizations.

## Changes

- **Core measured support**: Extended `Measured` record with optional `warmup-args-fn` field, added `warmup-args` function that falls back to `args-fn`
- **Bench API**: Added `:warmup-args-fn` option to bench macro, baked into Measured at compile time
- **arg-gen helper**: Added `args-fn` macro for creating generator-based warmup functions with test.check
- **Domain analysis**: Added `warmup-args-fn` support to `domain-expr` and `domain/bench`
- **callable macro**: Extended to accept warmup-args-fn as third argument
- **Documentation**: Added warmup notebook, updated docstrings throughout

## API Examples

```clojure
;; Basic usage with bench macro
(bench (sort coll)
       :warmup-args-fn (fn [] [(vec (shuffle (range 5000)))]))

;; Using arg-gen for generator-based warmup
(bench (sort coll)
       :warmup-args-fn (arg-gen/args-fn {:size 200}
                         [coll (gen/vector gen/small-integer)]
                         [coll]))

;; Setting on existing Measured
(measured/with-warmup-args-fn my-measured warmup-fn)

;; Domain analysis with shared warmup
(domain/domain-expr
  [n (domain/log-range 10 10000 10)]
  {:impl-a (impl-a (vec (range n)))
   :impl-b (impl-b (vec (range n)))}
  {:warmup-args-fn warmup-fn})
```

## Commits

- feat(measured): add warmup-args-fn field for JIT optimization
- feat(collect): use warmup-args-fn for warmup collection
- feat(bench): add :warmup-args-fn option for varied warmup inputs
- feat(arg-gen): add args-fn macro for generator-based warmup functions
- feat(domain): add warmup-args-fn support to domain-expr
- feat(measured): add warmup-args-fn support to callable macro
- docs: update docstrings and add warmup notebook

## Test plan

- [x] Unit tests for Measured record with warmup-args-fn
- [x] Tests for warmup collection using warmup-args
- [x] Tests for bench macro :warmup-args-fn option
- [x] Tests for arg-gen/args-fn macro
- [x] Tests for domain-expr warmup-args-fn option
- [x] Tests for callable macro 3-arity