### PR TITLE
feat(view): add extremes view showing min/max values

### DIFF
--- a/bases/criterium/src/criterium/view.clj
+++ b/bases/criterium/src/criterium/view.clj
@@ -38,6 +38,7 @@
 (def-multi-view samples)
 (def-multi-view stats)
 (def-multi-view shape-stats)
+(def-multi-view extremes)
 
 ;;; Distribution Fit Views
 
@@ -110,6 +111,7 @@
 (defmethod samples* :none [_ _ _])
 (defmethod stats* :none [_ _ _])
 (defmethod shape-stats* :none [_ _ _])
+(defmethod extremes* :none [_ _ _])
 
 ;; Distribution Fit Null Viewer
 (defmethod distribution-models* :none [_ _ _])

--- a/bases/criterium/src/criterium/viewer/common/core.clj
+++ b/bases/criterium/src/criterium/viewer/common/core.clj
@@ -53,6 +53,29 @@
    []
    (filterv (metric/type-pred :quantitative) metric-configs)))
 
+(defn extremes-map
+  "Prepare min/max extremes for display in tabular format.
+  Returns a vector of maps with :metric, :min, and :max keys."
+  [stats metric-configs transforms]
+  (reduce
+   (fn [res metric]
+     (let [stat (util/transform-vals->
+                 (get-in stats (:path metric))
+                 transforms)
+           min-val (double (:min-val stat))
+           max-val (double (:max-val stat))
+           metric-scale (double (:scale metric))
+           [scale label] (format/scale
+                          (:dimension metric)
+                          (* metric-scale min-val))
+           scale (* (double scale) metric-scale)]
+       (conj res
+             {:metric (str (:label metric) " " label)
+              :min (format/round (* min-val scale) 4)
+              :max (format/round (* max-val scale) 4)})))
+   []
+   (filterv (metric/type-pred :quantitative) metric-configs)))
+
 (defn composite-key [path]
   (keyword (str/join "-" (mapv name path))))
 

--- a/bases/criterium/src/criterium/viewer/kindly.clj
+++ b/bases/criterium/src/criterium/viewer/kindly.clj
@@ -120,6 +120,23 @@
             metric-configs
             transforms)))))))
 
+(defmethod view/extremes* :kindly
+  [_ {:keys [stats-id metric-ids]} data-map]
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)]
+    (when stats-map
+      (let [metrics-defs (-> (:metrics-defs stats-map)
+                             (metric/select-metrics metric-ids))
+            metric-configs (metric/all-metric-configs metrics-defs)
+            transforms (util/get-transforms data-map stats-id)]
+        (when (seq metric-configs)
+          (kindly-heading "Extremes")
+          (kindly-table
+           (core/extremes-map
+            (util/stats stats-map)
+            metric-configs
+            transforms)))))))
+
 (defmethod view/quantiles* :kindly
   [_ {:keys [quantiles-id]} data-map]
   (let [quantiles-id (or quantiles-id :quantiles)

--- a/bases/criterium/src/criterium/viewer/portal.clj
+++ b/bases/criterium/src/criterium/viewer/portal.clj
@@ -111,6 +111,23 @@
             metric-configs
             transforms)))))))
 
+(defmethod view/extremes* :portal
+  [_ {:keys [stats-id metric-ids]} data-map]
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)]
+    (when stats-map
+      (let [metrics-defs (-> (:metrics-defs stats-map)
+                             (metric/select-metrics metric-ids))
+            metric-configs (metric/all-metric-configs metrics-defs)
+            transforms (util/get-transforms data-map stats-id)]
+        (when (seq metric-configs)
+          (heading "Extremes")
+          (portal-table
+           (core/extremes-map
+            (util/stats stats-map)
+            metric-configs
+            transforms)))))))
+
 (defmethod view/event-stats* :portal
   [_ {:keys [event-stats-id]} data-map]
   (let [event-stats-id (or event-stats-id :event-stats)

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -43,6 +43,24 @@
             metric-configs
             transforms)))))))
 
+(defmethod view/extremes* :pprint
+  [_ {:keys [stats-id metric-ids]} data-map]
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)]
+    (when stats-map
+      (let [metrics-defs (-> (:metrics-defs stats-map)
+                             (metric/select-metrics metric-ids))
+            metric-configs (metric/all-metric-configs metrics-defs)
+            transforms (util/get-transforms data-map stats-id)]
+        (when (seq metric-configs)
+          (println "Extremes:")
+          (pprint/print-table
+           [:metric :min :max]
+           (core/extremes-map
+            (util/stats stats-map)
+            metric-configs
+            transforms)))))))
+
 (defmethod view/quantiles* :pprint
   [_ {:keys [quantiles-id]} data-map]
   (let [quantiles-id (or quantiles-id :quantiles)

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -66,6 +66,31 @@
   (doseq [metric metrics]
     (print-stat metric (get-in stats (:path metric)) transforms)))
 
+(defn print-extreme
+  "Print min and max values for a metric."
+  [metric stat transforms]
+  (when (and (:min-val stat) (:max-val stat))
+    (let [stat (util/transform-vals-> stat transforms)
+          [scale unit] (format/scale
+                        (:dimension metric)
+                        (* (:scale metric) (:min-val stat)))
+          scale (* scale (:scale metric))]
+      (println
+       (format
+        "%32s: %s %s - %s %s"
+        (:label metric)
+        (format/format-scaled (:min-val stat) scale)
+        unit
+        (format/format-scaled (:max-val stat) scale)
+        unit)))))
+
+(defn print-extremes
+  "Print min/max extremes for all metrics."
+  [metrics stats transforms]
+  (println "Extremes:")
+  (doseq [metric metrics]
+    (print-extreme metric (get-in stats (:path metric)) transforms)))
+
 (defmethod view/stats* :print
   [_ {:keys [stats-id metric-ids]} data-map]
   (let [stats-id (or stats-id :stats)
@@ -75,6 +100,19 @@
                              (metric/select-metrics metric-ids))
             metric-configs (metric/all-metric-configs metrics-defs)]
         (print-stats
+         metric-configs
+         (util/stats stats-map)
+         (util/get-transforms data-map stats-id))))))
+
+(defmethod view/extremes* :print
+  [_ {:keys [stats-id metric-ids]} data-map]
+  (let [stats-id (or stats-id :stats)
+        stats-map (data-map stats-id)]
+    (when stats-map
+      (let [metrics-defs (-> (:metrics-defs stats-map)
+                             (metric/select-metrics metric-ids))
+            metric-configs (metric/all-metric-configs metrics-defs)]
+        (print-extremes
          metric-configs
          (util/stats stats-map)
          (util/get-transforms data-map stats-id))))))

--- a/bases/criterium/test/criterium/viewer/kindly_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_test.clj
@@ -179,6 +179,39 @@
                    (:data (test-data/bench-stats-map)))
       (is (nil? (kindly/flush))))))
 
+(deftest extremes-view-test
+  ;; Tests the view/extremes* multimethod for :kindly viewer.
+  ;; Verifies that extremes data is rendered as a heading and table with correct
+  ;; Kindly metadata showing min and max values for quantitative metrics.
+  (testing "view/extremes* :kindly"
+    (testing "renders extremes as heading and table"
+      (reset! kindly/accumulated [])
+      (view/extremes* :kindly {} (:data (test-data/bench-stats-map)))
+      (let [result (kindly/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result))
+            "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Extremes**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 1 (count table))
+              "Expected one metric row")
+          (let [row (first table)]
+            (is (string? (:metric row))
+                "Expected :metric column as string")
+            (is (number? (:min row))
+                "Expected :min column as number")
+            (is (number? (:max row))
+                "Expected :max column as number")))))
+
+    (testing "outputs nothing when metric-ids filter yields no matching metrics"
+      (reset! kindly/accumulated [])
+      (view/extremes* :kindly
+                      {:metric-ids [:nonexistent-metric]}
+                      (:data (test-data/bench-stats-map)))
+      (is (nil? (kindly/flush))))))
+
 (deftest quantiles-view-test
   ;; Tests the view/quantiles* multimethod for :kindly viewer.
   ;; Verifies that quantiles data is rendered as a heading and table with correct

--- a/bases/criterium/test/criterium/viewer/portal_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal_test.clj
@@ -182,6 +182,33 @@
           (finally
             (remove-tap f)))))))
 
+(deftest portal-extremes-test
+  ;; Verifies extremes display with conditional heading behavior.
+  (testing "view/extremes*"
+    (testing "displays extremes when metrics match"
+      (is (= [[:b "Extremes"]
+              [{:metric "Elapsed Time ns",
+                :min 89.0
+                :max 114.0}]]
+             (with-tap-out
+               (view/extremes*
+                :portal
+                {}
+                (:data (test-data/bench-stats-map)))))))
+    (testing "outputs nothing when metric-ids filter yields no matching metrics"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= ::portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/extremes*
+           :portal
+           {:metric-ids [:nonexistent-metric]}
+           (:data (test-data/bench-stats-map)))
+          (portal/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))
+
 (deftest portal-outlier-count-test
   (testing "print-outlier-count"
     (testing "prints via view"

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -54,6 +54,32 @@
                 {:metric-ids [:nonexistent-metric]}
                 (:data (test-data/bench-stats-map)))))))))
 
+(def expected-extremes
+  ["Extremes:"
+   ""
+   "|         :metric | :min |  :max |"
+   "|-----------------+------+-------|"
+   "| Elapsed Time ns | 89.0 | 114.0 |"])
+
+(deftest pprint-extremes-test
+  ;; Verifies extremes display with table output showing min/max values.
+  (testing "view/extremes*"
+    (testing "displays min and max values in table format"
+      (is (= expected-extremes
+             (trimmed-lines
+              (with-out-str
+                (view/extremes*
+                 :pprint
+                 {}
+                 (:data (test-data/bench-stats-map))))))))
+    (testing "outputs nothing when metric-ids filter yields no matching metrics"
+      (is (= ""
+             (with-out-str
+               (view/extremes*
+                :pprint
+                {:metric-ids [:nonexistent-metric]}
+                (:data (test-data/bench-stats-map)))))))))
+
 (def expected-counts
   [""
    "|     :_metric | :low-severe | :low-mild | :high-mild | :high-severe |"

--- a/bases/criterium/test/criterium/viewer/print_test.clj
+++ b/bases/criterium/test/criterium/viewer/print_test.clj
@@ -35,6 +35,22 @@
                 :min-val 89.0}
                [collect-plan/identity-transforms])))))))
 
+(deftest print-extreme-test
+  ;; Tests print-extreme function for min/max display.
+  ;; Covers: SI unit formatting and value display.
+  (testing "print-extreme"
+    (testing "prints min and max values with SI units"
+      (is (= "Elapsed Time: 89.0 ns - 114 ns"
+             (str/trim
+              (with-out-str
+                (print/print-extreme
+                 {:label "Elapsed Time"
+                  :scale 1e-9
+                  :dimension :time}
+                 {:min-val 89.0
+                  :max-val 114.0}
+                 [collect-plan/identity-transforms]))))))))
+
 (defn identity-transform [samples]
   (with-meta samples {:transform {:sample-> identity :->sample identity}}))
 
@@ -42,6 +58,38 @@
   "Return indices where char c appears in string s."
   [c s]
   (keep-indexed (fn [i ch] (when (= ch c) i)) s))
+
+(deftest print-extremes-test
+  ;; Tests print-extremes function and view/extremes* multimethod.
+  ;; Covers: min/max display for quantitative metrics.
+  (testing "print-extremes"
+    (testing "prints via output-view"
+      (is (= ["Extremes:"
+              "Elapsed Time: 89.0 ns - 114 ns"]
+             (trimmed-lines
+              (with-out-str
+                (view/extremes*
+                 :print
+                 {}
+                 (:data (test-data/bench-stats-map))))))))
+
+    (testing "applies batch-size transform to per-execution values"
+      (is (= ["Extremes:"
+              "Elapsed Time: 0.500 ns - 4.50 ns"]
+             (let [data-map
+                   (-> (update-in
+                        (:data (test-data/samples-with-variance-12-map))
+                        [:samples]
+                        merge
+                        {:batch-size 2
+                         :transform (#'collect-plan/batch-transforms 2)}))
+                   stats (analyse/stats)
+                   view-extremes (view/extremes)]
+               (trimmed-lines
+                (with-out-str
+                  (->> data-map
+                       stats
+                       (view-extremes :print))))))))))
 
 (deftest print-stats-test
   (testing "print-stats"


### PR DESCRIPTION
## Summary

Add a new `extremes` viewer that displays both minimum and maximum values for quantitative metrics in benchmark results, providing a quick overview of the observed value range.

## Description

The existing `stats` view shows mean, 3σ bounds, and only the min value. This view explicitly shows both extremes together.

**Features:**
- Shows min-val and max-val for each quantitative metric (elapsed-time, thread-allocation)
- Uses existing `:stats` analysis data (no new analysis needed)
- Supports standard options: `:stats-id` (defaults to `:stats`), `:metric-ids` (optional filter)
- Applies transforms (batch-size scaling) like other stats-based views
- Formats values with appropriate SI units (ns/μs/ms for time, bytes/KB/MB for memory)

**Output format (print viewer):**
```
Extremes:
         Elapsed Time: 89.2 ns - 114.3 ns
    Thread Allocation: 1.2 KB - 1.5 KB
```

## Changes

- Add `extremes` view multimethod to `criterium.view`
- Implement print viewer with SI unit formatting
- Implement pprint viewer with table format
- Implement portal viewer with table visualization
- Implement kindly viewer for notebook display

## Commits

- `bc6d90c5` feat(view): add extremes view multimethod
- `5eccbeb1` feat(view): add print viewer for extremes
- `17079835` feat(view): add pprint viewer for extremes
- `00d7aa44` feat(view): add portal viewer for extremes
- `1bcd7eef` feat(view): add kindly viewer for extremes