### PR TITLE
feat(bench-plans): use :extremes view instead of :log-stats

### DIFF
--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -37,7 +37,7 @@
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
           :bootstrap-stats
-          [:stats {:stats-id :log-stats}]
+          :extremes
           [:multimodal-warning {:modes-id :modes}]
           :event-stats
           :outlier-counts
@@ -67,7 +67,7 @@
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
           :bootstrap-stats
-          [:stats {:stats-id :log-stats}]
+          :extremes
           :quantiles
           :event-stats
           :outlier-counts
@@ -104,7 +104,7 @@
              :allocation-by-type
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
-          [:stats {:stats-id :log-stats}]
+          :extremes
           :quantiles
           :event-stats
           :outlier-counts
@@ -140,7 +140,7 @@
              :allocation-by-type
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
-          [:stats {:stats-id :log-stats}]
+          :extremes
           [:stats {:stats-id :kde-stats}]
           :quantiles
           :event-stats
@@ -181,7 +181,7 @@
              :allocation-by-type
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
-          [:stats {:stats-id :log-stats}]
+          :extremes
           [:stats {:stats-id :kde-stats}]
           :quantiles
           :event-stats
@@ -235,7 +235,7 @@
              [:allocation-hotspots {:limit 10}]
              :allocation-by-type]
    :view [[:stats {:metric-ids [:memory]}]
-          [:stats {:stats-id :log-stats}]
+          :extremes
           :bootstrap-stats
           :shape-stats
           :distribution-models
@@ -288,7 +288,7 @@
              :allocation-by-type]
    :view [[:stats {:metric-ids [:memory]}]
           :bootstrap-stats
-          [:stats {:stats-id :log-stats}]
+          :extremes
           :quantiles
           :tail-summary
           :tail-ratios

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -14,13 +14,11 @@
     (is (nil? (bench/last-bench)))
     (let [out (with-out-str (bench/bench 1 :limit-time-s 0.1))]
       (testing "outputs the estimated time on stdout"
-        (is (re-find
-             #"Elapsed Time: [0-9.]+ [mn]s  3σ \[[0-9.e+-]+ [0-9.e+-]+]  min [0-9.]+"
-             out)))))
+        (is (re-find #"Elapsed Time median:" out)))))
   (testing "time with stats"
     (let [out (with-out-str (bench/bench 1 :limit-time-s 0.1))]
-      (testing "outputs statistics on stdout"
-        (is (re-find #"3σ" out)))))
+      (testing "outputs extremes on stdout"
+        (is (re-find #"Extremes:" out)))))
   (testing "time with one-shot"
     (let [out (with-out-str (bench/bench 1 :collect-plan :one-shot))]
       (testing "outputs statistics on stdout"
@@ -306,11 +304,10 @@
           (is (some? (:modes data))
               "modes analysis should be present")
           (is (= :criterium/modes (:type (:modes data)))
-              "modes should have correct type"))
+              "modes should have correct type"))))))
         ;; Note: multimodal-warning only displays when n-modes > 1
         ;; For a simple (+ 1 1) benchmark, distribution should be unimodal
         ;; so we don't test for warning output here
-        ))))
 
 ;;; warmup-args-fn option tests
 ;; Tests for the :warmup-args-fn option in the bench macro.

--- a/bases/criterium/test/criterium/viewer/kindly_clay_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_clay_test.clj
@@ -68,8 +68,8 @@
           (let [html (slurp (io/file temp-dir ".clay.html"))]
             (is (str/includes? html "<table")
                 "HTML contains table elements")
-            (is (str/includes? html "Summary stats")
-                "HTML contains stats heading")
+            (is (str/includes? html "Extremes")
+                "HTML contains extremes heading")
             (is (str/includes? html "Quantiles")
                 "HTML contains quantiles heading")
             (is (str/includes? html "Histogram")


### PR DESCRIPTION
## Summary

Replace `[:stats {:stats-id :log-stats}]` with `:extremes` in the `:view` section of all bench plans.

## Changes

- Updated 7 bench plans in `criterium.bench-plans`:
  - default-with-warmup
  - log-histogram
  - knuth-histogram
  - kde-histogram
  - kde-modes
  - distribution-analysis
  - tail-analysis

The `:extremes` view provides min/max values using the default `:stats` stats-id.

## Test plan

- [x] Tests pass