### PR TITLE
feat: add marketplace.json for Claude plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "criterium",
+  "metadata": {
+    "description": "Claude Code plugin for Clojure benchmarking with criterium"
+  },
+  "owner": {
+    "name": "Criterium Team"
+  },
+  "plugins": [
+    {
+      "name": "criterium",
+      "source": "./",
+      "description": "Benchmarking library for Clojure",
+      "version": "0.5.0",
+      "license": "EPL-1.0",
+      "category": "development"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a marketplace.json file to enable installation as a Claude Code marketplace plugin.

## Changes

- Create `.claude-plugin/marketplace.json` with:
  - Plugin name: "criterium"
  - Owner: "Criterium Team"
  - Version: 0.5.0 (matching plugin.json)
  - License: EPL-1.0
  - Category: development

## Commits

- feat: add marketplace.json for Claude plugin installation