### PR TITLE
feat(domain): enable domain/bench with :one-shot collect plan

### DIFF
--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -44,7 +44,8 @@
   ;; Return a sampled data map.
   [collect-plan collector measured]
   (let [args (measured/args measured)
-        sample (collector/collect collector measured args 1)]
+        sample (collector/collect collector measured args 1)
+        elapsed-time-ns (metric/elapsed-time sample)]
     (collect/force-gc! (:max-gc-attempts collect-plan))
     {:samples
      {:type :criterium/metrics-samples
@@ -54,7 +55,8 @@
                        (:metrics-defs collector))
       :transform identity-transforms
       :batch-size 1
-      :elapsed-time (metric/elapsed-time sample)
+      :elapsed-time elapsed-time-ns
+      :total-benchmark-time-ns elapsed-time-ns
       :eval-count 1
       :num-samples 1
       :expr-value (:expr-value sample)}}))

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -339,9 +339,9 @@
                                                             (extract-error-bounds
                                                              data metric-id)]
                                                         (when median-value
-                                                          {:value median-value
-                                                           :lower lower
-                                                           :upper upper}))
+                                                          (cond-> {:value median-value}
+                                                            lower (assoc :lower lower)
+                                                            upper (assoc :upper upper))))
                                                       median-value)
                                                     ;; Bootstrap stats (when available)
                                                     bootstrap (helpers/bootstrap-box-plot-stats

--- a/bases/criterium/src/criterium/domain/analysis.clj
+++ b/bases/criterium/src/criterium/domain/analysis.clj
@@ -13,12 +13,15 @@
 ;;; Analysis
 
 (defn- discover-quantitative-metrics
-  "Discover quantitative metric-ids from a benchmark result's stats.
+  "Discover quantitative metric-ids from a benchmark result.
+  Prefers [:stats :metrics-defs], falls back to [:samples :metrics-defs]
+  for :one-shot benchmarks that skip statistical analysis.
 
   Returns a sequence of metric-ids (keywords
   like :elapsed-time, :thread-allocation)."
   [bench-result]
-  (let [metrics-defs (get-in bench-result [:stats :metrics-defs])]
+  (let [metrics-defs (or (get-in bench-result [:stats :metrics-defs])
+                         (get-in bench-result [:samples :metrics-defs]))]
     (->> metrics-defs
          (filter (fn [[_k v]] (= :quantitative (:type v))))
          (map first))))
@@ -29,12 +32,13 @@
   "Extract the primary metric value from a benchmark data map.
 
   Prefers bootstrapped median (quantile 0.5) when available, falls back to
-  mean from stats when bootstrap stats are unavailable.
+  mean from stats, then to raw samples for :one-shot benchmarks.
 
-  Returns the transformed value, or nil if neither source has the metric."
+  Returns the transformed value, or nil if no source has the metric."
   [data-map metric-id]
   (or (helpers/bootstrap-quantile-value data-map metric-id 0.5)
-      (helpers/stats-value data-map :stats metric-id :mean)))
+      (helpers/stats-value data-map :stats metric-id :mean)
+      (helpers/samples-single-value data-map metric-id)))
 
 (defn- extract-error-bounds
   "Extract error bounds for a metric from a benchmark data map.

--- a/bases/criterium/src/criterium/domain/builder.clj
+++ b/bases/criterium/src/criterium/domain/builder.clj
@@ -194,12 +194,8 @@
           extract-data
           (mapv
            (fn [{:keys [coord data]}]
-             (let [time-ns (if-let [projected
-                                    (get-in
-                                     data
-                                     [:samples :time-limit :projected-time-ns])]
-                             projected
-                             (get-in data [:samples :total-benchmark-time-ns]))]
+             (let [time-ns (or (get-in data [:samples :time-limit :projected-time-ns])
+                               (get-in data [:samples :total-benchmark-time-ns]))]
                [coord time-ns]))
            impl-runs)
           extract             {:type    :criterium/domain-extract

--- a/bases/criterium/src/criterium/domain_plans.clj
+++ b/bases/criterium/src/criterium/domain_plans.clj
@@ -73,6 +73,10 @@
   For median-based extraction with bootstrap fallback, use extract-metrics or
   complexity-analysis instead.
 
+  NOTE: This plan returns nil for :one-shot benchmarks because the explicit
+  :metric-path bypasses the samples fallback. For one-shot data, use
+  extract-metrics instead.
+
   Example:
     (analyse-domain extract-elapsed-time my-domain)"
   {:analyse [[:domain-extract-fn {:metric-path [:stats :elapsed-time :mean]}]]

--- a/bases/criterium/src/criterium/util/helpers.clj
+++ b/bases/criterium/src/criterium/util/helpers.clj
@@ -2,6 +2,7 @@
   "Criterium domain helpers and backward-compatible re-exports from utils."
   (:refer-clojure :exclude [update-vals])
   (:require
+   [criterium.array :as arr]
    [criterium.utils.interface :as utils :refer [have have?]]))
 
 ;;; Re-exports from utils component for backward compatibility
@@ -205,6 +206,21 @@
     (when (and p10 p50 p90)
       (merge {:median p50 :p10 p10 :p90 p90}
              (bootstrap-quantile-ci data-map metric-id 0.5)))))
+
+(defn samples-single-value
+  "Extract a metric value from raw samples when only a single sample exists.
+  For use with :one-shot benchmarks that produce a single data point without
+  statistical analysis.
+
+  Returns the transformed metric value, or nil if samples unavailable,
+  multi-sample, or the metric doesn't exist in the samples."
+  [data-map metric-id]
+  (let [samples (:samples data-map)]
+    (when (and samples (= 1 (:num-samples samples)))
+      (let [transforms (get-transforms data-map :samples)
+            metric-values (get (:metric->values samples) [metric-id])]
+        (when (and metric-values (pos? (arr/length metric-values)))
+          (transform-sample-> (arr/get-double metric-values 0) transforms))))))
 
 ;;; Thread
 

--- a/bases/criterium/src/criterium/util/helpers.clj
+++ b/bases/criterium/src/criterium/util/helpers.clj
@@ -150,14 +150,16 @@
   (e.g. :stats or :log-stats), a metric-id (e.g. :elapsed-time),
   and a value-key (e.g. :mean, :std-dev).
 
-  Returns the value with all transforms applied."
+  Returns the value with all transforms applied, or nil if the
+  stats-id entry is not present in the data map."
   [data-map stats-id metric-id value-key]
   {:pre [(have? keyword? stats-id)
          (have? keyword? value-key)]}
-  (let [transforms (get-transforms data-map stats-id)
-        raw-value (get-in data-map [stats-id :stats metric-id value-key])]
-    (when raw-value
-      (transform-sample-> raw-value transforms))))
+  (when (contains? data-map stats-id)
+    (let [transforms (get-transforms data-map stats-id)
+          raw-value (get-in data-map [stats-id :stats metric-id value-key])]
+      (when raw-value
+        (transform-sample-> raw-value transforms)))))
 
 (defn bootstrap-quantile-value
   "Extract a transformed bootstrap quantile value from a benchmark data map.

--- a/bases/criterium/test/criterium/domain/analysis_test.clj
+++ b/bases/criterium/test/criterium/domain/analysis_test.clj
@@ -6,7 +6,8 @@
    [criterium.domain.test-util :refer [sample-data sample-data-2
                                        mock-bench-result
                                        mock-bench-result-with-defs
-                                       mock-bench-result-with-bootstrap]]))
+                                       mock-bench-result-with-bootstrap
+                                       mock-one-shot-result]]))
 
 ;; Tests for AIC/BIC computation functions.
 ;; Validates information criterion formulas for model selection.
@@ -75,13 +76,36 @@
             bic-high-rss (analysis/compute-bic 5.0 10 2)]
         (is (< bic-low-rss bic-high-rss))))))
 
+;; Tests for discover-quantitative-metrics helper.
+;; Validates finding metric-ids from stats or samples.
+
+(deftest discover-quantitative-metrics-test
+  ;; Tests the discover-quantitative-metrics private helper.
+  ;; Prefers [:stats :metrics-defs], falls back to [:samples :metrics-defs].
+  (testing "discover-quantitative-metrics"
+    (testing "with stats present"
+      (testing "returns metric-ids from stats"
+        (let [data (mock-bench-result-with-defs {:elapsed-time {:mean 1.0}
+                                                 :thread-allocation {:mean 2.0}})]
+          (is (= #{:elapsed-time :thread-allocation}
+                 (set (#'analysis/discover-quantitative-metrics data)))))))
+    (testing "with one-shot data (samples only, no stats)"
+      (testing "falls back to samples metrics-defs"
+        (let [data (mock-one-shot-result {:elapsed-time 42.5})]
+          (is (= [:elapsed-time]
+                 (#'analysis/discover-quantitative-metrics data))))))
+    (testing "with neither stats nor samples metrics-defs"
+      (testing "returns empty sequence"
+        (is (empty? (#'analysis/discover-quantitative-metrics {})))))))
+
 ;; Tests for metric value extraction helpers.
 ;; Validates extract-metric-value and extract-error-bounds which prefer
 ;; bootstrapped median/CI with fallback to mean/±3σ from stats.
 
 (deftest extract-metric-value-test
   ;; Tests the extract-metric-value private helper.
-  ;; Prefers bootstrap median (quantile 0.5), falls back to stats mean.
+  ;; Prefers bootstrap median (quantile 0.5), falls back to stats mean,
+  ;; then to raw samples for :one-shot benchmarks.
   (testing "extract-metric-value"
     (testing "with bootstrap data present"
       (testing "returns bootstrapped median"
@@ -93,7 +117,11 @@
       (testing "falls back to stats mean"
         (let [data (mock-bench-result {:elapsed-time {:mean 2.5}})]
           (is (= 2.5 (#'analysis/extract-metric-value data :elapsed-time))))))
-    (testing "with neither bootstrap nor stats"
+    (testing "with one-shot data (samples only, no stats)"
+      (testing "falls back to raw sample value"
+        (let [data (mock-one-shot-result {:elapsed-time 42.5})]
+          (is (= 42.5 (#'analysis/extract-metric-value data :elapsed-time))))))
+    (testing "with neither bootstrap, stats, nor samples"
       (testing "returns nil"
         (let [data (mock-bench-result {:other-metric {:mean 1.0}})]
           (is (nil? (#'analysis/extract-metric-value data :elapsed-time))))))))

--- a/bases/criterium/test/criterium/domain/test_util.clj
+++ b/bases/criterium/test/criterium/domain/test_util.clj
@@ -4,6 +4,7 @@
   Provides mock data constructors and sample data for testing
   domain types, analysis, and builder functions."
   (:require
+   [criterium.array :as arr]
    [criterium.collect-plan :as collect-plan]))
 
 ;;; Sample Data
@@ -91,3 +92,23 @@
      :samples {:type :criterium/metrics-samples
                :transform collect-plan/identity-transforms
                :batch-size 1}}))
+
+(defn mock-one-shot-result
+  "Create a mock :one-shot bench result with only samples (no stats/bootstrap).
+  metrics-data is a map of {metric-id value}."
+  [metrics-data]
+  (let [metrics-defs (into {}
+                           (map (fn [k] [k {:type :quantitative}]))
+                           (keys metrics-data))
+        metric->values (into {}
+                             (map (fn [[k v]]
+                                    [[k] (arr/->double-array (double-array [v]))]))
+                             metrics-data)]
+    {:samples {:type :criterium/metrics-samples
+               :metrics-defs metrics-defs
+               :metric->values metric->values
+               :transform collect-plan/identity-transforms
+               :batch-size 1
+               :eval-count 1
+               :num-samples 1
+               :elapsed-time 1}}))

--- a/bases/criterium/test/criterium/domain_test.clj
+++ b/bases/criterium/test/criterium/domain_test.clj
@@ -263,7 +263,26 @@
           (is (= 10.0 (get-in fast-entry [:value :value]))
               "extracts fast impl value")
           (is (= 50.0 (get-in slow-entry [:value :value]))
-              "extracts slow impl value"))))))
+              "extracts slow impl value"))))
+    (testing "omits error bound keys when bounds are nil"
+      ;; Regression test: ensures :lower/:upper keys are absent (not nil)
+      ;; when error bounds unavailable. Presence of nil values causes NPE
+      ;; in chart rendering (values-have-error-bounds? uses contains?).
+      (let [d (domain/domain
+               {:coord {:impl :a}
+                :data (mock-one-shot-result {:elapsed-time 10.0})}
+               {:implementations [:a]})
+            plan (analysis/options->domain-plan
+                  domain-plans/implementation-comparison
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            et-metric (get-in result [:comparison :metrics :elapsed-time])
+            entry (first (get-in et-metric [:data :a]))
+            value-map (:value entry)]
+        (is (not (contains? value-map :lower))
+            "value map should not contain :lower key")
+        (is (not (contains? value-map :upper))
+            "value map should not contain :upper key")))))
 
 (deftest one-shot-extract-elapsed-time-test
   ;; Tests extract-elapsed-time plan with one-shot data.

--- a/bases/criterium/test/criterium/domain_test.clj
+++ b/bases/criterium/test/criterium/domain_test.clj
@@ -310,3 +310,42 @@
               "has lower bound from bootstrap")
           (is (some? (:upper value-map))
               "has upper bound from bootstrap"))))))
+
+;;; End-to-end integration tests with actual domain/bench
+;; Tests full pipeline using real benchmark execution (not mock data).
+
+(deftest ^:slow domain-bench-one-shot-end-to-end-test
+  ;; End-to-end test running actual domain/bench with :one-shot collect plan.
+  ;; Verifies full pipeline integration from benchmark execution through analysis.
+  (testing "domain/bench with :bench-options {:collect-plan :one-shot}"
+    (testing "runs benchmarks and extracts metrics from single samples"
+      (let [result (domain/bench
+                    (domain/domain-expr [n [10 100]] (reduce + (range n)))
+                    :domain-plan domain-plans/extract-metrics
+                    :bench-options {:collect-plan :one-shot}
+                    :reporter nil
+                    :viewer :none)
+            extract (:extract result)]
+        (is (= :criterium/domain-extract (:type extract))
+            "produces domain-extract result")
+        (is (contains? (:metrics extract) :elapsed-time)
+            "discovers elapsed-time metric")
+        (let [et-data (get-in extract [:metrics :elapsed-time])
+              coords (set (map first (:data et-data)))]
+          (is (= #{{:impl :default :n 10} {:impl :default :n 100}} coords)
+              "has data for all coordinates")
+          (is (every? #(number? (:value (second %))) (:data et-data))
+              "all values are numbers"))))
+    (testing "produces no error bounds (n=1)"
+      (let [result (domain/bench
+                    (domain/domain-expr [n [10]] (reduce + (range n)))
+                    :domain-plan domain-plans/extract-metrics
+                    :bench-options {:collect-plan :one-shot}
+                    :reporter nil
+                    :viewer :none)
+            et-data (get-in result [:extract :metrics :elapsed-time])
+            [_coord value-map] (first (:data et-data))]
+        (is (nil? (:lower value-map))
+            "no lower bound for one-shot")
+        (is (nil? (:upper value-map))
+            "no upper bound for one-shot")))))

--- a/bases/criterium/test/criterium/domain_test.clj
+++ b/bases/criterium/test/criterium/domain_test.clj
@@ -415,3 +415,29 @@
             "value map should not contain :lower key")
         (is (not (contains? value-map :upper))
             "value map should not contain :upper key")))))
+
+(deftest ^:slow domain-bench-one-shot-small-domain-test
+  ;; End-to-end test verifying domain/bench handles small domain values without crashing.
+  ;; Regression test for issue #820: estimate_limit_time_s crashed with "Wrong number of
+  ;; args (0) passed to: clojure.core/max" when model fitting returned empty results.
+  ;; Small, fast operations with tiny domain values often fail model fitting.
+  (testing "domain/bench with :one-shot and small domain values"
+    (testing "handles model fitting returning empty results"
+      (let [result (domain/bench
+                    (domain/domain-expr
+                     [n [1 2 3]]
+                     {:reduce-range (reduce + (range n))
+                      :apply-range  (apply + (range n))})
+                    :domain-plan domain-plans/implementation-comparison
+                    :bench-options {:collect-plan :one-shot}
+                    :reporter nil
+                    :viewer :none)
+            comparison (:comparison result)]
+        (is (= :criterium/domain-comparison (:type comparison))
+            "produces domain-comparison result without crashing")
+        (is (= [:reduce-range :apply-range] (:implementations comparison))
+            "preserves implementation order")
+        (let [et-metric (get-in comparison [:metrics :elapsed-time])
+              reduce-data (get-in et-metric [:data :reduce-range])]
+          (is (= 3 (count reduce-data))
+              "has data for all n values"))))))

--- a/bases/criterium/test/criterium/domain_test.clj
+++ b/bases/criterium/test/criterium/domain_test.clj
@@ -368,3 +368,50 @@
             "no lower bound for one-shot")
         (is (nil? (:upper value-map))
             "no upper bound for one-shot")))))
+
+(deftest ^:slow domain-bench-one-shot-impl-comparison-test
+  ;; End-to-end test for implementation-comparison with one-shot data.
+  ;; Verifies multiple implementations can be compared without NPE.
+  (testing "domain/bench with implementation-comparison and :one-shot"
+    (testing "compares multiple implementations"
+      (let [result (domain/bench
+                    (domain/domain-expr
+                     [n [100 1000]]
+                     {:reduce-range (reduce + (range n))
+                      :apply-range  (apply + (range n))})
+                    :domain-plan domain-plans/implementation-comparison
+                    :bench-options {:collect-plan :one-shot}
+                    :reporter nil
+                    :viewer :none)
+            comparison (:comparison result)]
+        (is (= :criterium/domain-comparison (:type comparison))
+            "produces domain-comparison result")
+        (is (= [:reduce-range :apply-range] (:implementations comparison))
+            "preserves implementation order")
+        (let [et-metric (get-in comparison [:metrics :elapsed-time])
+              reduce-data (get-in et-metric [:data :reduce-range])
+              apply-data (get-in et-metric [:data :apply-range])]
+          (is (= 2 (count reduce-data))
+              "has data for all n values in reduce-range")
+          (is (= 2 (count apply-data))
+              "has data for all n values in apply-range")
+          (is (every? #(number? (get-in % [:value :value])) reduce-data)
+              "reduce-range values are numbers")
+          (is (every? #(number? (get-in % [:value :value])) apply-data)
+              "apply-range values are numbers"))))
+    (testing "omits error bound keys from comparison data"
+      (let [result (domain/bench
+                    (domain/domain-expr
+                     [n [10]]
+                     {:impl-a (reduce + (range n))})
+                    :domain-plan domain-plans/implementation-comparison
+                    :bench-options {:collect-plan :one-shot}
+                    :reporter nil
+                    :viewer :none)
+            entry (first (get-in result [:comparison :metrics :elapsed-time
+                                         :data :impl-a]))
+            value-map (:value entry)]
+        (is (not (contains? value-map :lower))
+            "value map should not contain :lower key")
+        (is (not (contains? value-map :upper))
+            "value map should not contain :upper key")))))

--- a/bases/criterium/test/criterium/domain_test.clj
+++ b/bases/criterium/test/criterium/domain_test.clj
@@ -12,7 +12,9 @@
    [criterium.domain :as domain]
    [criterium.domain-plans :as domain-plans]
    [criterium.domain.analysis :as analysis]
-   [criterium.domain.test-util :refer [mock-bench-result]]
+   [criterium.domain.test-util :refer [mock-bench-result
+                                       mock-bench-result-with-bootstrap
+                                       mock-one-shot-result]]
    [criterium.measured :as measured]))
 
 ;; Tests for the domain-expr macro.
@@ -161,3 +163,150 @@
             updated-plan (analysis/options->domain-plan original-plan :viewer :none)]
         (is (= (:analyse original-plan) (:analyse updated-plan)))
         (is (= (:view original-plan) (:view updated-plan)))))))
+
+;;; One-shot domain benchmarking integration tests
+;; Tests end-to-end functionality with :one-shot collect plan (single sample, no stats).
+;; One-shot mode is for measuring infrequently-executed code without JIT warmup.
+
+(deftest one-shot-extract-metrics-test
+  ;; Tests extract-metrics plan with one-shot data (samples only, no stats/bootstrap).
+  ;; Verifies metric extraction falls back to raw sample values.
+  (testing "extract-metrics with one-shot data"
+    (testing "extracts metric values from single samples"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-one-shot-result {:elapsed-time 42.5})}
+               {:coord {:n 200}
+                :data (mock-one-shot-result {:elapsed-time 85.0})})
+            plan (analysis/options->domain-plan
+                  domain-plans/extract-metrics
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            extract (:extract result)]
+        (is (= :criterium/domain-extract (:type extract))
+            "returns domain-extract result type")
+        (is (contains? (:metrics extract) :elapsed-time)
+            "discovers elapsed-time metric from samples")
+        (let [et-data (get-in extract [:metrics :elapsed-time])
+              values (into {} (map (fn [[c v]] [c (:value v)]) (:data et-data)))]
+          (is (= 42.5 (get values {:n 100}))
+              "extracts value for n=100")
+          (is (= 85.0 (get values {:n 200}))
+              "extracts value for n=200"))))
+    (testing "has no error bounds (n=1 means no CI)"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-one-shot-result {:elapsed-time 42.5})})
+            plan (analysis/options->domain-plan
+                  domain-plans/extract-metrics
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            et-data (get-in result [:extract :metrics :elapsed-time])
+            [_coord value-map] (first (:data et-data))]
+        (is (nil? (:lower value-map))
+            "no lower bound for one-shot data")
+        (is (nil? (:upper value-map))
+            "no upper bound for one-shot data")))))
+
+(deftest one-shot-complexity-analysis-test
+  ;; Tests complexity-analysis plan with one-shot data.
+  ;; Verifies model fitting works with single-sample data points.
+  (testing "complexity-analysis with one-shot data"
+    (testing "extracts metrics and fits models"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-one-shot-result {:elapsed-time 100.0})}
+               {:coord {:n 200}
+                :data (mock-one-shot-result {:elapsed-time 200.0})}
+               {:coord {:n 400}
+                :data (mock-one-shot-result {:elapsed-time 400.0})})
+            plan (analysis/options->domain-plan
+                  domain-plans/complexity-analysis
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)]
+        (is (= :criterium/domain-extract (:type (:extract result)))
+            "produces extract result")
+        (is (= :criterium/domain-regression (:type (:regression result)))
+            "produces regression result")
+        (let [regression (:regression result)
+              et-regression (get-in regression [:regressions :elapsed-time])]
+          (is (some? et-regression)
+              "has elapsed-time regression data")
+          (is (seq (:models et-regression))
+              "fits models to elapsed-time data")
+          (is (every? #(contains? % :id) (:models et-regression))
+              "each fit has a model id"))))))
+
+(deftest one-shot-implementation-comparison-test
+  ;; Tests implementation-comparison plan with one-shot data.
+  ;; Verifies comparison works with single-sample data per implementation.
+  (testing "implementation-comparison with one-shot data"
+    (testing "compares implementations"
+      (let [d (domain/domain
+               {:coord {:impl :fast}
+                :data (mock-one-shot-result {:elapsed-time 10.0})}
+               {:coord {:impl :slow}
+                :data (mock-one-shot-result {:elapsed-time 50.0})}
+               {:implementations [:fast :slow]})
+            plan (analysis/options->domain-plan
+                  domain-plans/implementation-comparison
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            comparison (:comparison result)]
+        (is (= :criterium/domain-comparison (:type comparison))
+            "returns domain-comparison result type")
+        (is (= [:fast :slow] (:implementations comparison))
+            "preserves implementation order")
+        (let [et-metric (get-in comparison [:metrics :elapsed-time])
+              fast-entry (first (get-in et-metric [:data :fast]))
+              slow-entry (first (get-in et-metric [:data :slow]))]
+          (is (= 10.0 (get-in fast-entry [:value :value]))
+              "extracts fast impl value")
+          (is (= 50.0 (get-in slow-entry [:value :value]))
+              "extracts slow impl value"))))))
+
+(deftest one-shot-extract-elapsed-time-test
+  ;; Tests extract-elapsed-time plan with one-shot data.
+  ;; This plan uses explicit :metric-path [:stats :elapsed-time :mean] which
+  ;; does NOT fall back to samples - users should use extract-metrics instead.
+  (testing "extract-elapsed-time with one-shot data"
+    (testing "returns nil values (no stats in one-shot data)"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-one-shot-result {:elapsed-time 42.5})})
+            plan (analysis/options->domain-plan
+                  domain-plans/extract-elapsed-time
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            et-data (get-in result [:extract :metrics :elapsed-time])
+            [_coord value-map] (first (:data et-data))]
+        (is (nil? (:value value-map))
+            "returns nil - explicit :metric-path bypasses fallback to samples")))))
+
+(deftest with-jit-warmup-regression-test
+  ;; Regression test: verifies existing :with-jit-warmup behavior unchanged.
+  ;; Uses mock data with stats (normal benchmark results, not one-shot).
+  (testing "with-jit-warmup data (regression)"
+    (testing "extract-metrics works with stats data"
+      (let [d (domain/domain
+               {:coord {:n 100}
+                :data (mock-bench-result-with-bootstrap
+                       {:elapsed-time {:mean 1.0}})}
+               {:coord {:n 200}
+                :data (mock-bench-result-with-bootstrap
+                       {:elapsed-time {:mean 2.0}})})
+            plan (analysis/options->domain-plan
+                  domain-plans/extract-metrics
+                  :viewer :none)
+            result (analysis/analyse-domain plan d)
+            extract (:extract result)]
+        (is (= :criterium/domain-extract (:type extract))
+            "returns domain-extract result type")
+        (let [et-data (get-in extract [:metrics :elapsed-time])
+              [_coord value-map] (first (:data et-data))]
+          (is (some? (:value value-map))
+              "extracts metric value")
+          (is (some? (:lower value-map))
+              "has lower bound from bootstrap")
+          (is (some? (:upper value-map))
+              "has upper bound from bootstrap"))))))

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -37,6 +37,22 @@
                     (metrics/metrics)
                     [:elapsed-time])}}})
 
+(defn samples-with-1-value-map
+  "Create a samples map with a single sample for :one-shot testing."
+  []
+  (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
+    {:metrics-defs metrics-defs
+     :data
+     {:samples
+      {:type           :criterium/metrics-samples
+       :metrics-defs   metrics-defs
+       :metric->values {[:elapsed-time] (arr/->double-array (double-array [42.5]))}
+       :transform      collect-plan/identity-transforms
+       :batch-size     1
+       :eval-count     1
+       :num-samples    1
+       :elapsed-time   1}}}))
+
 (defn samples-with-2-values-map []
   (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])]
     {:metrics-defs metrics-defs

--- a/bases/criterium/test/criterium/util/helpers_test.clj
+++ b/bases/criterium/test/criterium/util/helpers_test.clj
@@ -109,3 +109,24 @@
                      data-without-p10 :elapsed-time)))))
       (testing "returns nil when bootstrap-stats is missing"
         (is (nil? (util/bootstrap-box-plot-stats {} :elapsed-time)))))))
+
+;;; Single-sample extraction tests
+;;;
+;;; Tests that samples-single-value correctly extracts raw values from
+;;; single-sample data produced by :one-shot benchmarks.
+
+(deftest samples-single-value-test
+  ;; Tests that samples-single-value extracts values from single-sample data,
+  ;; applies transforms, and returns nil for multi-sample or missing data.
+  (testing "samples-single-value"
+    (testing "extracts value from single-sample data"
+      (let [data-map (:data (test-data/samples-with-1-value-map))]
+        (is (= 42.5 (util/samples-single-value data-map :elapsed-time)))))
+    (testing "returns nil for multi-sample data"
+      (let [data-map (:data (test-data/samples-with-2-values-map))]
+        (is (nil? (util/samples-single-value data-map :elapsed-time)))))
+    (testing "returns nil when samples is missing"
+      (is (nil? (util/samples-single-value {} :elapsed-time))))
+    (testing "returns nil for non-existent metric"
+      (let [data-map (:data (test-data/samples-with-1-value-map))]
+        (is (nil? (util/samples-single-value data-map :nonexistent)))))))

--- a/development/src/criterium/schema.clj
+++ b/development/src/criterium/schema.clj
@@ -55,6 +55,27 @@
 
 ;;; Typed data maps
 
+(def raw-samples-map
+  "Schema for raw samples output from collect*.
+  This is the samples structure before analysis adds :source-id."
+  [:map
+   [:type [:= :criterium/metrics-samples]]
+   [:transform transform-map]
+   [:metric->values map?]
+   [:num-samples pos-int?]
+   [:batch-size pos-int?]
+   [:metrics-defs map?]
+   [:elapsed-time number?]
+   [:total-benchmark-time-ns number?]
+   [:eval-count pos-int?]
+   [:expr-value any?]])
+
+(def collect-output-map
+  "Schema for output of collect* multimethod.
+  Contains :samples key with raw metrics samples data."
+  [:map
+   [:samples raw-samples-map]])
+
 (def metrics-samples-map
   "Schema for metrics samples with :type :criterium/metrics-samples."
   [:map
@@ -344,6 +365,8 @@
     :criterium/collection-map         collection-map
     :criterium/data-entry-map         data-entry-map
     :criterium/collected-metrics-map  collected-metrics-map
+    :criterium/raw-samples-map        raw-samples-map
+    :criterium/collect-output-map     collect-output-map
     :criterium/metrics-samples-map    metrics-samples-map
     :criterium/digest-samples-map     digest-samples-map
     :criterium/quantiles-map          quantiles-map

--- a/development/src/criterium/schema/instrument.clj
+++ b/development/src/criterium/schema/instrument.clj
@@ -23,6 +23,7 @@
   Instruments:
   - criterium.bench public API functions
   - criterium.util.helpers typed accessor functions
+  - criterium.collect-plan.impl/collect* multimethod
 
   Usage:
     (require '[criterium.schema.instrument :as inst])
@@ -37,6 +38,7 @@
     (inst/unstrument!)"
   (:require
    [criterium.bench]
+   [criterium.collect-plan.impl]
    [criterium.schema :as schema]
    [criterium.util.helpers]
    [malli.core :as m]
@@ -161,6 +163,12 @@
       [:=> [:cat :criterium/outlier-significance-map]
        :criterium/outlier-significance-map])
 
+;;; Function schemas for criterium.collect-plan.impl
+
+(m/=> criterium.collect-plan.impl/collect*
+      [:=> [:cat :criterium/collect-plan :criterium/collector :criterium/measured]
+       :criterium/collect-output-map])
+
 ;;; Instrumentation functions
 
 (defn instrument!
@@ -180,7 +188,8 @@
    (mi/instrument!
     (merge
      {:filters [(mi/-filter-ns 'criterium.bench)
-                (mi/-filter-ns 'criterium.util.helpers)]}
+                (mi/-filter-ns 'criterium.util.helpers)
+                (mi/-filter-ns 'criterium.collect-plan.impl)]}
      options))))
 
 (defn unstrument!
@@ -195,7 +204,8 @@
    (mi/unstrument!
     (merge
      {:filters [(mi/-filter-ns 'criterium.bench)
-                (mi/-filter-ns 'criterium.util.helpers)]}
+                (mi/-filter-ns 'criterium.util.helpers)
+                (mi/-filter-ns 'criterium.collect-plan.impl)]}
      options))))
 
 (defn instrumented?


### PR DESCRIPTION
## Summary

Enable domain benchmarking to work with the `:one-shot` collect plan option, allowing single-iteration benchmarks across a parameter space for measuring expressions that should NOT be JIT-optimized.

**Use cases:**
- Infrequently-evaluated code (startup/initialization)
- Cold-path code
- One-off transformations

## Changes

- Add `samples-single-value` helper for extracting metrics from single-sample data
- Modify `domain.analysis/extract-metric-value` to fall back to raw samples when stats unavailable
- Modify `discover-quantitative-metrics` to check `[:samples :metrics-defs]` when `[:stats :metrics-defs]` missing
- Fix NPE in `compare-by` when error bounds are nil (omit keys rather than include nil values)
- Add `:total-benchmark-time-ns` to one-shot collect plan output
- Add comprehensive integration tests including end-to-end tests with real benchmarks

## Behavior

- `(domain/bench expr :bench-options {:collect-plan :one-shot})` now works with `extract-metrics`, `complexity-analysis`, and `implementation-comparison` domain plans
- No error bounds shown for one-shot data (correct for n=1)
- Existing `:with-jit-warmup` behavior unchanged

## Test plan

- [x] Unit tests for `samples-single-value` helper
- [x] Integration tests for all domain plans with one-shot data
- [x] End-to-end tests with real `domain/bench` execution
- [x] Regression tests for `:with-jit-warmup` unchanged