### PR TITLE
fix(clj-kondo): add proper hook for domain-expr macro

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,8 +67,14 @@ clojure -T:build notebooks :aliases :with-agent-linux
 
 ### Code Quality
 ```bash
-# Lint code
-clj-kondo --lint src
+# Build clj-kondo cache from classpath (run once after checkout or deps.edn changes)
+clj-kondo --lint "$(clojure -Spath -M:test)" --dependencies --parallel --copy-configs
+
+# Lint all source code
+clj-kondo --lint bases/*/src bases/*/test components/*/src components/*/test
+
+# Lint a specific base
+clj-kondo --lint bases/notebooks/src
 
 # Format code
 clojure -M:cljfmt check

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules/
 bases/agent/resources/native/**/*.so
 bases/agent/resources/native/**/*.dylib
 bases/agent/resources/native/**/*.sha256
+/bases/criterium/.clj-kondo/imports/

--- a/bases/criterium/resources/clj-kondo.exports/criterium/criterium/clj_kondo/criterium/hooks.clj
+++ b/bases/criterium/resources/clj-kondo.exports/criterium/criterium/clj_kondo/criterium/hooks.clj
@@ -1,0 +1,33 @@
+(ns clj-kondo.criterium.hooks
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn domain-expr
+  "Rewrite domain-expr forms for clj-kondo analysis.
+
+  Transforms (domain-expr [n range1 m range2] body options?)
+  into (let [n (first range1) m (first range2)] body options?)
+
+  This allows clj-kondo to verify that:
+  - Axis symbols are properly bound (to single elements, not collections)
+  - Body expressions can reference axis symbols
+  - Range expressions are valid"
+  [{:keys [node]}]
+  (let [[_domain-expr bindings body options] (:children node)
+        ;; Transform [sym1 range1 sym2 range2 ...] to [sym1 (first range1) sym2 (first range2) ...]
+        binding-pairs (partition 2 (:children bindings))
+        transformed-bindings (mapcat (fn [[sym range-expr]]
+                                       [sym (api/list-node
+                                             [(api/token-node 'first)
+                                              range-expr])])
+                                     binding-pairs)
+        new-bindings (api/vector-node transformed-bindings)
+        let-body (if options
+                   (list body options)
+                   (list body))
+        new-node (api/list-node
+                  (list*
+                   (api/token-node 'let)
+                   new-bindings
+                   let-body))]
+    {:node (with-meta new-node (meta node))}))

--- a/bases/criterium/resources/clj-kondo.exports/criterium/criterium/config.edn
+++ b/bases/criterium/resources/clj-kondo.exports/criterium/criterium/config.edn
@@ -1,2 +1,3 @@
-{:lint-as
- {criterium.domain/domain-expr clojure.core/let}}
+{:hooks
+ {:analyze-call
+  {criterium.domain/domain-expr clj-kondo.criterium.hooks/domain-expr}}}

--- a/bases/notebooks/.clj-kondo/config.edn
+++ b/bases/notebooks/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:config-paths
+ ["../../../.clj-kondo"]}


### PR DESCRIPTION
## Summary

Remove lint errors from notebooks by replacing the inadequate `lint-as` configuration for `criterium.domain/domain-expr` with a proper clj-kondo hook.

The `domain-expr` macro:
- Has a 3-arity version that `let` doesn't support
- Uses `[axis range-expr ...]` bindings where axis symbols bind to individual values from ranges

The new hook:
- Handles both 2-arity and 3-arity `domain-expr` calls
- Transforms bindings so clj-kondo sees axis symbols as single elements
- Uses unique namespace (`clj-kondo.criterium.hooks`) to avoid collision with arg-gen hooks

## Changes

- `bases/criterium/resources/clj-kondo.exports/criterium/criterium/config.edn` - Use hook instead of lint-as
- `bases/criterium/resources/clj-kondo.exports/criterium/criterium/clj_kondo/criterium/hooks.clj` - New hook implementation

## Verification

After rebuilding clj-kondo cache, `clj-kondo --lint bases/notebooks/src` reports no domain-expr related errors.

## Test Plan

- [x] Rebuild clj-kondo cache picks up new hook
- [x] `clj-kondo --lint bases/notebooks/src` passes without domain-expr errors