### PR TITLE
fix(warnings): eliminate boxed math and reflection warnings

### DIFF
--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -691,9 +691,10 @@
               ;; Compute rolling variance
               rolling-vars
               (for [i (range (- n window-size))]
-                (let [window (subvec estimates i (+ i window-size))
-                      mean (/ (reduce + window) window-size)
-                      var (/ (reduce + (map #(Math/pow (- % mean) 2) window))
+                (let [i (long i)
+                      window (subvec estimates i (+ i window-size))
+                      mean (/ (double (reduce + window)) window-size)
+                      var (/ (double (reduce + (map #(Math/pow (- (double %) mean) 2) window)))
                              window-size)]
                   {:start i :variance var :mean mean}))
               ;; Find region with minimum variance
@@ -726,7 +727,7 @@
                 ;; Above threshold, use GPD extrapolation
                 (let [;; Transform p to GPD scale
                       p-excess (/ (- p f-u) (- 1.0 f-u))
-                      gpd-q (gpd-quantile-fn p-excess)]
+                      gpd-q (double (gpd-quantile-fn p-excess))]
                   [p (+ threshold gpd-q)])))))))
 
 (defn tail-analysis-for-metric

--- a/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/domain/comparison_test.clj
@@ -1084,8 +1084,8 @@
             y (double (get point "y"))
             y-lower (get point "yLower")
             y-upper (get point "yUpper")
-            lower-ratio (/ y-lower y)
-            upper-ratio (/ y-upper y)]
+            lower-ratio (/ (double y-lower) y)
+            upper-ratio (/ (double y-upper) y)]
         ;; 0.8/1.0 = 0.8, 1.2/1.0 = 1.2
         (is (< 0.79 lower-ratio 0.81))
         (is (< 1.19 upper-ratio 1.21))))

--- a/components/stats/test/criterium/stats/tail_test.clj
+++ b/components/stats/test/criterium/stats/tail_test.clj
@@ -73,7 +73,8 @@
       (let [samples (darr (sort (range 1 21)))
             results (stats/hill-estimator samples [5])]
         (is (= 1 (count results)))
-        (let [{:keys [estimate tail-index]} (first results)]
+        (let [{:keys [estimate tail-index]} (first results)
+              estimate (double estimate)]
           (when (pos? estimate)
             (is (< (abs-error (/ 1.0 estimate) tail-index) 1e-10))))))))
 
@@ -206,7 +207,7 @@
         (is (contains? result :converged?))
         (is (:converged? result))
         ;; For exponential-like data, xi should be close to 0
-        (is (< (Math/abs (:xi result)) 1.0))))
+        (is (< (Math/abs (double (:xi result))) 1.0))))
     (testing "returns positive sigma"
       (let [samples (darr [1.0 2.0 3.0 4.0 5.0])
             result (stats/gpd-mle samples)]


### PR DESCRIPTION
## Summary

Eliminate ~15 boxed math and reflection warnings across 3 namespaces using explicit numeric coercions.

**Changes:**
- `criterium.analyse.metrics-samples` - Fix arithmetic operations using `(long ...)` and `(double ...)` coercions
- `criterium.stats.tail-test` - Fix 3 warnings using explicit `(double ...)` coercions
- `criterium.viewer.common.domain.comparison-test` - Fix 2 warnings in division operations

## Commits

- fix(test): eliminate boxed math warnings in criterium.viewer.common.domain.comparison-test
- fix(test): eliminate boxed math warnings in criterium.stats.tail-test
- fix(analyse): eliminate boxed math warnings in criterium.analyse.metrics-samples

## Test plan

- [x] All tests pass with `clojure -M:kaocha:dev:test :all --reporter dots`
- [x] No new warnings introduced