### PR TITLE
feat(ci): add boxed math and reflection warning checks to GH test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,3 +172,9 @@ jobs:
       run: |
         set -x
         clj-kondo --lint bases projects --fail-level warning
+
+    - name: Check for boxed math and reflection warnings
+      if: matrix.os == 'ubuntu-latest' && matrix.with-agent == false
+      run: |
+        set -x
+        clojure -M:dev:test:check-warnings

--- a/.nrepl.edn
+++ b/.nrepl.edn
@@ -1,4 +1,3 @@
 {:dynamic-vars
- {clojure.core/*warn-on-reflection*      true
-  clojure.core/*unchecked-math*          :warn-on-boxed
-  clojure.core/*warn-on-late-bound-call* true}}
+ {clojure.core/*warn-on-reflection* true
+  clojure.core/*unchecked-math*     :warn-on-boxed}}

--- a/.nrepl.edn
+++ b/.nrepl.edn
@@ -1,0 +1,4 @@
+{:dynamic-vars
+ {clojure.core/*warn-on-reflection*      true
+  clojure.core/*unchecked-math*          :warn-on-boxed
+  clojure.core/*warn-on-late-bound-call* true}}

--- a/bases/notebooks/src/criterium/analyse_domain_notebook.clj
+++ b/bases/notebooks/src/criterium/analyse_domain_notebook.clj
@@ -219,19 +219,22 @@
 
 ;; Extract times and observe scaling:
 
-(let [extract (analysis/extract scaling-domain [:stats :elapsed-time :mean])]
-  (kind/table
-   {:column-names [:n :time-ns :ratio-to-previous]
-    :row-vectors
-    (let [data (:data extract)]
-      (map-indexed
-       (fn [i [coord value]]
-         [(:n coord)
-          (format "%.1f" value)
-          (if (zero? i)
-            "-"
-            (format "%.2fx" (/ value (second (nth data (dec i))))))])
-       data))}))
+(binding [*unchecked-math* nil]
+  (let [extract (analysis/extract scaling-domain [:stats :elapsed-time :mean])]
+    (kind/table
+     {:column-names [:n :time-ns :ratio-to-previous]
+      :row-vectors
+      (let [data (:data extract)]
+        (map-indexed
+         (fn [^long i [coord value]]
+           [(:n coord)
+            (format "%.1f" value)
+            (if (zero? i)
+              "-"
+              (format
+               "%.2fx"
+               (/ (double value) (double (second (nth data (dec i)))))))])
+         data))})))
 
 ;; ### Regression Fitting
 ;;
@@ -259,7 +262,7 @@
 (let [result (analysis/fit-complexity
               (analysis/extract scaling-domain [:stats :elapsed-time :mean])
               :n
-              {:cubic {:transform (fn [n] (* n n n)) :label "O(n³)"}
+              {:cubic  {:transform (fn [^double n] (* n n n)) :label "O(n³)"}
                :linear {:transform identity :label "O(n)"}})]
   (get-in result [:regressions :elapsed-time :best-fit]))
 

--- a/bases/notebooks/src/criterium/basic_usage_notebook.clj
+++ b/bases/notebooks/src/criterium/basic_usage_notebook.clj
@@ -134,21 +134,21 @@
 (do
   (println "With reduce")
   (bench/bench (reduce + numbers-for-sum))
-  (let [reduce-mean (util/stats-value
-                     (:data (bench/last-bench))
-                     :stats
-                     :elapsed-time
-                     :mean)]
+  (let [^double reduce-mean (util/stats-value
+                             (:data (bench/last-bench))
+                             :stats
+                             :elapsed-time
+                             :mean)]
     (println "With apply")
     (bench/bench (apply + numbers-for-sum))
-    (let [apply-mean (util/stats-value
-                      (:data (bench/last-bench))
-                      :stats
-                      :elapsed-time
-                      :mean)]
+    (let [^double apply-mean (util/stats-value
+                              (:data (bench/last-bench))
+                              :stats
+                              :elapsed-time
+                              :mean)]
       {:reduce-ns reduce-mean
-       :apply-ns apply-mean
-       :ratio (/ apply-mean reduce-mean)})))
+       :apply-ns  apply-mean
+       :ratio     (/ apply-mean reduce-mean)})))
 
 ;; ## Best Practices
 

--- a/bases/notebooks/src/criterium/call_graph_notebook.clj
+++ b/bases/notebooks/src/criterium/call_graph_notebook.clj
@@ -208,7 +208,7 @@ combined-filter
   [items]
   (->> items
        (filter even?)
-       (map #(* % %))
+       (map #(* (long %) (long %)))
        (take 10)
        (reduce +)))
 

--- a/bases/notebooks/src/criterium/instrument_fn_notebook.clj
+++ b/bases/notebooks/src/criterium/instrument_fn_notebook.clj
@@ -28,8 +28,8 @@
 (defn slow
   "A computation with variable execution time."
   [n]
-  (Thread/sleep (long (+ 1 (rand-int 5))))
-  (* n n))
+  (Thread/sleep (+ 1 (long (rand-int 5))))
+  (* (long n) (long n)))
 
 (def instrumented-slow
   "Instrumented version of slow-computation."
@@ -115,11 +115,13 @@
   "Process data with multiple arguments."
   [data multiplier offset]
   (Thread/sleep 1)
-  (+ (* data multiplier) offset))
+  (+ (* (long data) (long multiplier)) (long offset)))
 
 (def instrumented-process
   "Instrumented version of process-data."
-  (inst-fn/instrument-fn process-data collector-configs/default-collector-config))
+  (inst-fn/instrument-fn
+   process-data
+   collector-configs/default-collector-config))
 
 (do
   (sampler/reset-samples! instrumented-process)
@@ -191,7 +193,7 @@
 (defn handle-request
   "Simulate handling an HTTP request."
   [request]
-  (Thread/sleep (long (+ 5 (rand-int 10))))
+  (Thread/sleep (+ 5 (long (rand-int 10))))
   {:status  200
    :headers {"Content-Type" "application/json"}
    :body    (str "Processed: " (:path request))})

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -332,7 +332,7 @@
 
 ;; Compare results on the multimodal example:
 (compare-test-methods
- (measured/callable #(variable-work 100 (zero? (mod (rand-int 100) 3)))))
+ (measured/callable #(variable-work 100 (zero? (long (mod (rand-int 100) 3))))))
 
 ;; ## Comparing KDE to Histograms
 ;;

--- a/bases/notebooks/src/criterium/sampled_fn/examples.clj
+++ b/bases/notebooks/src/criterium/sampled_fn/examples.clj
@@ -81,7 +81,7 @@
   "Simulate a network call with variable latency"
   []
   (let [base-latency 50
-        jitter       (rand-int 20)]
+        ^long jitter (rand-int 20)]
     (Thread/sleep (long (+ base-latency jitter)))
     {:status :success}))
 

--- a/bases/notebooks/src/criterium/sampled_fn_notebook.clj
+++ b/bases/notebooks/src/criterium/sampled_fn_notebook.clj
@@ -40,8 +40,8 @@
 (defn slow-computation
   "A computation with variable execution time."
   [n]
-  (Thread/sleep (long (+ 1 (rand-int 5))))
-  (* n n))
+  (Thread/sleep (+ 1 (long (rand-int 5))))
+  (* (long n) (long n)))
 
 (def sampled-slow
   "Sampled version of slow-computation."
@@ -61,7 +61,7 @@
 
 (defn process-item
   "Process a single item."
-  [x]
+  [^long x]
   (Thread/sleep 1)
   (* x 2))
 

--- a/build/deps.edn
+++ b/build/deps.edn
@@ -1,4 +1,5 @@
-{:deps {babashka/fs {:mvn/version "0.5.27"}
+{:paths ["src" "resources"]
+ :deps {babashka/fs {:mvn/version "0.5.27"}
         com.taoensso/truss {:mvn/version "1.12.0"}
         io.github.clojure/tools.build {:git/tag "v0.10.11"
                                        :git/sha "c6c670a"}

--- a/build/resources/build/noisy-namespaces.edn
+++ b/build/resources/build/noisy-namespaces.edn
@@ -33,7 +33,10 @@
  nrepl.core
  nrepl.middleware
  nrepl.middleware.session
+ org.httpkit.client
  orchard.inspect
+ portal.runtime
+ portal.runtime.shell
  potemkin.utils
  scicloj.clay.v2.make
  scicloj.clay.v2.notebook

--- a/build/resources/build/noisy-namespaces.edn
+++ b/build/resources/build/noisy-namespaces.edn
@@ -1,0 +1,41 @@
+;; Third-party namespaces that emit reflection or boxed math warnings.
+;;
+;; These must be loaded before enabling warnings to avoid false positives
+;; in project code. Used by:
+;; - build.check-warnings (CI warning check)
+;; - criterium.kaocha-hooks (test runs)
+
+[aero.alpha.core
+ babashka.fs
+ cider.nrepl.inlined.deps.toolsreader.v1v4v1.clojure.tools.reader
+ cider.nrepl.middleware.test
+ cider.nrepl.middleware.util.instrument
+ clj-http.client
+ clj-http.headers
+ clojure.data.json
+ clojure.test.check
+ clojure.test.check.clojure-test
+ clojure.tools.cli
+ clojure.tools.deps
+ clojure.tools.gitlibs
+ clojure.tools.reader
+ fipp
+ kaocha.plugin.profiling
+ kaocha.report
+ kaocha.runner
+ lambdaisland.deep-diff2
+ malli.core
+ malli.generator
+ malli.instrument
+ nextjournal.beholder
+ nextjournal.markdown.transform
+ nextjournal.markdown.utils
+ nrepl.core
+ nrepl.middleware
+ nrepl.middleware.session
+ orchard.inspect
+ potemkin.utils
+ scicloj.clay.v2.make
+ scicloj.clay.v2.notebook
+ scicloj.clay.v2.util.image
+ scicloj.kindly-render.note.to-hiccup]

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -372,4 +372,4 @@
         {:keys [warning-count results]} result
         error-count (count (filter :error results))]
     (report-warnings result)
-    (System/exit (if (or (< 0 warning-count) (< 0 error-count)) 1 0))))
+    (System/exit (if (or (pos? warning-count) (pos? error-count)) 1 0))))

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -235,7 +235,7 @@
                          *unchecked-math* :warn-on-boxed
                          *err* (java.io.PrintWriter. err-writer)]
                  (try
-                   (require ns-sym :reload)
+                   (require ns-sym)
                    {:namespace ns-sym}
                    (catch Exception e
                      {:namespace ns-sym

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -310,3 +310,66 @@
       :checked-namespaces (count namespaces-to-check)
       :results with-issues
       :warning-count warning-count})))
+
+;;; Reporting
+
+(defn report-warnings
+  "Print human-readable report of warnings.
+
+   Groups warnings by namespace and prints in format:
+   namespace.name: N warnings
+     - Reflection warning: ...
+     - Boxed math warning: ...
+
+   Prints summary at end: Found N warnings in M namespaces"
+  [check-result]
+  (let [{:keys [preload-result total-namespaces exempt-namespaces
+                checked-namespaces results warning-count]} check-result
+        namespaces-with-warnings (filter :warnings results)
+        namespaces-with-errors (filter :error results)]
+    ;; Header
+    (println "=== Boxed Math and Reflection Warning Check ===")
+    (println)
+    ;; Preload summary
+    (println "Pre-loaded" (count (:loaded preload-result)) "third-party namespaces")
+    (when (seq (:missing preload-result))
+      (println "  (skipped" (count (:missing preload-result)) "missing namespaces)"))
+    (println)
+    ;; Namespace counts
+    (println "Total project namespaces:" total-namespaces)
+    (when (seq exempt-namespaces)
+      (println "Exempt namespaces:" (count exempt-namespaces))
+      (doseq [ns-sym exempt-namespaces]
+        (println "  -" ns-sym)))
+    (println "Checked namespaces:" checked-namespaces)
+    (println)
+    ;; Errors
+    (when (seq namespaces-with-errors)
+      (println "=== Compilation Errors ===")
+      (doseq [{:keys [namespace error]} namespaces-with-errors]
+        (println (str namespace ": " error)))
+      (println))
+    ;; Warnings
+    (if (seq namespaces-with-warnings)
+      (do
+        (println "=== Warnings ===")
+        (doseq [{:keys [namespace warnings]} namespaces-with-warnings]
+          (println (str namespace ": " (count warnings) " warning(s)"))
+          (doseq [{:keys [message]} warnings]
+            (println "  -" message)))
+        (println)
+        (println "Found" warning-count "warning(s) in"
+                 (count namespaces-with-warnings) "namespace(s)"))
+      (println "No warnings found."))
+    (println)))
+
+(defn -main
+  "Run warning check and exit with appropriate code.
+
+   Exits with 0 if no warnings found, 1 otherwise."
+  [& _args]
+  (let [result (check-all-namespaces)
+        {:keys [warning-count results]} result
+        error-count (count (filter :error results))]
+    (report-warnings result)
+    (System/exit (if (or (< 0 warning-count) (< 0 error-count)) 1 0))))

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -1,0 +1,111 @@
+(ns build.check-warnings
+  "Namespace discovery and warning check utilities.
+
+   Discovers project namespaces using tools.deps and provides
+   utilities for checking boxed math and reflection warnings."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [clojure.tools.deps :as deps]))
+
+;;; Namespace Discovery
+
+(defn- clj-file->ns-symbol
+  "Convert a Clojure file path to a namespace symbol.
+
+   The source-root is the path prefix to strip from the file path.
+   Returns a namespace symbol, or nil if the file doesn't look like a namespace."
+  [source-root file]
+  (let [source-root-str (str source-root)
+        file-str (str file)
+        rel-path (if (str/starts-with? file-str source-root-str)
+                   (subs file-str (count source-root-str))
+                   file-str)
+        ;; Remove leading slash if present
+        rel-path (if (str/starts-with? rel-path "/")
+                   (subs rel-path 1)
+                   rel-path)]
+    (when (str/ends-with? rel-path ".clj")
+      (-> rel-path
+          (str/replace #"\.clj$" "")
+          (str/replace "/" ".")
+          (str/replace "_" "-")
+          symbol))))
+
+(defn- find-clj-files
+  "Find all .clj files under a directory."
+  [dir]
+  (when (fs/exists? dir)
+    (->> (fs/glob dir "**/*.clj")
+         (map str))))
+
+(defn- discover-namespaces-in-path
+  "Discover namespaces under a source path.
+
+   Returns a vector of namespace symbols found under the path."
+  [source-root]
+  (when (fs/exists? source-root)
+    (->> (find-clj-files source-root)
+         (keep (partial clj-file->ns-symbol source-root))
+         vec)))
+
+(defn- project-source-path?
+  "Return true if the path is a project source directory (not a JAR or maven repo)."
+  [path]
+  (let [path-str (str path)]
+    (and (not (str/ends-with? path-str ".jar"))
+         (not (str/includes? path-str ".m2/repository"))
+         (fs/directory? path-str))))
+
+(defn- excluded-path?
+  "Return true if the path should be excluded from warning checks.
+
+   Excludes:
+   - development/ directory
+   - projects/ directory (contains test fixtures, not real code)
+   - */resources directories (contain clj-kondo exports, not project code)"
+  [project-root path]
+  (let [path-str (str path)
+        rel-path (if (str/starts-with? path-str (str project-root))
+                   (subs path-str (count (str project-root)))
+                   path-str)
+        rel-path (if (str/starts-with? rel-path "/")
+                   (subs rel-path 1)
+                   rel-path)]
+    (or (str/starts-with? rel-path "development")
+        (str/starts-with? rel-path "projects/")
+        (str/ends-with? path-str "/resources"))))
+
+(defn discover-project-namespaces
+  "Discover all project namespaces using tools.deps.
+
+   Uses the :dev and :test aliases to build a basis and extracts
+   source paths from the classpath roots.
+
+   Returns a sorted vector of namespace symbols found in project
+   source and test directories.
+
+   Excludes:
+   - development/ directory
+   - JAR files
+   - Maven repository paths"
+  ([]
+   (discover-project-namespaces "."))
+  ([project-root]
+   (let [basis (deps/create-basis {:aliases [:dev :test]
+                                   :dir project-root})
+         classpath-roots (:classpath-roots basis)
+         ;; Normalize the project root path (remove trailing /.)
+         project-root-abs (-> (fs/absolutize project-root)
+                              fs/normalize
+                              str)
+         source-paths (->> classpath-roots
+                           (filter project-source-path?)
+                           (map #(str (fs/absolutize %)))
+                           (remove #(excluded-path? project-root-abs %)))]
+     (->> source-paths
+          (mapcat discover-namespaces-in-path)
+          (filter some?)
+          distinct
+          sort
+          vec))))

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -229,3 +229,84 @@
           (catch Exception _
             (swap! results update :missing conj ns-sym)))))
     @results))
+
+;;; Warning Capture and Compilation
+
+(defn- parse-warnings
+  "Parse warning messages from compiler output.
+
+   Returns a vector of maps with :type (:reflection or :boxed-math) and :message."
+  [output]
+  (let [lines (str/split-lines output)]
+    (->> lines
+         (keep (fn [line]
+                 (cond
+                   (str/includes? line "Reflection warning")
+                   {:type :reflection :message line}
+
+                   (str/includes? line "Boxed math warning")
+                   {:type :boxed-math :message line}
+
+                   :else nil)))
+         vec)))
+
+(defn check-namespace-warnings
+  "Check a single namespace for reflection and boxed math warnings.
+
+   Compiles the namespace with warnings enabled and captures any emitted warnings.
+   Returns a map with:
+   - :namespace - the namespace symbol
+   - :warnings - vector of {:type :message} maps
+   - :error - exception message if compilation failed (optional)"
+  [ns-sym]
+  (let [err-writer (java.io.StringWriter.)
+        result (binding [*warn-on-reflection* true
+                         *unchecked-math* :warn-on-boxed
+                         *err* (java.io.PrintWriter. err-writer)]
+                 (try
+                   (require ns-sym :reload)
+                   {:namespace ns-sym}
+                   (catch Exception e
+                     {:namespace ns-sym
+                      :error (.getMessage e)})))
+        err-output (str err-writer)
+        warnings (parse-warnings err-output)]
+    (if (seq warnings)
+      (assoc result :warnings warnings)
+      result)))
+
+(defn check-all-namespaces
+  "Check all project namespaces for reflection and boxed math warnings.
+
+   Process:
+   1. Pre-loads third-party namespaces with warnings disabled
+   2. Discovers project namespaces
+   3. Filters out namespaces with explicit exemptions
+   4. Checks each namespace for warnings
+
+   Returns a map with:
+   - :preload-result - result from preload-noisy-namespaces!
+   - :total-namespaces - count of discovered namespaces
+   - :exempt-namespaces - namespaces skipped due to exemptions
+   - :checked-namespaces - count of namespaces checked
+   - :results - vector of check results (only those with warnings or errors)
+   - :warning-count - total number of warnings found"
+  ([]
+   (check-all-namespaces "."))
+  ([project-root]
+   (let [preload-result (preload-noisy-namespaces!)
+         all-namespaces (discover-project-namespaces project-root)
+         exempt-nses (filterv #(namespace-has-exemption? % project-root) all-namespaces)
+         exempt-set (set exempt-nses)
+         namespaces-to-check (remove exempt-set all-namespaces)
+         results (mapv check-namespace-warnings namespaces-to-check)
+         with-issues (filterv #(or (:warnings %) (:error %)) results)
+         warning-count (->> results
+                            (mapcat :warnings)
+                            count)]
+     {:preload-result preload-result
+      :total-namespaces (count all-namespaces)
+      :exempt-namespaces exempt-nses
+      :checked-namespaces (count namespaces-to-check)
+      :results with-issues
+      :warning-count warning-count})))

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -152,6 +152,64 @@
     scicloj.clay.v2.util.image
     scicloj.kindly-render.note.to-hiccup])
 
+;;; Exemption Detection
+
+(def ^:private exemption-patterns
+  "Regex patterns that indicate a namespace explicitly disables warnings."
+  [#"\(\s*set!\s+\*warn-on-reflection\*\s+false\s*\)"
+   #"\(\s*set!\s+\*unchecked-math\*\s+false\s*\)"])
+
+(defn- ns-symbol->file-path
+  "Convert a namespace symbol to a relative file path."
+  [ns-sym]
+  (-> (str ns-sym)
+      (str/replace "." "/")
+      (str/replace "-" "_")
+      (str ".clj")))
+
+(defn- find-namespace-source-file
+  "Find the source file for a namespace symbol.
+
+   Searches the classpath roots from tools.deps for a matching file.
+   Returns the absolute path as a string, or nil if not found."
+  [ns-sym project-root]
+  (let [basis (deps/create-basis {:aliases [:dev :test]
+                                  :dir project-root})
+        classpath-roots (:classpath-roots basis)
+        rel-path (ns-symbol->file-path ns-sym)
+        ;; Resolve classpath roots relative to project root
+        resolve-root (fn [root]
+                       (let [root-path (fs/path project-root root)]
+                         (when (fs/directory? root-path)
+                           root-path)))]
+    (some->> classpath-roots
+             (keep resolve-root)
+             (filter project-source-path?)
+             (map #(fs/path % rel-path))
+             (filter fs/exists?)
+             first
+             str)))
+
+(defn namespace-has-exemption?
+  "Check if a namespace source file contains an exemption declaration.
+
+   Reads the source file and checks for patterns like:
+   - (set! *warn-on-reflection* false)
+   - (set! *unchecked-math* false)
+
+   Returns true if any exemption pattern is found, false otherwise.
+   Returns false if the source file cannot be found or read."
+  ([ns-sym]
+   (namespace-has-exemption? ns-sym "."))
+  ([ns-sym project-root]
+   (if-let [source-file (find-namespace-source-file ns-sym project-root)]
+     (try
+       (let [content (slurp source-file)]
+         (boolean (some #(re-find % content) exemption-patterns)))
+       (catch Exception _
+         false))
+     false)))
+
 (defn preload-noisy-namespaces!
   "Pre-load third-party namespaces that emit warnings with warnings disabled.
 

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -109,3 +109,65 @@
           distinct
           sort
           vec))))
+
+;;; Noisy Namespace Pre-loading
+
+(def noisy-namespaces
+  "Third-party namespaces that emit reflection or boxed math warnings.
+
+   These must be loaded before enabling warnings to avoid false positives.
+   Kept in sync with criterium.kaocha-hooks/noisy-namespaces."
+  '[aero.alpha.core
+    babashka.fs
+    cider.nrepl.inlined.deps.toolsreader.v1v4v1.clojure.tools.reader
+    cider.nrepl.middleware.test
+    cider.nrepl.middleware.util.instrument
+    clj-http.client
+    clj-http.headers
+    clojure.data.json
+    clojure.test.check
+    clojure.test.check.clojure-test
+    clojure.tools.cli
+    clojure.tools.deps
+    clojure.tools.gitlibs
+    clojure.tools.reader
+    fipp
+    kaocha.plugin.profiling
+    kaocha.report
+    kaocha.runner
+    lambdaisland.deep-diff2
+    malli.core
+    malli.generator
+    malli.instrument
+    nextjournal.beholder
+    nextjournal.markdown.transform
+    nextjournal.markdown.utils
+    nrepl.core
+    nrepl.middleware
+    nrepl.middleware.session
+    orchard.inspect
+    potemkin.utils
+    scicloj.clay.v2.make
+    scicloj.clay.v2.notebook
+    scicloj.clay.v2.util.image
+    scicloj.kindly-render.note.to-hiccup])
+
+(defn preload-noisy-namespaces!
+  "Pre-load third-party namespaces that emit warnings with warnings disabled.
+
+   Loads each namespace in `noisy-namespaces` with *warn-on-reflection* and
+   *unchecked-math* set to false. Missing namespaces are silently ignored
+   since not all dependencies may be on the classpath in all configurations.
+
+   Returns a map with :loaded and :missing vectors of namespace symbols."
+  []
+  (let [results (atom {:loaded [] :missing []})]
+    (binding [*warn-on-reflection* false
+              *unchecked-math* false]
+      (doseq [ns-sym noisy-namespaces]
+        (try
+          (require ns-sym)
+          (swap! results update :loaded conj ns-sym)
+          (catch Exception _
+            (swap! results update :missing conj ns-sym)))))
+    @results))

--- a/build/src/build/check_warnings.clj
+++ b/build/src/build/check_warnings.clj
@@ -5,6 +5,8 @@
    utilities for checking boxed math and reflection warnings."
   (:require
    [babashka.fs :as fs]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.deps :as deps]))
 
@@ -116,41 +118,10 @@
   "Third-party namespaces that emit reflection or boxed math warnings.
 
    These must be loaded before enabling warnings to avoid false positives.
-   Kept in sync with criterium.kaocha-hooks/noisy-namespaces."
-  '[aero.alpha.core
-    babashka.fs
-    cider.nrepl.inlined.deps.toolsreader.v1v4v1.clojure.tools.reader
-    cider.nrepl.middleware.test
-    cider.nrepl.middleware.util.instrument
-    clj-http.client
-    clj-http.headers
-    clojure.data.json
-    clojure.test.check
-    clojure.test.check.clojure-test
-    clojure.tools.cli
-    clojure.tools.deps
-    clojure.tools.gitlibs
-    clojure.tools.reader
-    fipp
-    kaocha.plugin.profiling
-    kaocha.report
-    kaocha.runner
-    lambdaisland.deep-diff2
-    malli.core
-    malli.generator
-    malli.instrument
-    nextjournal.beholder
-    nextjournal.markdown.transform
-    nextjournal.markdown.utils
-    nrepl.core
-    nrepl.middleware
-    nrepl.middleware.session
-    orchard.inspect
-    potemkin.utils
-    scicloj.clay.v2.make
-    scicloj.clay.v2.notebook
-    scicloj.clay.v2.util.image
-    scicloj.kindly-render.note.to-hiccup])
+   Loaded from build/noisy-namespaces.edn resource."
+  (-> (io/resource "build/noisy-namespaces.edn")
+      slurp
+      edn/read-string))
 
 ;;; Exemption Detection
 

--- a/build/test/build/check_warnings_test.clj
+++ b/build/test/build/check_warnings_test.clj
@@ -1,0 +1,66 @@
+(ns build.check-warnings-test
+  (:require
+   [build.check-warnings :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;; Tests for parse-warnings and check-namespace-warnings functionality.
+;; Uses synthetic warning output and a test fixture namespace.
+
+(deftest parse-warnings-test
+  (testing "parse-warnings"
+    (testing "extracts reflection warnings"
+      (let [output "Reflection warning, test.clj:10:5 - call to method foo can't be resolved"
+            result (#'sut/parse-warnings output)]
+        (is (= 1 (count result)))
+        (is (= :reflection (:type (first result))))
+        (is (= output (:message (first result))))))
+
+    (testing "extracts boxed math warnings"
+      (let [output "Boxed math warning, test.clj:20:3 - call: public static java.lang.Number clojure.lang.Numbers.add(java.lang.Object, java.lang.Object)"
+            result (#'sut/parse-warnings output)]
+        (is (= 1 (count result)))
+        (is (= :boxed-math (:type (first result))))
+        (is (= output (:message (first result))))))
+
+    (testing "extracts multiple warnings"
+      (let [output "Reflection warning, test.clj:10:5 - call to method foo
+Boxed math warning, test.clj:20:3 - call: add
+Some other output that is not a warning
+Reflection warning, test.clj:30:1 - reference to field bar"
+            result (#'sut/parse-warnings output)]
+        (is (= 3 (count result)))
+        (is (= [:reflection :boxed-math :reflection] (mapv :type result)))))
+
+    (testing "returns empty vector for no warnings"
+      (let [output "Some normal output\nNo warnings here"]
+        (is (= [] (#'sut/parse-warnings output)))))))
+
+(deftest check-namespace-warnings-test
+  ;; Tests check-namespace-warnings by checking known namespaces
+  (testing "check-namespace-warnings"
+    (testing "returns namespace in result"
+      (let [result (sut/check-namespace-warnings 'clojure.string)]
+        (is (= 'clojure.string (:namespace result)))))
+
+    (testing "returns empty warnings for clean namespace"
+      ;; clojure.string is a well-maintained namespace without warnings
+      (let [result (sut/check-namespace-warnings 'clojure.string)]
+        (is (nil? (:warnings result)))
+        (is (nil? (:error result)))))
+
+    (testing "handles non-existent namespace gracefully"
+      (let [result (sut/check-namespace-warnings 'this.namespace.does.not.exist)]
+        (is (= 'this.namespace.does.not.exist (:namespace result)))
+        (is (some? (:error result)))))
+
+    (testing "captures warnings from namespace with known issues"
+      ;; criterium.stats.tail has boxed math and reflection warnings
+      (let [result (sut/check-namespace-warnings 'criterium.stats.tail)]
+        (is (= 'criterium.stats.tail (:namespace result)))
+        (is (vector? (:warnings result)))
+        (is (pos? (count (:warnings result)))
+            "Expected warnings from criterium.stats.tail")
+        (is (some #(= :boxed-math (:type %)) (:warnings result))
+            "Expected boxed-math warnings")
+        (is (some #(= :reflection (:type %)) (:warnings result))
+            "Expected reflection warnings")))))

--- a/build/test/build/check_warnings_test.clj
+++ b/build/test/build/check_warnings_test.clj
@@ -54,12 +54,12 @@ Reflection warning, test.clj:30:1 - reference to field bar"
         (is (some? (:error result)))))
 
     (testing "captures warnings from namespace with known issues"
-      ;; criterium.stats.tail has boxed math and reflection warnings
-      (let [result (sut/check-namespace-warnings 'criterium.stats.tail)]
-        (is (= 'criterium.stats.tail (:namespace result)))
+      ;; Use a dedicated test fixture that won't be pre-loaded by kaocha hooks
+      (let [result (sut/check-namespace-warnings 'build.fixtures.warning-examples)]
+        (is (= 'build.fixtures.warning-examples (:namespace result)))
         (is (vector? (:warnings result)))
         (is (pos? (count (:warnings result)))
-            "Expected warnings from criterium.stats.tail")
+            "Expected warnings from build.fixtures.warning-examples")
         (is (some #(= :boxed-math (:type %)) (:warnings result))
             "Expected boxed-math warnings")
         (is (some #(= :reflection (:type %)) (:warnings result))

--- a/build/test/build/fixtures/warning_examples.clj
+++ b/build/test/build/fixtures/warning_examples.clj
@@ -1,0 +1,28 @@
+(ns build.fixtures.warning-examples
+  "Test fixture namespace with intentional warnings for testing warning detection.
+
+   DO NOT add type hints or fix warnings in this file - they are intentional.")
+
+;;; Boxed math warnings
+
+(defn boxed-add
+  "Intentionally uses boxed math (Object + long)."
+  [x]
+  (+ x 1))
+
+(defn boxed-multiply
+  "Intentionally uses boxed math (Object * Object)."
+  [x y]
+  (* x y))
+
+;;; Reflection warnings
+
+(defn reflect-get-bytes
+  "Intentionally triggers reflection warning."
+  [s]
+  (.getBytes s))
+
+(defn reflect-to-upper
+  "Intentionally triggers reflection warning."
+  [s]
+  (.toUpperCase s))

--- a/components/stats/src/criterium/stats/kde.clj
+++ b/components/stats/src/criterium/stats/kde.clj
@@ -7,6 +7,7 @@
   All functions require typed arrays (DoubleArray, LongArray)."
   (:require
    [criterium.array :as arr]
+   [criterium.array.interface]
    [criterium.random.interface :as random]
    [criterium.stats.core :as core]
    [criterium.stats.sampling :as sampling]

--- a/components/stats/src/criterium/stats/mle.clj
+++ b/components/stats/src/criterium/stats/mle.clj
@@ -14,6 +14,7 @@
   All functions require typed arrays (DoubleArray, LongArray)."
   (:require
    [criterium.array :as arr]
+   [criterium.array.interface]
    [criterium.stats.probability :as probability]
    [criterium.utils.interface :refer [have?]])
   (:import

--- a/components/stats/src/criterium/stats/tail.clj
+++ b/components/stats/src/criterium/stats/tail.clj
@@ -15,6 +15,7 @@
   - Coles (2001), An Introduction to Statistical Modeling of Extreme Values"
   (:require
    [criterium.array :as arr]
+   [criterium.primitive-fn :as prim]
    [criterium.utils.interface :refer [have?]]))
 
 ;;; Exceedances
@@ -91,16 +92,15 @@
             log-vals (arr/dmap sorted-samples (fn ^double [^double x] (Math/log x)))]
         (into []
               (comp
-               (filter (fn [k] (and (>= k 1) (< k n))))
-               (map (fn [k]
-                      (let [k (long k)
-                            ;; X_{(n-k)} is the (k+1)-th largest, at index n-k-1
+               (filter (fn [^long k] (and (>= k 1) (< k n))))
+               (map (fn [^long k]
+                      (let [;; X_{(n-k)} is the (k+1)-th largest, at index n-k-1
                             threshold-idx (- n k 1)
                             log-threshold (arr/get-double log-vals threshold-idx)
                             ;; Sum log(X_{(n-i+1)}) - log(X_{(n-k)}) for i=1..k
                             ;; X_{(n-i+1)} for i=1..k are the k largest values
                             ;; at indices n-1, n-2, ..., n-k
-                            sum-log-diff
+                            ^double sum-log-diff
                             (loop [i 0
                                    acc 0.0]
                               (if (>= i k)
@@ -108,7 +108,7 @@
                                 (let [idx (- n 1 i)
                                       log-xi (arr/get-double log-vals idx)]
                                   (recur (inc i) (+ acc (- log-xi log-threshold))))))
-                            h-k (/ sum-log-diff (double k))]
+                            h-k (/ sum-log-diff k)]
                         {:k k
                          :estimate h-k
                          :tail-index (if (pos? h-k) (/ 1.0 h-k) Double/POSITIVE_INFINITY)}))))
@@ -271,7 +271,7 @@
   Returns {:xi xi :sigma sigma :log-likelihood ll :converged? bool}"
   [exceedances opts]
   (let [n (arr/length exceedances)
-        {:keys [max-iter tol xi-min xi-max]
+        {:keys [^long max-iter ^double tol ^double xi-min ^double xi-max]
          :or {max-iter 100 tol 1e-8 xi-min -0.5 xi-max 2.0}} opts
         ;; Sample statistics
         sum-y (arr/fold-double exceedances
@@ -332,19 +332,19 @@
         ;; Grid search
         grid-points 20
         xi-step (/ (- xi-max effective-xi-min) grid-points)
-        best-xi
+        ^double best-xi
         (loop [xi effective-xi-min
                best-xi 0.0
                best-ll Double/NEGATIVE_INFINITY]
           (if (> xi xi-max)
             best-xi
-            (let [ll (profile-ll xi)]
+            (let [ll (prim/invoke-dd profile-ll xi)]
               (if (> ll best-ll)
                 (recur (+ xi xi-step) xi ll)
                 (recur (+ xi xi-step) best-xi best-ll)))))
 
         ;; Golden section refinement around best-xi
-        final-xi
+        ^double final-xi
         (let [golden (/ (- (Math/sqrt 5.0) 1.0) 2.0)
               refine-width (* 2.0 xi-step)]
           (loop [a (Math/max effective-xi-min (- best-xi refine-width))
@@ -354,8 +354,8 @@
               (/ (+ a b) 2.0)
               (let [c (- b (* golden (- b a)))
                     d (+ a (* golden (- b a)))
-                    fc (profile-ll c)
-                    fd (profile-ll d)]
+                    fc (prim/invoke-dd profile-ll c)
+                    fd (prim/invoke-dd profile-ll d)]
                 (if (> fc fd)
                   (recur a d (inc iter))
                   (recur c b (inc iter)))))))
@@ -453,16 +453,16 @@
       (into []
             (comp
              (map (fn [u]
-                    (let [u (double u)
+                    (let [u        (double u)
                           ;; Find first index where sample > u
                           ;; Since sorted, we can binary search
-                          exceed-start
+                          ^long exceed-start
                           (loop [lo 0
                                  hi n]
                             (if (>= lo hi)
                               lo
                               (let [mid (quot (+ lo hi) 2)
-                                    v (arr/get-double sorted-samples mid)]
+                                    v   (arr/get-double sorted-samples mid)]
                                 (if (<= v u)
                                   (recur (inc mid) hi)
                                   (recur lo mid)))))
@@ -470,8 +470,8 @@
                       (if (zero? n-exceed)
                         {:threshold u :mrl Double/NaN :n-exceed 0}
                         (let [;; Sum of exceedances: Σ(xᵢ - u) for xᵢ > u
-                              sum-excess
-                              (loop [i exceed-start
+                              ^double sum-excess
+                              (loop [i   exceed-start
                                      acc 0.0]
                                 (if (>= i n)
                                   acc
@@ -495,11 +495,11 @@
    {:pre [(have? arr/typed-array? sorted-samples)]}
    (let [n (arr/length sorted-samples)]
      (when (pos? n)
-       (let [q-min 0.5
-             q-max 0.95
+       (let [q-min  0.5
+             q-max  0.95
              q-step (/ (- q-max q-min) (dec n-points))]
-         (for [i (range n-points)]
-           (let [q (+ q-min (* i q-step))
+         (for [^long i (range n-points)]
+           (let [q   (+ q-min (* i q-step))
                  idx (min (dec n) (long (* q (dec n))))]
              (arr/get-double sorted-samples idx))))))))
 

--- a/components/stats/src/criterium/stats/tail.clj
+++ b/components/stats/src/criterium/stats/tail.clj
@@ -91,7 +91,7 @@
             log-vals (arr/dmap sorted-samples (fn ^double [^double x] (Math/log x)))]
         (into []
               (comp
-               (filter (fn [k] (let [k (long k)] (and (>= k 1) (< k n)))))
+               (filter (fn [k] (and (>= k 1) (< k n))))
                (map (fn [k]
                       (let [k (long k)
                             ;; X_{(n-k)} is the (k+1)-th largest, at index n-k-1
@@ -101,14 +101,13 @@
                             ;; X_{(n-i+1)} for i=1..k are the k largest values
                             ;; at indices n-1, n-2, ..., n-k
                             sum-log-diff
-                            (double
-                             (loop [i (long 0)
-                                    acc 0.0]
-                               (if (>= i k)
-                                 acc
-                                 (let [idx (- n 1 i)
-                                       log-xi (arr/get-double log-vals idx)]
-                                   (recur (inc i) (+ acc (- log-xi log-threshold)))))))
+                            (loop [i 0
+                                   acc 0.0]
+                              (if (>= i k)
+                                acc
+                                (let [idx (- n 1 i)
+                                      log-xi (arr/get-double log-vals idx)]
+                                  (recur (inc i) (+ acc (- log-xi log-threshold))))))
                             h-k (/ sum-log-diff (double k))]
                         {:k k
                          :estimate h-k
@@ -274,15 +273,11 @@
   (let [n (arr/length exceedances)
         {:keys [max-iter tol xi-min xi-max]
          :or {max-iter 100 tol 1e-8 xi-min -0.5 xi-max 2.0}} opts
-        ^long max-iter max-iter
-        ^double tol tol
-        ^double xi-min xi-min
-        ^double xi-max xi-max
         ;; Sample statistics
         sum-y (arr/fold-double exceedances
                                (fn ^double [^double acc ^double y] (+ acc y))
                                0.0)
-        mean-y (/ sum-y (double n))
+        mean-y (/ sum-y n)
         max-y (arr/fold-double exceedances
                                (fn ^double [^double acc ^double y] (Math/max acc y))
                                Double/NEGATIVE_INFINITY)
@@ -301,8 +296,8 @@
                   init-sigma mean-y
                   ;; Newton iteration to find σ
                   sigma
-                  (loop [sigma (double init-sigma)
-                         iter (long 0)]
+                  (loop [sigma init-sigma
+                         iter 0]
                     (if (>= iter 50)
                       sigma
                       (let [;; Compute Σlog(1 + ξyᵢ/σ)
@@ -319,7 +314,7 @@
                           ;; Profile equation: n/σ - (1/ξ + 1) * Σ(ξyᵢ/(σ(σ + ξyᵢ))) = 0
                           ;; Simplified: σ = (1 + ξ) * Σyᵢ / (n + ξ*Σlog(1 + ξyᵢ/σ))
                           (let [new-sigma (/ (* (+ 1.0 xi) sum-y)
-                                             (+ (double n) (* xi sum-log)))]
+                                             (+ n (* xi sum-log)))]
                             (if (or (<= new-sigma 0.0)
                                     (< (Math/abs (- new-sigma sigma)) (* tol sigma)))
                               (if (pos? new-sigma) new-sigma sigma)
@@ -335,48 +330,43 @@
         effective-xi-min (Math/max xi-min (- (/ mean-y max-y) 0.1))
 
         ;; Grid search
-        grid-points (long 20)
-        xi-step (/ (- xi-max effective-xi-min) (double grid-points))
+        grid-points 20
+        xi-step (/ (- xi-max effective-xi-min) grid-points)
         best-xi
-        (double
-         (loop [xi (double effective-xi-min)
-                best-xi 0.0
-                best-ll Double/NEGATIVE_INFINITY]
-           (if (> xi xi-max)
-             best-xi
-             (let [ll #_{:clj-kondo/ignore [:redundant-primitive-coercion]}
-                   (double (profile-ll xi))]
-               (if (> ll best-ll)
-                 (recur (+ xi xi-step) xi ll)
-                 (recur (+ xi xi-step) best-xi best-ll))))))
+        (loop [xi effective-xi-min
+               best-xi 0.0
+               best-ll Double/NEGATIVE_INFINITY]
+          (if (> xi xi-max)
+            best-xi
+            (let [ll (profile-ll xi)]
+              (if (> ll best-ll)
+                (recur (+ xi xi-step) xi ll)
+                (recur (+ xi xi-step) best-xi best-ll)))))
 
         ;; Golden section refinement around best-xi
         final-xi
         (let [golden (/ (- (Math/sqrt 5.0) 1.0) 2.0)
               refine-width (* 2.0 xi-step)]
-          (loop [a (double (Math/max (double effective-xi-min) (- best-xi refine-width)))
-                 b (double (Math/min xi-max (+ best-xi refine-width)))
-                 iter (long 0)]
+          (loop [a (Math/max effective-xi-min (- best-xi refine-width))
+                 b (Math/min xi-max (+ best-xi refine-width))
+                 iter 0]
             (if (or (>= iter max-iter) (< (- b a) tol))
               (/ (+ a b) 2.0)
               (let [c (- b (* golden (- b a)))
                     d (+ a (* golden (- b a)))
-                    fc #_{:clj-kondo/ignore [:redundant-primitive-coercion]}
-                    (double (profile-ll c))
-                    fd #_{:clj-kondo/ignore [:redundant-primitive-coercion]}
-                    (double (profile-ll d))]
+                    fc (profile-ll c)
+                    fd (profile-ll d)]
                 (if (> fc fd)
                   (recur a d (inc iter))
                   (recur c b (inc iter)))))))
 
         ;; Compute final σ for the optimal ξ
-        final-xi (double final-xi)
         final-sigma
         (if (< (Math/abs final-xi) 1e-10)
           mean-y
           ;; Iterate to get correct σ
-          (loop [sigma (double mean-y)
-                 iter (long 0)]
+          (loop [sigma mean-y
+                 iter 0]
             (if (>= iter 50)
               sigma
               (let [sum-log-curr
@@ -388,7 +378,7 @@
                                            (+ acc (Math/log z)))))
                                      0.0)
                     new-sigma (/ (* (+ 1.0 final-xi) sum-y)
-                                 (+ (double n) (* final-xi sum-log-curr)))]
+                                 (+ n (* final-xi sum-log-curr)))]
                 (if (or (<= new-sigma 0.0)
                         (< (Math/abs (- new-sigma sigma)) (* tol sigma)))
                   (if (pos? new-sigma) new-sigma sigma)
@@ -467,29 +457,27 @@
                           ;; Find first index where sample > u
                           ;; Since sorted, we can binary search
                           exceed-start
-                          (long
-                           (loop [lo (long 0)
-                                  hi n]
-                             (if (>= lo hi)
-                               lo
-                               (let [mid (quot (+ lo hi) 2)
-                                     v (arr/get-double sorted-samples mid)]
-                                 (if (<= v u)
-                                   (recur (inc mid) hi)
-                                   (recur lo mid))))))
+                          (loop [lo 0
+                                 hi n]
+                            (if (>= lo hi)
+                              lo
+                              (let [mid (quot (+ lo hi) 2)
+                                    v (arr/get-double sorted-samples mid)]
+                                (if (<= v u)
+                                  (recur (inc mid) hi)
+                                  (recur lo mid)))))
                           n-exceed (- n exceed-start)]
                       (if (zero? n-exceed)
                         {:threshold u :mrl Double/NaN :n-exceed 0}
                         (let [;; Sum of exceedances: Σ(xᵢ - u) for xᵢ > u
                               sum-excess
-                              (double
-                               (loop [i exceed-start
-                                      acc 0.0]
-                                 (if (>= i n)
-                                   acc
-                                   (recur (inc i)
-                                          (+ acc (- (arr/get-double sorted-samples i) u))))))
-                              mrl (/ sum-excess (double n-exceed))]
+                              (loop [i exceed-start
+                                     acc 0.0]
+                                (if (>= i n)
+                                  acc
+                                  (recur (inc i)
+                                         (+ acc (- (arr/get-double sorted-samples i) u)))))
+                              mrl (/ sum-excess n-exceed)]
                           {:threshold u :mrl mrl :n-exceed n-exceed}))))))
             threshold-range))))
 
@@ -509,11 +497,10 @@
      (when (pos? n)
        (let [q-min 0.5
              q-max 0.95
-             q-step (/ (- q-max q-min) (double (dec n-points)))]
+             q-step (/ (- q-max q-min) (dec n-points))]
          (for [i (range n-points)]
-           (let [i (long i)
-                 q (+ q-min (* (double i) q-step))
-                 idx (min (dec n) (long (* q (double (dec n)))))]
+           (let [q (+ q-min (* i q-step))
+                 idx (min (dec n) (long (* q (dec n))))]
              (arr/get-double sorted-samples idx))))))))
 
 ;;; Tail Ratios

--- a/deps.edn
+++ b/deps.edn
@@ -97,6 +97,9 @@
                              org.clojure/clojure {:mvn/version "1.12.0"}}
                 :jvm-opts ["-Djdk.attach.allowAttachSelf"]
                 :main-opts ["-m" "criterium.notebook.render"]}
+  :check-warnings {:extra-paths ["development/src"]
+                   :extra-deps {local/build {:local/root "build"}}
+                   :main-opts ["-m" "build.check-warnings"]}
   :validation {:extra-paths ["bases/criterium/validation"
                              "components/stats/validation"
                              "components/optimisation/validation"

--- a/deps.edn
+++ b/deps.edn
@@ -109,6 +109,7 @@
                {poly/criterium {:local/root "bases/criterium"}
                 poly/r-validation {:local/root "components/r-validation"}
                 poly/test-assert {:local/root "components/test-assert"}
+                local/build {:local/root "build"}
                 lambdaisland/kaocha {:mvn/version "1.91.1392"}
                 metosin/malli {:mvn/version "0.20.0"}}
                :main-opts ["-m" "kaocha.runner"

--- a/development/src/criterium/kaocha_hooks.clj
+++ b/development/src/criterium/kaocha_hooks.clj
@@ -9,49 +9,22 @@
   This namespace pre-loads noisy third-party namespaces with warnings
   disabled BEFORE loading criterium.schema.instrument. This prevents
   warning noise from malli.generator and other libraries that are
-  pulled in transitively by the instrumentation system.")
+  pulled in transitively by the instrumentation system."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
 
 ;;; Third-party namespaces with known reflection or boxed math warnings
 ;;
 ;; Must be loaded before criterium.schema.instrument to prevent warnings.
+;; Loaded from build/noisy-namespaces.edn resource (shared with build.check-warnings).
 
 (def ^:private noisy-namespaces
   "Third-party namespaces that emit reflection or boxed math warnings.
   Each require wrapped in try/catch for silent failure when deps aren't on classpath."
-  '[aero.alpha.core
-    babashka.fs
-    cider.nrepl.inlined.deps.toolsreader.v1v4v1.clojure.tools.reader
-    cider.nrepl.middleware.test
-    cider.nrepl.middleware.util.instrument
-    clj-http.client
-    clj-http.headers
-    clojure.data.json
-    clojure.test.check
-    clojure.test.check.clojure-test
-    clojure.tools.cli
-    clojure.tools.deps
-    clojure.tools.gitlibs
-    clojure.tools.reader
-    fipp
-    kaocha.plugin.profiling
-    kaocha.report
-    kaocha.runner
-    lambdaisland.deep-diff2
-    malli.core
-    malli.generator
-    malli.instrument
-    nextjournal.beholder
-    nextjournal.markdown.transform
-    nextjournal.markdown.utils
-    nrepl.core
-    nrepl.middleware
-    nrepl.middleware.session
-    orchard.inspect
-    potemkin.utils
-    scicloj.clay.v2.make
-    scicloj.clay.v2.notebook
-    scicloj.clay.v2.util.image
-    scicloj.kindly-render.note.to-hiccup])
+  (-> (io/resource "build/noisy-namespaces.edn")
+      slurp
+      edn/read-string))
 
 ;;; Pre-load noisy namespaces at compile time
 ;;


### PR DESCRIPTION
## Summary

Add a check to the GitHub Actions test workflow that fails the build if there are any boxed math warnings or reflection warnings in the codebase.

This ensures code quality by catching:
- Boxed math warnings (unchecked primitive operations)
- Reflection warnings (missing type hints causing runtime reflection)

## Implementation

**New tooling (`build/src/build/check_warnings.clj`):**
- Discovers all project namespaces from Polylith structure (bases/*/src, bases/*/test, components/*/src, components/*/test)
- Pre-loads third-party namespaces with warnings disabled to avoid noise
- Compiles project namespaces with `*warn-on-reflection* true` and `*unchecked-math* :warn-on-boxed`
- Detects exempt namespaces (those with explicit `(set! *warn-on-reflection* false)` or `(set! *unchecked-math* false)`)
- Reports all warnings grouped by namespace
- Returns non-zero exit code if any non-exempt warnings found

**Shared configuration:**
- Extracted noisy-namespaces list to `build/resources/build/noisy-namespaces.edn`
- Both `build.check-warnings` and `criterium.kaocha-hooks` read from this shared resource

**deps.edn alias:**
- Added `:check-warnings` alias to run the warning check: `clojure -M:dev:test:check-warnings`

**GitHub workflow:**
- Added step to `.github/workflows/tests.yml` that runs the warning check on ubuntu-latest

## Commits

- feat(build): add namespace discovery utility for warning checks
- feat(build): add noisy namespace pre-loading for warning checks
- feat(build): add exemption detection for warning checks
- feat(build): add warning capture and compilation functions
- feat(build): add reporting and main entry point for warning checks
- feat(build): add check-warnings deps.edn alias
- feat(ci): add boxed math and reflection warning checks to workflow
- revert: remove out-of-scope boxed math fixes from tail.clj
- fix: use pos? to avoid boxed math warning in check_warnings.clj
- refactor: extract noisy-namespaces to shared EDN resource
- fix: add missing third-party namespaces to noisy-namespaces

## Test Plan

- [x] Run `clojure -M:dev:test:check-warnings` locally - passes with no warnings
- [x] Verified workflow step syntax is valid YAML
- [x] Verified exemption detection works for namespaces with explicit warning disables