### PR TITLE
feat(collect-plan): add :num-warmup-samples option to :one-shot collect-plan

### DIFF
--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -50,8 +50,7 @@
   ;;
   ;; Returns a sampled data map.
   [collect-plan collector measured]
-  (let [{:keys [^long max-gc-attempts ^long num-warmup]
-         :or   {num-warmup 0}} collect-plan]
+  (let [{:keys [^long max-gc-attempts ^long num-warmup]} collect-plan]
     ;; Warmup invocations (if any)
     (dotimes [_ num-warmup]
       (collect/throw-away-collection measured))

--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -39,27 +39,34 @@
                (* v batch-size))})
 
 (defmethod impl/collect* :one-shot
-  ;; Collects a Single sample measured with no warmup of the measured function.
-  ;; Forces GC.
+  ;; Collects a single sample of measured with optional warmup invocations.
+  ;; Forces GC after warmup, then measures.
   ;; Return a sampled data map.
   [collect-plan collector measured]
-  (let [args (measured/args measured)
-        sample (collector/collect collector measured args 1)
-        elapsed-time-ns (metric/elapsed-time sample)]
-    (collect/force-gc! (:max-gc-attempts collect-plan))
-    {:samples
-     {:type :criterium/metrics-samples
-      :metrics-defs (:metrics-defs collector)
-      :metric->values (collect/sample-maps->map-of-samples
-                       [sample]
-                       (:metrics-defs collector))
-      :transform identity-transforms
-      :batch-size 1
-      :elapsed-time elapsed-time-ns
-      :total-benchmark-time-ns elapsed-time-ns
-      :eval-count 1
-      :num-samples 1
-      :expr-value (:expr-value sample)}}))
+  (let [{:keys [^long max-gc-attempts ^long num-warmup]
+         :or   {num-warmup 0}} collect-plan]
+    ;; Warmup invocations (if any)
+    (dotimes [_ num-warmup]
+      (collect/throw-away-collection measured))
+    ;; Force GC after warmup
+    (collect/force-gc! max-gc-attempts)
+    ;; Actual measurement
+    (let [args            (measured/args measured)
+          sample          (collector/collect collector measured args 1)
+          elapsed-time-ns (metric/elapsed-time sample)]
+      {:samples
+       {:type                    :criterium/metrics-samples
+        :metrics-defs            (:metrics-defs collector)
+        :metric->values          (collect/sample-maps->map-of-samples
+                                  [sample]
+                                  (:metrics-defs collector))
+        :transform               identity-transforms
+        :batch-size              1
+        :elapsed-time            elapsed-time-ns
+        :total-benchmark-time-ns elapsed-time-ns
+        :eval-count              1
+        :num-samples             1
+        :expr-value              (:expr-value sample)}})))
 
 (defn- collected-data-map
   [collection-map]

--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -51,7 +51,6 @@
   ;; Returns a sampled data map.
   [collect-plan collector measured]
   (let [{:keys [^long max-gc-attempts ^long num-warmup-samples]} collect-plan]
-    ;; Warmup invocations (if any)
     (dotimes [_ num-warmup-samples]
       (collect/throw-away-collection measured))
     ;; Force GC after warmup

--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -39,9 +39,16 @@
                (* v batch-size))})
 
 (defmethod impl/collect* :one-shot
-  ;; Collects a single sample of measured with optional warmup invocations.
-  ;; Forces GC after warmup, then measures.
-  ;; Return a sampled data map.
+  ;; Collect a single sample with optional warmup invocations.
+  ;;
+  ;; The :num-warmup option specifies how many throw-away invocations to run
+  ;; before measurement. This is useful for skipping JVM first-invocation
+  ;; allocation overhead (use :num-warmup 1).
+  ;;
+  ;; GC is forced after warmup invocations (even when :num-warmup is 0),
+  ;; then a single measurement is taken.
+  ;;
+  ;; Returns a sampled data map.
   [collect-plan collector measured]
   (let [{:keys [^long max-gc-attempts ^long num-warmup]
          :or   {num-warmup 0}} collect-plan]

--- a/bases/criterium/src/criterium/collect_plan.clj
+++ b/bases/criterium/src/criterium/collect_plan.clj
@@ -41,18 +41,18 @@
 (defmethod impl/collect* :one-shot
   ;; Collect a single sample with optional warmup invocations.
   ;;
-  ;; The :num-warmup option specifies how many throw-away invocations to run
-  ;; before measurement. This is useful for skipping JVM first-invocation
-  ;; allocation overhead (use :num-warmup 1).
+  ;; The :num-warmup-samples option specifies how many throw-away invocations (not
+  ;; batched samples) to run before measurement. This is useful for skipping JVM
+  ;; first-invocation allocation overhead (use :num-warmup-samples 1).
   ;;
-  ;; GC is forced after warmup invocations (even when :num-warmup is 0),
+  ;; GC is forced after warmup invocations (even when :num-warmup-samples is 0),
   ;; then a single measurement is taken.
   ;;
   ;; Returns a sampled data map.
   [collect-plan collector measured]
-  (let [{:keys [^long max-gc-attempts ^long num-warmup]} collect-plan]
+  (let [{:keys [^long max-gc-attempts ^long num-warmup-samples]} collect-plan]
     ;; Warmup invocations (if any)
-    (dotimes [_ num-warmup]
+    (dotimes [_ num-warmup-samples]
       (collect/throw-away-collection measured))
     ;; Force GC after warmup
     (collect/force-gc! max-gc-attempts)

--- a/bases/criterium/src/criterium/collect_plan/config.clj
+++ b/bases/criterium/src/criterium/collect_plan/config.clj
@@ -36,8 +36,8 @@
 
   :one-shot - Single measurement without JIT warmup.
     Options:
-      :num-warmup      - Number of warmup invocations before measurement. Use 1 to
-                         skip JVM first-invocation allocation overhead. Default: 0
+      :num-warmup-samples - Number of warmup invocations (not batched) before measurement.
+                         Use 1 to skip JVM first-invocation allocation overhead. Default: 0
       :max-gc-attempts - Maximum GC attempts after warmup. Default: 3
 
   :with-jit-warmup - Multiple samples with JIT warmup phase.
@@ -62,19 +62,19 @@
   ;; Configure a one-shot collection plan.
   ;;
   ;; Options:
-  ;;   :num-warmup      - Number of warmup invocations before measurement. Use 1 to
-  ;;                      skip JVM first-invocation allocation overhead. Default: 0
+  ;;   :num-warmup-samples - Number of warmup invocations (not batched) before measurement.
+  ;;                         Use 1 to skip JVM first-invocation allocation overhead. Default: 0
   ;;   :max-gc-attempts - Maximum GC attempts after warmup. Default: 3
   ;;
   ;; Returns config map with :scheme-type :one-shot.
   [_collect-plan-id
-   {:keys [max-gc-attempts num-warmup]
-    :or   {max-gc-attempts 3
-           num-warmup      0}
+   {:keys [max-gc-attempts num-warmup-samples]
+    :or   {max-gc-attempts    3
+           num-warmup-samples 0}
     :as   _options}]
-  {:scheme-type     :one-shot
-   :max-gc-attempts max-gc-attempts
-   :num-warmup      num-warmup})
+  {:scheme-type        :one-shot
+   :max-gc-attempts    max-gc-attempts
+   :num-warmup-samples num-warmup-samples})
 
 (defmethod collect-plan-config :with-jit-warmup
   [_collect-plan-id

--- a/bases/criterium/src/criterium/collect_plan/config.clj
+++ b/bases/criterium/src/criterium/collect_plan/config.clj
@@ -38,10 +38,13 @@
 
 (defmethod collect-plan-config :one-shot
   [_collect-plan-id
-   {:keys [max-gc-attempts]
+   {:keys [max-gc-attempts num-warmup]
+    :or   {max-gc-attempts 3
+           num-warmup      0}
     :as   _options}]
   {:scheme-type     :one-shot
-   :max-gc-attempts (or max-gc-attempts 3)})
+   :max-gc-attempts max-gc-attempts
+   :num-warmup      num-warmup})
 
 (defmethod collect-plan-config :with-jit-warmup
   [_collect-plan-id

--- a/bases/criterium/src/criterium/collect_plan/config.clj
+++ b/bases/criterium/src/criterium/collect_plan/config.clj
@@ -29,7 +29,29 @@
 (def TARGET-WARMUP-SAMPLES 150000)
 (def TARGET-SAMPLES 200)
 
-(defmulti  collect-plan-config
+(defmulti collect-plan-config
+  "Create a collect-plan configuration map from an id and options.
+
+  Available collect-plan types:
+
+  :one-shot - Single measurement without JIT warmup.
+    Options:
+      :num-warmup      - Number of warmup invocations before measurement. Use 1 to
+                         skip JVM first-invocation allocation overhead. Default: 0
+      :max-gc-attempts - Maximum GC attempts after warmup. Default: 3
+
+  :with-jit-warmup - Multiple samples with JIT warmup phase.
+    Options:
+      :num-estimation-samples - Samples for timing estimation. Default: 1000
+      :num-warmup-samples     - Samples for JIT warmup. Default: 150000
+      :num-measure-samples    - Samples for measurement. Default: 200
+      :max-gc-attempts        - Maximum GC attempts. Default: 6
+      :limit-time-ns          - Time limit in nanoseconds. Default: 10s
+      :batch-time-ns          - Target batch time. Default: 10µs
+      :thread-priority        - Optional thread priority during measurement
+
+  :without-jit-warmup - Multiple samples without warmup phase.
+    Same options as :with-jit-warmup but :num-warmup-samples defaults to 0."
   (fn [collect-plan-id _options] collect-plan-id))
 
 (defmethod collect-plan-config :default
@@ -37,6 +59,14 @@
   (throw (ex-info "Unknown collect-plan" {:collect-plan collect-plan-id})))
 
 (defmethod collect-plan-config :one-shot
+  ;; Configure a one-shot collection plan.
+  ;;
+  ;; Options:
+  ;;   :num-warmup      - Number of warmup invocations before measurement. Use 1 to
+  ;;                      skip JVM first-invocation allocation overhead. Default: 0
+  ;;   :max-gc-attempts - Maximum GC attempts after warmup. Default: 3
+  ;;
+  ;; Returns config map with :scheme-type :one-shot.
   [_collect-plan-id
    {:keys [max-gc-attempts num-warmup]
     :or   {max-gc-attempts 3

--- a/bases/criterium/test/criterium/collect_plan/config_test.clj
+++ b/bases/criterium/test/criterium/collect_plan/config_test.clj
@@ -4,16 +4,16 @@
    [criterium.collect-plan.config :as config]))
 
 ;; Tests for collect-plan-config :one-shot method
-;; Verifies :num-warmup option handling and defaults.
+;; Verifies :num-warmup-samples option handling and defaults.
 
 (deftest collect-plan-config-one-shot-test
   (testing ":one-shot collect-plan-config"
-    (testing "returns default :num-warmup of 0 when not specified"
+    (testing "returns default :num-warmup-samples of 0 when not specified"
       (let [config (config/collect-plan-config :one-shot {})]
-        (is (= 0 (:num-warmup config)))))
-    (testing "returns provided :num-warmup value"
-      (let [config (config/collect-plan-config :one-shot {:num-warmup 5})]
-        (is (= 5 (:num-warmup config)))))
+        (is (= 0 (:num-warmup-samples config)))))
+    (testing "returns provided :num-warmup-samples value"
+      (let [config (config/collect-plan-config :one-shot {:num-warmup-samples 5})]
+        (is (= 5 (:num-warmup-samples config)))))
     (testing "returns default :max-gc-attempts when not specified"
       (let [config (config/collect-plan-config :one-shot {})]
         (is (= 3 (:max-gc-attempts config)))))

--- a/bases/criterium/test/criterium/collect_plan/config_test.clj
+++ b/bases/criterium/test/criterium/collect_plan/config_test.clj
@@ -1,0 +1,25 @@
+(ns criterium.collect-plan.config-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.collect-plan.config :as config]))
+
+;; Tests for collect-plan-config :one-shot method
+;; Verifies :num-warmup option handling and defaults.
+
+(deftest collect-plan-config-one-shot-test
+  (testing ":one-shot collect-plan-config"
+    (testing "returns default :num-warmup of 0 when not specified"
+      (let [config (config/collect-plan-config :one-shot {})]
+        (is (= 0 (:num-warmup config)))))
+    (testing "returns provided :num-warmup value"
+      (let [config (config/collect-plan-config :one-shot {:num-warmup 5})]
+        (is (= 5 (:num-warmup config)))))
+    (testing "returns default :max-gc-attempts when not specified"
+      (let [config (config/collect-plan-config :one-shot {})]
+        (is (= 3 (:max-gc-attempts config)))))
+    (testing "returns provided :max-gc-attempts value"
+      (let [config (config/collect-plan-config :one-shot {:max-gc-attempts 10})]
+        (is (= 10 (:max-gc-attempts config)))))
+    (testing "includes :scheme-type :one-shot"
+      (let [config (config/collect-plan-config :one-shot {})]
+        (is (= :one-shot (:scheme-type config)))))))

--- a/bases/criterium/test/criterium/collect_plan_test.clj
+++ b/bases/criterium/test/criterium/collect_plan_test.clj
@@ -56,3 +56,71 @@
       (is (every? #(instance? ITypedArray %)
                   (vals (:metric->values (:samples data-map)))))
       (is (= 1 (:expr-value (:samples data-map)))))))
+
+;;; Tests for :num-warmup option in :one-shot collect-plan
+;; Verifies that warmup invocations execute before measurement.
+
+(deftest one-shot-num-warmup-test
+  ;; Tests :num-warmup option for :one-shot collect-plan.
+  ;; Uses an atom counter to verify the number of invocations.
+  (let [collector (collector/collector
+                   {:stages     []
+                    :terminator :elapsed-time})]
+    (testing ":one-shot with :num-warmup"
+      (testing "when :num-warmup is 0 (default)"
+        (testing "invokes measured exactly once"
+          (let [counter  (atom 0)
+                measured (measured/measured
+                          (fn [] [])
+                          (fn [_ _]
+                            (swap! counter inc)
+                            [1000 @counter]))]
+            (collect-plan/collect
+             (collect-plan-config/collect-plan-config :one-shot {})
+             collector
+             measured)
+            (is (= 1 @counter)
+                "Expected 1 invocation (measurement only)"))))
+      (testing "when :num-warmup is 1"
+        (testing "invokes measured twice (1 warmup + 1 measurement)"
+          (let [counter  (atom 0)
+                measured (measured/measured
+                          (fn [] [])
+                          (fn [_ _]
+                            (swap! counter inc)
+                            [1000 @counter]))]
+            (collect-plan/collect
+             (collect-plan-config/collect-plan-config :one-shot {:num-warmup 1})
+             collector
+             measured)
+            (is (= 2 @counter)
+                "Expected 2 invocations (1 warmup + 1 measurement)"))))
+      (testing "when :num-warmup is 3"
+        (testing "invokes measured four times (3 warmup + 1 measurement)"
+          (let [counter  (atom 0)
+                measured (measured/measured
+                          (fn [] [])
+                          (fn [_ _]
+                            (swap! counter inc)
+                            [1000 @counter]))]
+            (collect-plan/collect
+             (collect-plan-config/collect-plan-config :one-shot {:num-warmup 3})
+             collector
+             measured)
+            (is (= 4 @counter)
+                "Expected 4 invocations (3 warmup + 1 measurement)"))))
+      (testing "returns result from measurement invocation (not warmup)"
+        (let [counter  (atom 0)
+              measured (measured/measured
+                        (fn [] [])
+                        (fn [_ _]
+                          (swap! counter inc)
+                          [1000 @counter]))
+              result   (collect-plan/collect
+                        (collect-plan-config/collect-plan-config
+                         :one-shot
+                         {:num-warmup 2})
+                        collector
+                        measured)]
+          (is (= 3 (:expr-value (:samples result)))
+              "expr-value should be from the 3rd invocation (after 2 warmups)"))))))

--- a/bases/criterium/test/criterium/collect_plan_test.clj
+++ b/bases/criterium/test/criterium/collect_plan_test.clj
@@ -57,17 +57,17 @@
                   (vals (:metric->values (:samples data-map)))))
       (is (= 1 (:expr-value (:samples data-map)))))))
 
-;;; Tests for :num-warmup option in :one-shot collect-plan
+;;; Tests for :num-warmup-samples option in :one-shot collect-plan
 ;; Verifies that warmup invocations execute before measurement.
 
 (deftest one-shot-num-warmup-test
-  ;; Tests :num-warmup option for :one-shot collect-plan.
+  ;; Tests :num-warmup-samples option for :one-shot collect-plan.
   ;; Uses an atom counter to verify the number of invocations.
   (let [collector (collector/collector
                    {:stages     []
                     :terminator :elapsed-time})]
-    (testing ":one-shot with :num-warmup"
-      (testing "when :num-warmup is 0 (default)"
+    (testing ":one-shot with :num-warmup-samples"
+      (testing "when :num-warmup-samples is 0 (default)"
         (testing "invokes measured exactly once"
           (let [counter  (atom 0)
                 measured (measured/measured
@@ -81,7 +81,7 @@
              measured)
             (is (= 1 @counter)
                 "Expected 1 invocation (measurement only)"))))
-      (testing "when :num-warmup is 1"
+      (testing "when :num-warmup-samples is 1"
         (testing "invokes measured twice (1 warmup + 1 measurement)"
           (let [counter  (atom 0)
                 measured (measured/measured
@@ -90,12 +90,12 @@
                             (swap! counter inc)
                             [1000 @counter]))]
             (collect-plan/collect
-             (collect-plan-config/collect-plan-config :one-shot {:num-warmup 1})
+             (collect-plan-config/collect-plan-config :one-shot {:num-warmup-samples 1})
              collector
              measured)
             (is (= 2 @counter)
                 "Expected 2 invocations (1 warmup + 1 measurement)"))))
-      (testing "when :num-warmup is 3"
+      (testing "when :num-warmup-samples is 3"
         (testing "invokes measured four times (3 warmup + 1 measurement)"
           (let [counter  (atom 0)
                 measured (measured/measured
@@ -104,7 +104,7 @@
                             (swap! counter inc)
                             [1000 @counter]))]
             (collect-plan/collect
-             (collect-plan-config/collect-plan-config :one-shot {:num-warmup 3})
+             (collect-plan-config/collect-plan-config :one-shot {:num-warmup-samples 3})
              collector
              measured)
             (is (= 4 @counter)
@@ -119,7 +119,7 @@
               result   (collect-plan/collect
                         (collect-plan-config/collect-plan-config
                          :one-shot
-                         {:num-warmup 2})
+                         {:num-warmup-samples 2})
                         collector
                         measured)]
           (is (= 3 (:expr-value (:samples result)))


### PR DESCRIPTION
## Summary

Add `:num-warmup-samples` option to `:one-shot` collect-plan, allowing measurement after a specified number of warmup invocations.

**Motivation:** The JVM allocates internal function metrics on the first invocation. With `:num-warmup-samples 1`, users can skip this first-invocation overhead and measure subsequent calls.

## Changes

- Add `:num-warmup-samples` to `:one-shot` collect-plan config (default 0, preserves existing behavior)
- Implement warmup loop in `:one-shot` collect method using `throw-away-collection`
- Force GC after warmup invocations before measurement
- Document the option in config docstrings

## Test plan

- [x] Tests verify invocation counts for `:num-warmup-samples` 0, 1, and 3
- [x] All existing tests pass