### PR TITLE
feat(view): improve print viewer

### DIFF
--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -46,14 +46,14 @@
    :view [[:stats {:metric-ids [:memory]}]
           :bootstrap-stats
           :extremes
+          :collect-plan
+          :outlier-counts
+          [:multimodal-warning {:modes-id :modes}]
           [:autocorrelation-classification {:classification-id :autocorrelation-classification-raw}]
           [:effective-sample-size {:ess-id :effective-sample-size-filtered}]
           [:acf-plot {:autocorrelation-id :autocorrelation-raw
                       :min-severity :moderate}]
-          [:multimodal-warning {:modes-id :modes}]
           :event-stats
-          :outlier-counts
-          :collect-plan
           :allocation-summary
           :allocation-hotspots
           :allocation-by-type

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -43,13 +43,15 @@
              [:allocation-hotspots {:limit 10}]
              :allocation-by-type
              :allocation-treemap]
-   :view [[:stats {:metric-ids [:memory]}]
+   :view [:collect-plan
+          [:stats {:metric-ids [:memory]}]
           :bootstrap-stats
           :extremes
-          :collect-plan
+          :shape-stats
           :outlier-counts
           [:multimodal-warning {:modes-id :modes}]
-          [:autocorrelation-classification {:classification-id :autocorrelation-classification-raw}]
+          [:autocorrelation-classification
+           {:classification-id :autocorrelation-classification-raw}]
           [:effective-sample-size {:ess-id :effective-sample-size-filtered}]
           [:acf-plot {:autocorrelation-id :autocorrelation-raw
                       :min-severity :moderate}]

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -45,11 +45,11 @@
              :allocation-treemap]
    :view [[:stats {:metric-ids [:memory]}]
           :bootstrap-stats
+          :extremes
           [:autocorrelation-classification {:classification-id :autocorrelation-classification-raw}]
           [:effective-sample-size {:ess-id :effective-sample-size-filtered}]
           [:acf-plot {:autocorrelation-id :autocorrelation-raw
                       :min-severity :moderate}]
-          :extremes
           [:multimodal-warning {:modes-id :modes}]
           :event-stats
           :outlier-counts

--- a/bases/criterium/src/criterium/viewer/common/allocation.clj
+++ b/bases/criterium/src/criterium/viewer/common/allocation.clj
@@ -5,7 +5,8 @@
   ASCII treemap rendering for allocation visualization."
   (:require
    [clojure.string :as str]
-   [criterium.util.format :as format]))
+   [criterium.util.format :as format]
+   [criterium.viewer.common.core :as core]))
 
 ;;; Call site and object type formatting
 
@@ -45,16 +46,6 @@
 
 ;;; ASCII Treemap rendering
 
-(defn ascii-bar
-  "Generate a bar of █ characters proportional to value/max-value.
-  Returns a string of at most `width` characters."
-  ^String [^double value ^double max-value ^long width]
-  (if (or (<= max-value 0) (<= value 0))
-    ""
-    (let [ratio (min 1.0 (/ value max-value))
-          bar-len (max 0 (long (Math/round (* ratio width))))]
-      (apply str (repeat bar-len \█)))))
-
 ;;; Treemap box-drawing constants
 
 (def ^:private ^String tree-branch
@@ -91,7 +82,7 @@
         node-name (if is-leaf? name (str name "/"))
         size-str (str "[" (format/format-value :memory value) "]")
         bar-str (when is-leaf?
-                  (ascii-bar (double value) max-value bar-width))
+                  (core/ascii-bar (double value) max-value bar-width))
         ;; Keep prefix + connector intact, only truncate the name if needed
         prefix-connector (str prefix connector)
         prefix-len (long (count prefix-connector))

--- a/bases/criterium/src/criterium/viewer/common/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/common/autocorrelation.clj
@@ -39,9 +39,9 @@
 
 (def pattern-recommendations
   "Recommendations for each displayable pattern."
-  {:transient-effects "Check: warmup iterations, system load, thermal throttling, GC pressure"
+  {:transient-effects "Check: warmup iterations, system load, thermal throttling"
    :drift "Shorter benchmark duration; check thermal throttling"
-   :periodic "Investigate GC logs; increase heap; check OS scheduler"
+   :periodic "Investigate GC logs; increase heap"
    :severe "Review methodology; results unreliable"
    :alternating-moderate "Review methodology; results unreliable"
    :alternating-severe "Review methodology; results unreliable"})

--- a/bases/criterium/src/criterium/viewer/common/core.clj
+++ b/bases/criterium/src/criterium/viewer/common/core.clj
@@ -466,3 +466,17 @@
                          formatted (format/format-value :time tval)]
                      {:quantile (clojure.core/format "p%.4g" (* (double q) 100))
                       :estimate formatted})))))))
+
+(defn strip-uniform-axes
+  "Strip uniform-value axes from coordinates.
+  Only strips axes if doing so leaves at least one key in each coord.
+  Returns coords unchanged if any coord is not a map."
+  [coords]
+  (if-not (every? map? coords)
+    coords
+    (let [uniform-axes (detect-uniform-axes coords)
+          first-coord (first coords)
+          remaining-keys (count (apply dissoc first-coord uniform-axes))]
+      (if (and (seq uniform-axes) (pos? remaining-keys))
+        (mapv #(apply dissoc % uniform-axes) coords)
+        coords))))

--- a/bases/criterium/src/criterium/viewer/common/core.clj
+++ b/bases/criterium/src/criterium/viewer/common/core.clj
@@ -382,6 +382,45 @@
                                (keys first-coord))]
       (set uniform-keys))))
 
+;;; ASCII Bar Rendering
+
+(defn ascii-bar
+  "Generate a bar of █ characters proportional to value/max-value.
+  Returns a string of at most `width` characters."
+  ^String [^double value ^double max-value ^long width]
+  (if (or (<= max-value 0) (<= value 0))
+    ""
+    (let [ratio (min 1.0 (/ value max-value))
+          bar-len (max 0 (long (Math/round (* ratio width))))]
+      (apply str (repeat bar-len \█)))))
+
+(defn ascii-bar-bidirectional
+  "Generate a bidirectional bar centered on a vertical line.
+  Negative values extend left, positive values extend right.
+  Returns a string of exactly (2 * half-width + 1) characters.
+
+  Example outputs for half-width=10:
+    value  0.5 -> '          |█████     '
+    value -0.3 -> '       ███|          '
+    value  0.0 -> '          |          '"
+  ^String [^double value ^double max-abs-value ^long half-width]
+  (if (<= max-abs-value 0)
+    (str (apply str (repeat half-width \space)) "|" (apply str (repeat half-width \space)))
+    (let [ratio (min 1.0 (/ (Math/abs value) max-abs-value))
+          bar-len (max 0 (long (Math/round (* ratio half-width))))
+          left-spaces (apply str (repeat half-width \space))
+          right-spaces (apply str (repeat half-width \space))]
+      (if (neg? value)
+        ;; Negative: bar extends left from center
+        (let [padding (- half-width bar-len)
+              left-part (str (apply str (repeat padding \space))
+                             (apply str (repeat bar-len \█)))]
+          (str left-part "|" right-spaces))
+        ;; Positive or zero: bar extends right from center
+        (let [right-part (str (apply str (repeat bar-len \█))
+                              (apply str (repeat (- half-width bar-len) \space)))]
+          (str left-spaces "|" right-part))))))
+
 ;;; Tail Analysis Table Helpers
 
 (defn tail-summary-table

--- a/bases/criterium/src/criterium/viewer/common/core.clj
+++ b/bases/criterium/src/criterium/viewer/common/core.clj
@@ -384,6 +384,25 @@
 
 ;;; ASCII Bar Rendering
 
+(def ^:private ^String max-bar-chars
+  "Pre-allocated string of 100 █ characters for ascii-bar substring operations."
+  (let [sb (StringBuilder. 100)]
+    (dotimes [_ 100] (.append sb \█))
+    (.toString sb)))
+
+(def ^:private ^String max-space-chars
+  "Pre-allocated string of 100 space characters for ascii-bar substring operations."
+  (let [sb (StringBuilder. 100)]
+    (dotimes [_ 100] (.append sb \space))
+    (.toString sb)))
+
+(defn- n-chars
+  "Return a string of n copies of char from pre-allocated string."
+  ^String [^String chars ^long n]
+  (if (<= n 0)
+    ""
+    (subs chars 0 (min n (count chars)))))
+
 (defn ascii-bar
   "Generate a bar of █ characters proportional to value/max-value.
   Returns a string of at most `width` characters."
@@ -392,7 +411,7 @@
     ""
     (let [ratio (min 1.0 (/ value max-value))
           bar-len (max 0 (long (Math/round (* ratio width))))]
-      (apply str (repeat bar-len \█)))))
+      (n-chars max-bar-chars bar-len))))
 
 (defn ascii-bar-bidirectional
   "Generate a bidirectional bar centered on a vertical line.
@@ -404,22 +423,21 @@
     value -0.3 -> '       ███|          '
     value  0.0 -> '          |          '"
   ^String [^double value ^double max-abs-value ^long half-width]
-  (if (<= max-abs-value 0)
-    (str (apply str (repeat half-width \space)) "|" (apply str (repeat half-width \space)))
-    (let [ratio (min 1.0 (/ (Math/abs value) max-abs-value))
-          bar-len (max 0 (long (Math/round (* ratio half-width))))
-          left-spaces (apply str (repeat half-width \space))
-          right-spaces (apply str (repeat half-width \space))]
-      (if (neg? value)
-        ;; Negative: bar extends left from center
-        (let [padding (- half-width bar-len)
-              left-part (str (apply str (repeat padding \space))
-                             (apply str (repeat bar-len \█)))]
-          (str left-part "|" right-spaces))
-        ;; Positive or zero: bar extends right from center
-        (let [right-part (str (apply str (repeat bar-len \█))
-                              (apply str (repeat (- half-width bar-len) \space)))]
-          (str left-spaces "|" right-part))))))
+  (let [spaces (n-chars max-space-chars half-width)]
+    (if (<= max-abs-value 0)
+      (str spaces "|" spaces)
+      (let [ratio (min 1.0 (/ (Math/abs value) max-abs-value))
+            bar-len (max 0 (long (Math/round (* ratio half-width))))]
+        (if (neg? value)
+          ;; Negative: bar extends left from center
+          (let [padding (- half-width bar-len)]
+            (str (n-chars max-space-chars padding)
+                 (n-chars max-bar-chars bar-len)
+                 "|" spaces))
+          ;; Positive or zero: bar extends right from center
+          (str spaces "|"
+               (n-chars max-bar-chars bar-len)
+               (n-chars max-space-chars (- half-width bar-len))))))))
 
 ;;; Tail Analysis Table Helpers
 

--- a/bases/criterium/src/criterium/viewer/common/shape.clj
+++ b/bases/criterium/src/criterium/viewer/common/shape.clj
@@ -4,6 +4,42 @@
   Provides functions for formatting and classifying shape statistics
   (skewness, kurtosis, CV) from bootstrap results.")
 
+;;; Classification Labels
+
+(def skewness-labels
+  "Human-readable labels for skewness classification keywords."
+  {:strongly-left-skewed "strongly left-skewed"
+   :moderately-left-skewed "moderately left-skewed"
+   :slightly-left-skewed "slightly left-skewed"
+   :symmetric "symmetric"
+   :slightly-right-skewed "slightly right-skewed"
+   :moderately-right-skewed "moderately right-skewed"
+   :strongly-right-skewed "strongly right-skewed"})
+
+(def kurtosis-labels
+  "Human-readable labels for kurtosis classification keywords."
+  {:heavy-tails "heavy tails (leptokurtic)"
+   :light-tails "light tails (platykurtic)"
+   :normal-tails "normal tails (mesokurtic)"})
+
+(def cv-labels
+  "Human-readable labels for coefficient of variation classification keywords."
+  {:low-variability "low variability"
+   :moderate-variability "moderate variability"
+   :high-variability "high variability"})
+
+;;; Formatting Functions
+
+(defn format-classification
+  "Format a classification keyword for display.
+  Returns the human-readable label from the appropriate label map, or
+  the keyword's name if not found."
+  [classification]
+  (or (skewness-labels classification)
+      (kurtosis-labels classification)
+      (cv-labels classification)
+      (some-> classification name)))
+
 ;;; Shape Statistics Classification
 
 (defn- classify-skewness

--- a/bases/criterium/src/criterium/viewer/common/shape.clj
+++ b/bases/criterium/src/criterium/viewer/common/shape.clj
@@ -8,11 +8,11 @@
 
 (defn- classify-skewness
   "Classify skewness based on absolute value.
-  Uses standard thresholds: |s| > 1 highly skewed, |s| > 0.5 moderately skewed."
+  Uses standard thresholds: |s| > 1 strongly skewed, |s| > 0.5 moderately skewed."
   [^double s]
   (let [abs-s (Math/abs s)]
     (cond
-      (> abs-s 1.0) (if (neg? s) :highly-left-skewed :highly-right-skewed)
+      (> abs-s 1.0) (if (neg? s) :strongly-left-skewed :strongly-right-skewed)
       (> abs-s 0.5) (if (neg? s) :moderately-left-skewed :moderately-right-skewed)
       (> abs-s 0.1) (if (neg? s) :slightly-left-skewed :slightly-right-skewed)
       :else :symmetric)))

--- a/bases/criterium/src/criterium/viewer/print.clj
+++ b/bases/criterium/src/criterium/viewer/print.clj
@@ -25,33 +25,11 @@
   is in criterium.viewer.print.autocorrelation."
   (:require
    [criterium.viewer.print.allocation]
-   [criterium.viewer.print.autocorrelation :as print.autocorrelation]
-   [criterium.viewer.print.core :as print.core]
+   [criterium.viewer.print.autocorrelation]
+   [criterium.viewer.print.core]
    [criterium.viewer.print.distribution]
    [criterium.viewer.print.domain]
    [criterium.viewer.print.modal]
    [criterium.viewer.print.shape]
    [criterium.viewer.print.tail]))
-
-;;; Re-exported functions from print.core for backwards compatibility
-(def print-stat
-  "Print a single metric's stats. Delegates to criterium.viewer.print.core."
-  print.core/print-stat)
-
-(def print-extreme
-  "Print a single metric's min/max values. Delegates to criterium.viewer.print.core."
-  print.core/print-extreme)
-
-(def print-bootstrap-stat
-  "Print bootstrap statistics for a metric. Delegates to criterium.viewer.print.core."
-  print.core/print-bootstrap-stat)
-
-(def print-outlier-count
-  "Print outlier counts for a metric. Delegates to criterium.viewer.print.core."
-  print.core/print-outlier-count)
-
-;;; Re-exported functions from print.autocorrelation for backwards compatibility
-(def print-autocorrelation
-  "Print autocorrelation analysis summary. Delegates to criterium.viewer.print.autocorrelation."
-  print.autocorrelation/print-autocorrelation)
 

--- a/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
@@ -2,11 +2,13 @@
   "Print viewer for autocorrelation analysis.
 
   Provides views for lag analysis, effective sample size,
-  CI inflation factors, and pattern classification."
+  CI inflation factors, pattern classification, and ACF plots."
   (:require
    [clojure.string :as str]
    [criterium.view :as view]
+   [criterium.viewer.common-charts.autocorrelation :as acf-charts]
    [criterium.viewer.common.autocorrelation :as acf-common]
+   [criterium.viewer.common.core :as core]
    [criterium.viewer.print.core :as print-core]))
 
 (set! *unchecked-math* false)
@@ -76,8 +78,99 @@
   [_ view data-map]
   (print-autocorrelations view data-map))
 
-;; ACF plot is a no-op for print viewer (charts not supported)
-(defmethod view/acf-plot* :print [_ _ _])
+;;; ACF Plot
+
+(defn- format-threshold-legend
+  "Format threshold legend showing only crossed thresholds.
+  Returns string like 'lag-1 [minor 0.10, moderate 0.20], other [minor 0.15]'."
+  [acf-map thresholds]
+  (let [lag-1-acf (Math/abs (double (get acf-map 1 0)))
+        other-max-acf (if (> (count acf-map) 1)
+                        (apply max 0 (map #(Math/abs (double %))
+                                          (vals (dissoc acf-map 1))))
+                        0)
+        lag-1-thresholds (:lag-1 thresholds)
+        other-thresholds (:other thresholds)
+        ;; Find crossed thresholds for lag-1
+        lag-1-crossed (for [[level ^double threshold] (sort-by val lag-1-thresholds)
+                            :when (> lag-1-acf threshold)]
+                        (format "%s %.2f" (name level) threshold))
+        ;; Find crossed thresholds for other lags
+        other-crossed (for [[level ^double threshold] (sort-by val other-thresholds)
+                            :when (> other-max-acf threshold)]
+                        (format "%s %.2f" (name level) threshold))]
+    (cond-> []
+      (seq lag-1-crossed)
+      (conj (str "lag-1 [" (str/join ", " lag-1-crossed) "]"))
+      (seq other-crossed)
+      (conj (str "other [" (str/join ", " other-crossed) "]")))))
+
+(defn print-acf-plot
+  "Print ASCII ACF plot for a single metric.
+
+  Shows autocorrelation coefficients as bidirectional ASCII bar charts.
+  Only renders if at least one lag meets the min-severity threshold.
+
+  Options:
+    :min-severity - minimum severity to display (default :moderate)
+    :bar-width    - half-width of bar in characters (default 15)"
+  [{:keys [acf effective-sample-size lag-severities thresholds]} metric-label opts]
+  (let [{:keys [min-severity bar-width]
+         :or {min-severity :moderate bar-width 15}} opts
+        n (get effective-sample-size :n-original)
+        ;; Default thresholds if not provided
+        thresholds (or thresholds
+                       {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                        :other {:minor 0.15 :moderate 0.25 :severe 0.40}})]
+    (when (and acf n lag-severities
+               (acf-charts/has-severity-at-or-above? lag-severities min-severity))
+      ;; Filter lags by severity
+      (let [min-rank (get acf-charts/severity-rank min-severity 0)
+            qualifying-lags (for [[lag sev] lag-severities
+                                  :when (>= (long (get acf-charts/severity-rank sev 0))
+                                            (long min-rank))]
+                              lag)
+            ;; Calculate max |acf| for scaling
+            max-abs-acf (apply max 0.01 (map #(Math/abs (double (get acf % 0)))
+                                             qualifying-lags))
+            ;; Sort lags numerically
+            sorted-lags (sort qualifying-lags)
+            ;; Calculate column widths
+            max-lag-width (max 3 (count (str (apply max 1 sorted-lags))))
+            ;; Print header
+            indent "  "
+            ;; Build format strings with dynamic width
+            header-fmt (str "%s%" max-lag-width "s   %s")
+            row-fmt (str "%s%" max-lag-width "d  %6.2f  %s (%s)")]
+        (println (format "%s ACF Plot (n=%d):" (print-core/format-sublabel metric-label) n))
+        (println (format header-fmt indent "Lag" "ACF"))
+        ;; Print each lag
+        (doseq [lag sorted-lags]
+          (let [acf-val (double (get acf lag))
+                severity (get lag-severities lag :none)
+                bar (core/ascii-bar-bidirectional acf-val max-abs-acf bar-width)]
+            (println (format row-fmt
+                             indent
+                             lag
+                             acf-val
+                             bar
+                             (acf-common/format-severity severity)))))
+        ;; Print threshold legend
+        (let [legend-parts (format-threshold-legend acf thresholds)]
+          (when (seq legend-parts)
+            (println)
+            (println (format "%sThresholds: %s" indent (str/join ", " legend-parts)))))))))
+
+(defn print-acf-plots
+  "Print ACF plots for all metrics."
+  [view data-map]
+  (acf-common/with-autocorrelation-metrics view data-map
+    (fn [acf-data mc]
+      (print-acf-plot acf-data (:label mc) view))))
+
+(defmethod view/acf-plot* :print
+  [_ view data-map]
+  (print-acf-plots view data-map))
 
 (defn- print-classification-for-metric
   "Print classification analysis for a single metric."

--- a/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
@@ -6,7 +6,8 @@
   (:require
    [clojure.string :as str]
    [criterium.view :as view]
-   [criterium.viewer.common.autocorrelation :as acf-common]))
+   [criterium.viewer.common.autocorrelation :as acf-common]
+   [criterium.viewer.print.core :as print-core]))
 
 (set! *unchecked-math* false)
 
@@ -26,42 +27,42 @@
            ljung-box pattern classification detected-period
            anomalous-lags lag-severities]}
    metric-label]
-  (println (format "%36s:" "Sample Independence"))
-  (println (format "%36s: %.2f (%s)"
-                   (str metric-label " Lag-1 autocorrelation")
+  (println (print-core/format-sublabel "Sample Independence"))
+  (println (format "%s %.2f (%s)"
+                   (print-core/format-sublabel (str metric-label " Lag-1 autocorrelation"))
                    (:value lag-1)
                    (acf-common/format-severity (:severity lag-1))))
-  (println (format "%36s: %d of %d (%.0f%%)"
-                   "Effective sample size"
+  (println (format "%s %d of %d (%.0f%%)"
+                   (print-core/format-sublabel "Effective sample size")
                    (:n-effective effective-sample-size)
                    (:n-original effective-sample-size)
                    (* 100.0 (:ratio effective-sample-size))))
-  (println (format "%36s: %.2f×"
-                   "CI inflation factor"
+  (println (format "%s %.2f×"
+                   (print-core/format-sublabel "CI inflation factor")
                    ci-inflation-factor))
-  (println (format "%36s: %.2f"
-                   "Ljung-Box p-value"
+  (println (format "%s %.2f"
+                   (print-core/format-sublabel "Ljung-Box p-value")
                    (:p-value ljung-box)))
-  (println (format "%36s: %s"
-                   "Assessment"
+  (println (format "%s %s"
+                   (print-core/format-sublabel "Assessment")
                    (str/capitalize (name classification))))
   (when-let [formatted (acf-common/format-anomalous-lags anomalous-lags lag-severities)]
-    (println (format "%36s: %s"
-                     "Anomalous lags"
+    (println (format "%s %s"
+                     (print-core/format-sublabel "Anomalous lags")
                      formatted)))
   (when (and (#{:warning :fail} classification)
              (acf-common/displayable-patterns pattern))
-    (println (format "%36s: %s"
-                     "Pattern"
+    (println (format "%s %s"
+                     (print-core/format-sublabel "Pattern")
                      (get acf-common/pattern-labels pattern (name pattern))))
     (when-let [period-str (acf-common/format-detected-period
                            detected-period acf lag-severities)]
-      (println (format "%36s: %s"
-                       "Suspected period"
+      (println (format "%s %s"
+                       (print-core/format-sublabel "Suspected period")
                        period-str)))
     (when-let [rec (get acf-common/pattern-recommendations pattern)]
-      (println (format "%36s: %s"
-                       "Recommendation"
+      (println (format "%s %s"
+                       (print-core/format-sublabel "Recommendation")
                        rec)))))
 
 (defn print-autocorrelations
@@ -82,30 +83,30 @@
   "Print classification analysis for a single metric."
   [{:keys [acf lag-1 lag-severities ljung-box pattern classification detected-period]}
    metric-label]
-  (println (format "%36s:" "Sample Independence Classification"))
-  (println (format "%36s: %.2f (%s)"
-                   (str metric-label " Lag-1 autocorrelation")
+  (println (print-core/format-sublabel "Sample Independence Classification"))
+  (println (format "%s %.2f (%s)"
+                   (print-core/format-sublabel (str metric-label " Lag-1 autocorrelation"))
                    (:value lag-1)
                    (acf-common/format-severity (:severity lag-1))))
-  (println (format "%36s: %.2f"
-                   (str metric-label " Ljung-Box p-value")
+  (println (format "%s %.2f"
+                   (print-core/format-sublabel (str metric-label " Ljung-Box p-value"))
                    (:p-value ljung-box)))
-  (println (format "%36s: %s"
-                   "Assessment"
+  (println (format "%s %s"
+                   (print-core/format-sublabel "Assessment")
                    (str/capitalize (name classification))))
   (when (and (#{:warning :fail} classification)
              (acf-common/displayable-patterns pattern))
-    (println (format "%36s: %s"
-                     "Pattern"
+    (println (format "%s %s"
+                     (print-core/format-sublabel "Pattern")
                      (get acf-common/pattern-labels pattern (name pattern))))
     (when-let [period-str (acf-common/format-detected-period
                            detected-period acf lag-severities)]
-      (println (format "%36s: %s"
-                       "Suspected period"
+      (println (format "%s %s"
+                       (print-core/format-sublabel "Suspected period")
                        period-str)))
     (when-let [rec (get acf-common/pattern-recommendations pattern)]
-      (println (format "%36s: %s"
-                       "Recommendation"
+      (println (format "%s %s"
+                       (print-core/format-sublabel "Recommendation")
                        rec)))))
 
 (defn print-autocorrelation-classifications
@@ -126,19 +127,19 @@
 (defn- print-effective-sample-size-for-metric
   "Print effective sample size analysis for a single metric."
   [{:keys [lag-1 effective-sample-size ci-inflation-factor]} metric-label]
-  (println (format "%36s:" "Effective Sample Size"))
+  (println (print-core/format-sublabel "Effective Sample Size"))
   (when lag-1
-    (println (format "%36s: %.2f (%s)"
-                     (str metric-label " Lag-1 autocorrelation")
+    (println (format "%s %.2f (%s)"
+                     (print-core/format-sublabel (str metric-label " Lag-1 autocorrelation"))
                      (:value lag-1)
                      (acf-common/format-severity (:severity lag-1)))))
-  (println (format "%36s: %d of %d (%.0f%%)"
-                   "Effective sample size"
+  (println (format "%s %d of %d (%.0f%%)"
+                   (print-core/format-sublabel "Effective sample size")
                    (:n-effective effective-sample-size)
                    (:n-original effective-sample-size)
                    (* 100.0 (:ratio effective-sample-size))))
-  (println (format "%36s: %.2f×"
-                   "CI inflation factor"
+  (println (format "%s %.2f×"
+                   (print-core/format-sublabel "CI inflation factor")
                    ci-inflation-factor)))
 
 (defn print-effective-sample-sizes

--- a/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
@@ -137,8 +137,8 @@
             sorted-lags (sort qualifying-lags)
             ;; Calculate column widths
             max-lag-width (max 3 (count (str (apply max 1 sorted-lags))))
-            ;; Print header
-            indent "  "
+            ;; Use sublabel-indent-str for lines following format-sublabel header
+            indent (print-core/sublabel-indent-str)
             ;; Build format strings with dynamic width
             header-fmt (str "%s%" max-lag-width "s   %s")
             row-fmt (str "%s%" max-lag-width "d  %6.2f  %s (%s)")]

--- a/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
@@ -83,31 +83,29 @@
   "Print classification analysis for a single metric."
   [{:keys [acf lag-1 lag-severities ljung-box pattern classification detected-period]}
    metric-label]
-  (println (print-core/format-sublabel "Sample Independence Classification"))
-  (println (format "%s %.2f (%s)"
-                   (print-core/format-sublabel (str metric-label " Lag-1 autocorrelation"))
-                   (:value lag-1)
-                   (acf-common/format-severity (:severity lag-1))))
-  (println (format "%s %.2f"
-                   (print-core/format-sublabel (str metric-label " Ljung-Box p-value"))
-                   (:p-value ljung-box)))
-  (println (format "%s %s"
-                   (print-core/format-sublabel "Assessment")
-                   (str/capitalize (name classification))))
+  (println)
+  (println (print-core/format-sublabel metric-label)
+           "Sample Independence Classification")
+  (println (print-core/format-sublabel "Lag-1 autocorrelation")
+           (format
+            "%.2f (%s)"
+            (:value lag-1)
+            (acf-common/format-severity (:severity lag-1))))
+  (println (print-core/format-sublabel "Ljung-Box p-value")
+           (format "%.2f" (:p-value ljung-box)))
+  (println (print-core/format-sublabel "Assessment")
+           (str/capitalize (name classification)))
   (when (and (#{:warning :fail} classification)
              (acf-common/displayable-patterns pattern))
-    (println (format "%s %s"
-                     (print-core/format-sublabel "Pattern")
-                     (get acf-common/pattern-labels pattern (name pattern))))
+    (println (print-core/format-sublabel "Pattern")
+             (get acf-common/pattern-labels pattern (name pattern)))
     (when-let [period-str (acf-common/format-detected-period
                            detected-period acf lag-severities)]
-      (println (format "%s %s"
-                       (print-core/format-sublabel "Suspected period")
-                       period-str)))
+      (println (print-core/format-sublabel "Suspected period")
+               period-str))
     (when-let [rec (get acf-common/pattern-recommendations pattern)]
-      (println (format "%s %s"
-                       (print-core/format-sublabel "Recommendation")
-                       rec)))))
+      (println (print-core/format-sublabel "Recommendation")
+               rec))))
 
 (defn print-autocorrelation-classifications
   "Print autocorrelation classification for all metrics.
@@ -127,20 +125,20 @@
 (defn- print-effective-sample-size-for-metric
   "Print effective sample size analysis for a single metric."
   [{:keys [lag-1 effective-sample-size ci-inflation-factor]} metric-label]
-  (println (print-core/format-sublabel "Effective Sample Size"))
+  (println)
+  (println (print-core/format-sublabel metric-label) "Effective Sample Size")
   (when lag-1
-    (println (format "%s %.2f (%s)"
-                     (print-core/format-sublabel (str metric-label " Lag-1 autocorrelation"))
+    (println (print-core/format-sublabel "Lag-1 autocorrelation (no outliers)")
+             (format "%.2f (%s)"
                      (:value lag-1)
                      (acf-common/format-severity (:severity lag-1)))))
-  (println (format "%s %d of %d (%.0f%%)"
-                   (print-core/format-sublabel "Effective sample size")
+  (println (print-core/format-sublabel "Effective sample size")
+           (format "%d of %d (%.0f%%)"
                    (:n-effective effective-sample-size)
                    (:n-original effective-sample-size)
-                   (* 100.0 (:ratio effective-sample-size))))
-  (println (format "%s %.2f×"
-                   (print-core/format-sublabel "CI inflation factor")
-                   ci-inflation-factor)))
+                   (* 100.0 (double (:ratio effective-sample-size)))))
+  (println (print-core/format-sublabel "CI inflation factor")
+           (format "%.2f×" ci-inflation-factor)))
 
 (defn print-effective-sample-sizes
   "Print effective sample size analysis for all metrics.

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -57,6 +57,36 @@
   [label]
   (str (sublabel-str label) ":"))
 
+;;; Analysis Context
+
+(defn get-analysis-context
+  "Extract common context for print viewer functions.
+
+  Looks up analysis data from data-map using the ID from view options
+  (or default-id), extracts metrics-defs (optionally filtered by
+  metric-filter), and computes transforms.
+
+  Arguments:
+    id-key       - keyword to look up in view for the analysis ID
+    default-id   - fallback ID if not specified in view
+    view         - view options map
+    data-map     - benchmark data map
+    metric-filter - predicate to filter metrics, or nil for no filtering
+
+  Returns map with :analysis-map, :metric-configs, :transforms,
+  or nil if no data found."
+  [id-key default-id view data-map metric-filter]
+  (let [analysis-id (or (get view id-key) default-id)
+        analysis-map (data-map analysis-id)]
+    (when analysis-map
+      (let [metrics-defs (cond-> (:metrics-defs analysis-map)
+                           metric-filter (metric/filter-metrics metric-filter))
+            metric-configs (metric/all-metric-configs metrics-defs)
+            transforms (util/get-transforms data-map analysis-id)]
+        {:analysis-map analysis-map
+         :metric-configs metric-configs
+         :transforms transforms}))))
+
 ;;; Metrics
 
 (defn print-metrics
@@ -246,17 +276,13 @@
                units)))))
 
 (defn print-bootstrap-stats
-  [{:keys [bootstrap-stats-id]} data-map]
-  (let [bootstrap-stats-id (or bootstrap-stats-id :bootstrap-stats)
-        bootstrap-map (data-map bootstrap-stats-id)]
-    (when bootstrap-map
-      (let [metrics-defs (:metrics-defs bootstrap-map)
-            metric-configs (metric/all-metric-configs metrics-defs)
-            bootstrap (util/bootstrap bootstrap-map)
-            transforms (util/get-transforms data-map bootstrap-stats-id)]
-        (doseq [metric metric-configs]
-          (when-let [stat (get-in bootstrap (:path metric))]
-            (print-bootstrap-stat metric stat transforms)))))))
+  [view data-map]
+  (when-let [{:keys [analysis-map metric-configs transforms]}
+             (get-analysis-context :bootstrap-stats-id :bootstrap-stats view data-map nil)]
+    (let [bootstrap (util/bootstrap analysis-map)]
+      (doseq [metric metric-configs]
+        (when-let [stat (get-in bootstrap (:path metric))]
+          (print-bootstrap-stat metric stat transforms))))))
 
 (defmethod view/bootstrap-stats* :print
   [_ view data-map]
@@ -396,19 +422,16 @@
                  (-> outlier-significance :effect labels))))
 
 (defn print-outlier-significances
-  [{:keys [outlier-significance-id] :as _view} data-map]
-  (let [outlier-sig-id (or outlier-significance-id :outlier-significance)
-        outlier-sig-map (data-map outlier-sig-id)
-        metrics-defs (-> (:metrics-defs outlier-sig-map)
-                         (metric/filter-metrics
-                          (metric/type-pred :quantitative)))
-        metric-configs (metric/all-metric-configs metrics-defs)
-        outlier-sig (util/outlier-significance outlier-sig-map)]
-    (doseq [m metric-configs]
-      (print-outlier-significance
-       m
-       (have seq (get-in outlier-sig (:path m))
-             {:metric m :outlier-sig outlier-sig})))))
+  [view data-map]
+  (when-let [{:keys [analysis-map metric-configs]}
+             (get-analysis-context :outlier-significance-id :outlier-significance
+                                   view data-map (metric/type-pred :quantitative))]
+    (let [outlier-sig (util/outlier-significance analysis-map)]
+      (doseq [m metric-configs]
+        (print-outlier-significance
+         m
+         (have seq (get-in outlier-sig (:path m))
+               {:metric m :outlier-sig outlier-sig}))))))
 
 (defmethod view/outlier-significance* :print
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -33,6 +33,91 @@
   "Secondary/detail label width for print viewer output."
   36)
 
+;;; Generic Table Printing
+
+(defn print-table
+  "Print a formatted table with box-drawing separators.
+
+  Takes a table specification map with:
+    :heading     - optional heading string printed before the table
+    :indent      - number of spaces to indent (default 2)
+    :row-key-col - optional {:header \"\" :width N} for leftmost row-key column
+    :columns     - vector of {:header \"Header\" :width N :align :right|:left}
+    :rows        - vector of row data, each row is a vector of cell strings
+                   If :row-key-col specified, first element is the row key
+
+  Cell alignment defaults to :right. Column widths are auto-calculated from
+  headers and data if not specified.
+
+  Example:
+    (print-table
+      {:heading \"My Table\"
+       :row-key-col {:header \"\" :width 8}
+       :columns [{:header \"A\"} {:header \"B\"}]
+       :rows [[\"key1\" \"val1\" \"val2\"]
+              [\"key2\" \"val3\" \"val4\"]]})"
+  [{:keys [heading indent row-key-col columns rows]
+    :or {indent 2}}]
+  (when heading
+    (println heading))
+  (let [indent-str (apply str (repeat indent \space))
+        ;; Calculate column widths if not provided
+        columns (mapv
+                 (fn [col-idx {:keys [header width] :as col}]
+                   (let [data-col-idx (if row-key-col (inc col-idx) col-idx)
+                         max-data-width (when (seq rows)
+                                          (apply max 0 (map #(count (str (nth % data-col-idx "")))
+                                                            rows)))
+                         calc-width (max (count header)
+                                         (or max-data-width 0))]
+                     (assoc col :width (or width calc-width))))
+                 (range)
+                 columns)
+        row-key-col (when row-key-col
+                      (let [{:keys [header width]} row-key-col
+                            max-key-width (when (seq rows)
+                                            (apply max 0 (map #(count (str (first %))) rows)))
+                            calc-width (max (count (or header ""))
+                                            (or max-key-width 0)
+                                            8)]
+                        (assoc row-key-col :width (or width calc-width))))
+        ;; Format a cell with alignment
+        format-cell (fn [{:keys [width align]} value]
+                      (let [align (or align :right)
+                            fmt (str "%" (when (= align :left) "-") width "s")]
+                        (format fmt (or value ""))))
+        ;; Print header row
+        _ (do
+            (print indent-str)
+            (when row-key-col
+              (print (format-cell row-key-col (:header row-key-col))))
+            (doseq [[i col] (map-indexed vector columns)]
+              (when (or row-key-col (pos? i))
+                (print " │ "))
+              (print (format-cell col (:header col))))
+            (println))
+        ;; Print separator line
+        _ (do
+            (print indent-str)
+            (when row-key-col
+              (print (apply str (repeat (:width row-key-col) "─"))))
+            (doseq [[i col] (map-indexed vector columns)]
+              (when (or row-key-col (pos? i))
+                (print "─┼─"))
+              (print (apply str (repeat (:width col) "─"))))
+            (println))]
+    ;; Print data rows
+    (doseq [row rows]
+      (print indent-str)
+      (when row-key-col
+        (print (format-cell row-key-col (first row))))
+      (doseq [[i col] (map-indexed vector columns)]
+        (let [data-idx (if row-key-col (inc i) i)]
+          (when (or row-key-col (pos? i))
+            (print " │ "))
+          (print (format-cell col (nth row data-idx nil)))))
+      (println))))
+
 (defn label-str
   "Format a label padded to primary width (32 chars).
   Returns a format-ready string without trailing colon."

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -370,16 +370,23 @@
 
 ;;; Bootstrap Stats
 
+(def ^:private default-bootstrap-stats
+  "Default statistics shown by bootstrap-stats view."
+  #{:median :spread})
+
 (defn print-bootstrap-stat
   "Print bootstrap statistics for a metric.
 
-  Output format:
-  1. Median with 95% CI
-  2. Mean with 95% CI
-  3. p10-p90 percentile spread"
+  The show-stats set controls which statistics are displayed:
+    :median - Median with 95% CI
+    :mean   - Mean with 95% CI
+    :spread - p10-p90 percentile spread
+
+  Default shows :median and :spread."
   [metric
    {:keys [mean quantiles]}
-   transforms]
+   transforms
+   show-stats]
   (let [{:keys [dimension label]} metric
         tform #(util/transform-sample-> % transforms)
         mean-val (tform (:point-estimate mean))
@@ -389,8 +396,9 @@
         median-ci (:estimate-quantiles median-est)
         p10-est (get quantiles 0.1)
         p90-est (get quantiles 0.9)
-        scale (* (:scale metric) scale)]
-    (when (and median-est (seq median-ci))
+        scale (* (:scale metric) scale)
+        show-stats (if (seq show-stats) (set show-stats) default-bootstrap-stats)]
+    (when (and (show-stats :median) median-est (seq median-ci))
       (println
        (format "%s %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
                (format-sublabel (str label " median"))
@@ -400,16 +408,17 @@
                (* scale (tform (-> median-ci second :value)))
                (-> median-ci first :alpha)
                (-> median-ci second :alpha))))
-    (println
-     (format "%s %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
-             (format-sublabel (str label " mean"))
-             (* scale mean-val)
-             units
-             (* scale (tform (-> mean-ci first :value)))
-             (* scale (tform (-> mean-ci second :value)))
-             (-> mean-ci first :alpha)
-             (-> mean-ci second :alpha)))
-    (when (and p10-est p90-est)
+    (when (show-stats :mean)
+      (println
+       (format "%s %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
+               (format-sublabel (str label " mean"))
+               (* scale mean-val)
+               units
+               (* scale (tform (-> mean-ci first :value)))
+               (* scale (tform (-> mean-ci second :value)))
+               (-> mean-ci first :alpha)
+               (-> mean-ci second :alpha))))
+    (when (and (show-stats :spread) p10-est p90-est)
       (println
        (format "%s [%.3g %.3g] %s (10th-90th percentile)"
                (format-sublabel (str label " spread"))
@@ -418,12 +427,19 @@
                units)))))
 
 (defn print-bootstrap-stats
+  "Print bootstrap statistics for all metrics.
+
+  View options:
+    :bootstrap-stats-id - key for bootstrap data (default :bootstrap-stats)
+    :show-stats         - set of stats to display: #{:median :mean :spread}
+                          Default: #{:median :spread}"
   [view data-map]
   (when-let [{:keys [analysis-map metric-configs transforms]}
              (get-analysis-context :bootstrap-stats-id :bootstrap-stats view data-map nil)]
-    (let [bootstrap (util/bootstrap analysis-map)]
+    (let [bootstrap (util/bootstrap analysis-map)
+          show-stats (:show-stats view)]
       (for-each-metric metric-configs bootstrap
-                       #(print-bootstrap-stat %1 %2 transforms)))))
+                       #(print-bootstrap-stat %1 %2 transforms show-stats)))))
 
 (defmethod view/bootstrap-stats* :print
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -20,7 +20,8 @@
    [criterium.util.invariant :refer [have have?]]
    [criterium.view :as view]
    [criterium.viewer.common.core :as core]
-   [criterium.viewer.common.shape :as shape]))
+   [criterium.viewer.common.shape :as shape]
+   [criterium.viewer.print.table :as table]))
 
 (set! *unchecked-math* false)
 
@@ -34,90 +35,9 @@
   "Secondary/detail label width for print viewer output."
   36)
 
-;;; Generic Table Printing
-
-(defn print-table
-  "Print a formatted table with box-drawing separators.
-
-  Takes a table specification map with:
-    :heading     - optional heading string printed before the table
-    :indent      - number of spaces to indent (default 2)
-    :row-key-col - optional {:header \"\" :width N} for leftmost row-key column
-    :columns     - vector of {:header \"Header\" :width N :align :right|:left}
-    :rows        - vector of row data, each row is a vector of cell strings
-                   If :row-key-col specified, first element is the row key
-
-  Cell alignment defaults to :right. Column widths are auto-calculated from
-  headers and data if not specified.
-
-  Example:
-    (print-table
-      {:heading \"My Table\"
-       :row-key-col {:header \"\" :width 8}
-       :columns [{:header \"A\"} {:header \"B\"}]
-       :rows [[\"key1\" \"val1\" \"val2\"]
-              [\"key2\" \"val3\" \"val4\"]]})"
-  [{:keys [heading indent row-key-col columns rows]
-    :or {indent 2}}]
-  (when heading
-    (println heading))
-  (let [indent-str (apply str (repeat indent \space))
-        ;; Calculate column widths if not provided
-        columns (mapv
-                 (fn [col-idx {:keys [header width] :as col}]
-                   (let [data-col-idx (if row-key-col (inc col-idx) col-idx)
-                         max-data-width (when (seq rows)
-                                          (apply max 0 (map #(count (str (nth % data-col-idx "")))
-                                                            rows)))
-                         calc-width (max (count header)
-                                         (or max-data-width 0))]
-                     (assoc col :width (or width calc-width))))
-                 (range)
-                 columns)
-        row-key-col (when row-key-col
-                      (let [{:keys [header width]} row-key-col
-                            max-key-width (when (seq rows)
-                                            (apply max 0 (map #(count (str (first %))) rows)))
-                            calc-width (max (count (or header ""))
-                                            (or max-key-width 0)
-                                            8)]
-                        (assoc row-key-col :width (or width calc-width))))
-        ;; Format a cell with alignment
-        format-cell (fn [{:keys [width align]} value]
-                      (let [align (or align :right)
-                            fmt (str "%" (when (= align :left) "-") width "s")]
-                        (format fmt (or value ""))))
-        ;; Print header row
-        _ (do
-            (print indent-str)
-            (when row-key-col
-              (print (format-cell row-key-col (:header row-key-col))))
-            (doseq [[i col] (map-indexed vector columns)]
-              (when (or row-key-col (pos? i))
-                (print " │ "))
-              (print (format-cell col (:header col))))
-            (println))
-        ;; Print separator line
-        _ (do
-            (print indent-str)
-            (when row-key-col
-              (print (apply str (repeat (:width row-key-col) "─"))))
-            (doseq [[i col] (map-indexed vector columns)]
-              (when (or row-key-col (pos? i))
-                (print "─┼─"))
-              (print (apply str (repeat (:width col) "─"))))
-            (println))]
-    ;; Print data rows
-    (doseq [row rows]
-      (print indent-str)
-      (when row-key-col
-        (print (format-cell row-key-col (first row))))
-      (doseq [[i col] (map-indexed vector columns)]
-        (let [data-idx (if row-key-col (inc i) i)]
-          (when (or row-key-col (pos? i))
-            (print " │ "))
-          (print (format-cell col (nth row data-idx nil)))))
-      (println))))
+(def print-table
+  "Alias to criterium.viewer.print.table/print-table for backwards compatibility."
+  table/print-table)
 
 (defn label-str
   "Format a label padded to primary width (32 chars).

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -57,6 +57,46 @@
   [label]
   (str (sublabel-str label) ":"))
 
+;;; Metric Iteration
+
+(defn for-each-metric
+  "Iterate over metrics, calling f for each with data present.
+
+  Extracts data from results using each metric's :path. Calls f only when
+  data is non-nil. Designed for the common print viewer pattern:
+    (doseq [mc metric-configs]
+      (when-let [data (get-in results (:path mc))]
+        (print-fn mc data)))
+
+  Arguments:
+    metric-configs - sequence of metric configs with :path keys
+    results        - nested map to look up data from (via get-in)
+    f              - function of (metric-config data)
+
+  Returns nil."
+  [metric-configs results f]
+  (doseq [mc metric-configs]
+    (when-let [data (get-in results (:path mc))]
+      (f mc data))))
+
+(defn for-each-metric-keyed
+  "Iterate over metrics, calling f for each with data present.
+
+  Like for-each-metric but uses (get results path) instead of get-in.
+  Use this when the results map has vector paths as keys:
+    {[:elapsed-time] {:data ...}}
+
+  Arguments:
+    metric-configs - sequence of metric configs with :path keys
+    results        - map with path vectors as keys
+    f              - function of (metric-config data)
+
+  Returns nil."
+  [metric-configs results f]
+  (doseq [mc metric-configs]
+    (when-let [data (get results (:path mc))]
+      (f mc data))))
+
 ;;; Analysis Context
 
 (defn get-analysis-context
@@ -132,8 +172,7 @@
 
 (defn print-stats
   [metrics stats transforms]
-  (doseq [metric metrics]
-    (print-stat metric (get-in stats (:path metric)) transforms)))
+  (for-each-metric metrics stats #(print-stat %1 %2 transforms)))
 
 (defmethod view/stats* :print
   [_ {:keys [stats-id metric-ids]} data-map]
@@ -172,8 +211,7 @@
   "Print min/max extremes for all metrics."
   [metrics stats transforms]
   (println (format-sublabel "Extremes"))
-  (doseq [metric metrics]
-    (print-extreme metric (get-in stats (:path metric)) transforms)))
+  (for-each-metric metrics stats #(print-extreme %1 %2 transforms)))
 
 (defmethod view/extremes* :print
   [_ {:keys [stats-id metric-ids]} data-map]
@@ -280,9 +318,8 @@
   (when-let [{:keys [analysis-map metric-configs transforms]}
              (get-analysis-context :bootstrap-stats-id :bootstrap-stats view data-map nil)]
     (let [bootstrap (util/bootstrap analysis-map)]
-      (doseq [metric metric-configs]
-        (when-let [stat (get-in bootstrap (:path metric))]
-          (print-bootstrap-stat metric stat transforms))))))
+      (for-each-metric metric-configs bootstrap
+                       #(print-bootstrap-stat %1 %2 transforms)))))
 
 (defmethod view/bootstrap-stats* :print
   [_ view data-map]
@@ -400,8 +437,8 @@
         metric-configs (metric/all-metric-configs metrics-defs)
         num-samples (have (:num-samples outliers-map))
         outliers (util/outliers outliers-map)]
-    (doseq [m metric-configs]
-      (print-outlier-count m num-samples (get-in outliers (:path m)) show-medcouple))))
+    (for-each-metric metric-configs outliers
+                     #(print-outlier-count %1 num-samples %2 show-medcouple))))
 
 (defmethod view/outlier-counts* :print
   [_ view data-map]
@@ -427,11 +464,10 @@
              (get-analysis-context :outlier-significance-id :outlier-significance
                                    view data-map (metric/type-pred :quantitative))]
     (let [outlier-sig (util/outlier-significance analysis-map)]
-      (doseq [m metric-configs]
-        (print-outlier-significance
-         m
-         (have seq (get-in outlier-sig (:path m))
-               {:metric m :outlier-sig outlier-sig}))))))
+      (for-each-metric
+       metric-configs outlier-sig
+       (fn [m data]
+         (print-outlier-significance m (have seq data {:metric m})))))))
 
 (defmethod view/outlier-significance* :print
   [_ view data-map]
@@ -603,10 +639,11 @@
             transforms (util/get-transforms data-map kde-id)
             kdes (:kdes kde-map)
             all-modes (when modes-map (:modes modes-map))]
-        (doseq [metric-config metric-configs]
-          (when-let [kde-data (get kdes (:path metric-config))]
-            (let [modes-data (when all-modes (get all-modes (:path metric-config)))]
-              (print-kde-metric metric-config kde-data modes-data transforms))))))))
+        (for-each-metric-keyed
+         metric-configs kdes
+         (fn [mc kde-data]
+           (let [modes-data (when all-modes (get all-modes (:path mc)))]
+             (print-kde-metric mc kde-data modes-data transforms))))))))
 
 ;;; Quantiles
 

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -35,6 +35,14 @@
   "Secondary/detail label width for print viewer output."
   36)
 
+(def ^:const label-indent
+  "Indent width for continuation lines after a label (label-width + 2 for ': ')."
+  (+ label-width 2))
+
+(def ^:const sublabel-indent
+  "Indent width for continuation lines after a sublabel (sublabel-width + 2 for ': ')."
+  (+ sublabel-width 2))
+
 (def print-table
   "Alias to criterium.viewer.print.table/print-table for backwards compatibility."
   table/print-table)
@@ -50,6 +58,18 @@
   Returns a format-ready string without trailing colon."
   [label]
   (format (str "%" sublabel-width "s") label))
+
+(defn label-indent-str
+  "Return a string of spaces matching label indent width (34 chars).
+  Use for continuation lines after a format-label line."
+  []
+  (format (str "%" label-indent "s") ""))
+
+(defn sublabel-indent-str
+  "Return a string of spaces matching sublabel indent width (38 chars).
+  Use for continuation lines after a format-sublabel line."
+  []
+  (format (str "%" sublabel-indent "s") ""))
 
 (defn format-label
   "Format a label with colon at primary width.
@@ -605,8 +625,8 @@
         (run!
          (fn [[x bin-count density]]
            (println
-            (format "%34s %-7.3f %5d  %-7.3g  %s"
-                    "" x (long bin-count) density
+            (format "%s %-7.3f %5d  %-7.3g  %s"
+                    (label-indent-str) x (long bin-count) density
                     (core/ascii-bar bin-count max-count bar-width))))
          (mapv vector (:centers h) (:counts h) (:density h))))
       (println))))
@@ -637,27 +657,27 @@
         n-modes (when modes-data (:n-modes modes-data))
         test-results (when modes-data (:test-results modes-data))]
     (println (format "%s KDE (n=%d)" (format-label label) n))
-    (println (format "%34s bandwidth: %s"
-                     ""
+    (println (format "%s bandwidth: %s"
+                     (label-indent-str)
                      (format/format-value dimension (* scale bw))))
     (when (seq modes)
-      (println (format "%34s modes: %d (validated: %s)"
-                       "" (count modes) (or n-modes "?")))
-      (println (format "%34s %12s %12s %12s %12s"
-                       "" "Location" "Density" "CI Lower" "CI Upper"))
+      (println (format "%s modes: %d (validated: %s)"
+                       (label-indent-str) (count modes) (or n-modes "?")))
+      (println (format "%s %12s %12s %12s %12s"
+                       (label-indent-str) "Location" "Density" "CI Lower" "CI Upper"))
       (doseq [mode modes]
         (let [[loc dens ci-lo ci-hi] (format-kde-mode mode metric-config transforms)]
-          (println (format "%34s %12s %12s %12s %12s"
-                           "" loc dens ci-lo ci-hi))))
+          (println (format "%s %12s %12s %12s %12s"
+                           (label-indent-str) loc dens ci-lo ci-hi))))
       (when test-results
         (let [{:keys [method p-values]} test-results
               method-name (case method
                             :acr "ACR"
                             :silverman "Silverman"
                             (name method))]
-          (println (format "%34s %s test p-values:" "" method-name))
+          (println (format "%s %s test p-values:" (label-indent-str) method-name))
           (doseq [k (sort (keys p-values))]
-            (println (format "%36s k=%d: p=%.4f" "" k (get p-values k)))))))
+            (println (format "%s k=%d: p=%.4f" (sublabel-str "") k (get p-values k)))))))
     (println)))
 
 (defmethod view/kde* :print

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -19,7 +19,8 @@
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have have?]]
    [criterium.view :as view]
-   [criterium.viewer.common.core :as core]))
+   [criterium.viewer.common.core :as core]
+   [criterium.viewer.common.shape :as shape]))
 
 (set! *unchecked-math* false)
 
@@ -481,18 +482,6 @@
     (<= mc 0.6) :moderately-right-skewed
     :else :strongly-right-skewed))
 
-(defn- format-skewness
-  "Format skewness classification for display."
-  [classification]
-  (case classification
-    :strongly-left-skewed "strongly left-skewed"
-    :moderately-left-skewed "moderately left-skewed"
-    :slightly-left-skewed "slightly left-skewed"
-    :symmetric "symmetric"
-    :slightly-right-skewed "slightly right-skewed"
-    :moderately-right-skewed "moderately right-skewed"
-    :strongly-right-skewed "strongly right-skewed"))
-
 (defn- format-outlier-method
   "Format outlier detection method for display."
   [method]
@@ -527,7 +516,7 @@
         (util/report "%s medcouple %.4f (%s)\n"
                      (format-label (:label metric-config))
                      mc
-                     (format-skewness classification))))))
+                     (shape/format-classification classification))))))
 
 (defn print-outlier-counts
   "Print outlier counts for all metrics.

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -142,6 +142,25 @@
   [label]
   (str (sublabel-str label) ":"))
 
+(defn format-labeled-value
+  "Format a labeled value for print output.
+
+  Returns string like '           Label: value'.
+
+  Arguments:
+    label   - label text (padded to standard width with colon)
+    value   - value to display after label
+    sublabel? - if true, use secondary width (36), else primary (32)
+
+  Example:
+    (println (format-labeled-value \"Elapsed\" \"123 ns\"))
+    ;;=>            Elapsed: 123 ns"
+  ([label value]
+   (format-labeled-value label value false))
+  ([label value sublabel?]
+   (str (if sublabel? (format-sublabel label) (format-label label))
+        " " value)))
+
 ;;; Metric Iteration
 
 (defn for-each-metric
@@ -220,12 +239,12 @@
     (when-let [a (metrics->values (:path m))]
       (when-let [v (arr/first-element a)]
         (println
-         (str
-          (format-sublabel (:label m))
-          " "
+         (format-labeled-value
+          (:label m)
           (if (number? v)
             (format/format-value (:dimension m) (* v (:scale m)))
-            v)))))))
+            v)
+          :sublabel))))))
 
 (defmethod view/metrics* :print
   [_ {:keys [samples-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -680,11 +680,15 @@
        (format "%s %s Histogram"
                (format-label (-> h :metric-config :label))
                (-> h :unit)))
-      (run!
-       (fn [[x bin-count density]]
-         (println
-          (format "%34s %-7.3f %5d  %-7.3g" "" x (long bin-count) density)))
-       (mapv vector (:centers h) (:counts h) (:density h)))
+      (let [max-count (double (apply max 1 (:counts h)))
+            bar-width (long 20)]
+        (run!
+         (fn [[x bin-count density]]
+           (println
+            (format "%34s %-7.3f %5d  %-7.3g  %s"
+                    "" x (long bin-count) density
+                    (core/ascii-bar bin-count max-count bar-width))))
+         (mapv vector (:centers h) (:counts h) (:density h))))
       (println))))
 
 ;;; KDE

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -295,7 +295,8 @@
 ;;; Extremes
 
 (defn print-extreme
-  "Print min and max values for a metric."
+  "Print min and max values for a metric in spread format.
+  Output: '{label} extremes [min max] unit'"
   [metric stat transforms]
   (when (and (:min-val stat) (:max-val stat))
     (let [stat (util/transform-vals-> stat transforms)
@@ -304,18 +305,16 @@
                         (* (:scale metric) (:min-val stat)))
           scale (* scale (:scale metric))]
       (println
-       (format
-        "%s %s %s - %s %s"
-        (format-label (:label metric))
-        (format/format-scaled (:min-val stat) scale)
-        unit
-        (format/format-scaled (:max-val stat) scale)
-        unit)))))
+       (format "%s [%.3g %.3g] %s"
+               (format-sublabel (str (:label metric) " extremes"))
+               (* scale (:min-val stat))
+               (* scale (:max-val stat))
+               unit)))))
 
 (defn print-extremes
-  "Print min/max extremes for all metrics."
+  "Print min/max extremes for all metrics.
+  Each metric gets its own line with 'label extremes' format."
   [metrics stats transforms]
-  (println (format-sublabel "Extremes"))
   (for-each-metric metrics stats #(print-extreme %1 %2 transforms)))
 
 (defmethod view/extremes* :print

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -516,29 +516,32 @@
         method (:outlier-method outliers)]
     (when (pos? sum)
       (util/report "%s Found %d outliers in %d samples (%.3g %%)%s\n"
-                   (format-label (:label metric-config))
+                   (format-sublabel (:label metric-config))
                    sum
                    num-samples
                    (* 100.0 (/ sum num-samples))
                    (if method (str " [" (format-outlier-method method) "]") ""))
       (doseq [[c v] (->> outlier-counts
-                         (filter #(pos? (val %))))]
+                         (filterv #(pos? (val %))))]
         (util/report
-         "                                 %12s\t %d (%2.4f %%)\n"
-         (name c) v (* 100.0 (/ v num-samples)))))
-    (when (and show-medcouple? mc)
-      (let [classification (skewness-classification mc)]
-        (util/report "%s medcouple %.4f (%s)\n"
-                     (format-label (:label metric-config))
-                     mc
-                     (shape/format-classification classification))))))
+         "                                     %12s\t %d (%2.4f %%)\n"
+         (name c) v (* 100.0 (/ v num-samples))))
+      (when (and show-medcouple? mc)
+        (let [classification (skewness-classification mc)]
+          (util/report "%s medcouple %.4f (%s)\n"
+                       (format-sublabel (:label metric-config))
+                       mc
+                       (shape/format-classification classification)))))))
 
 (defn print-outlier-counts
   "Print outlier counts for all metrics.
   Options:
     :outliers-id - key for outliers in data-map (default :outliers)
     :show-medcouple - if true, display medcouple and skewness classification"
-  [{:keys [outliers-id show-medcouple] :as _view} data-map]
+  [{:keys [outliers-id show-medcouple]
+    :or {show-medcouple true}
+    :as _view}
+   data-map]
   (let [outliers-id (or outliers-id :outliers)
         outliers-map (data-map outliers-id)
         metrics-defs (:metrics-defs outliers-map)
@@ -634,7 +637,7 @@
         samples (-> data-map :samples)
         fmt-val (fn [label n bs evals]
                   (format "%s %d samples with batch-size %d (%d evaluations)"
-                          (format-label label) n bs evals))]
+                          (format-sublabel label) n bs evals))]
     (println
      (fmt-val "Sample Scheme"
               (:num-samples samples)

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -23,6 +23,40 @@
 
 (set! *unchecked-math* false)
 
+;;; Label Formatting
+
+(def ^:const label-width
+  "Primary label width for print viewer output."
+  32)
+
+(def ^:const sublabel-width
+  "Secondary/detail label width for print viewer output."
+  36)
+
+(defn label-str
+  "Format a label padded to primary width (32 chars).
+  Returns a format-ready string without trailing colon."
+  [label]
+  (format (str "%" label-width "s") label))
+
+(defn sublabel-str
+  "Format a label padded to secondary width (36 chars).
+  Returns a format-ready string without trailing colon."
+  [label]
+  (format (str "%" sublabel-width "s") label))
+
+(defn format-label
+  "Format a label with colon at primary width.
+  Returns string like '           My Label:'"
+  [label]
+  (str (label-str label) ":"))
+
+(defn format-sublabel
+  "Format a label with colon at secondary width.
+  Returns string like '               My Sublabel:'"
+  [label]
+  (str (sublabel-str label) ":"))
+
 ;;; Metrics
 
 (defn print-metrics
@@ -31,9 +65,9 @@
     (when-let [a (metrics->values (:path m))]
       (when-let [v (arr/first-element a)]
         (println
-         (format
-          "%36s: %s"
-          (:label m)
+         (str
+          (format-sublabel (:label m))
+          " "
           (if (number? v)
             (format/format-value (:dimension m) (* v (:scale m)))
             v)))))))
@@ -58,8 +92,8 @@
           scale (* scale (:scale metric))]
       (println
        (format
-        "%32s: %s %s  3σ [%s %s]  min %s"
-        (:label metric)
+        "%s %s %s  3σ [%s %s]  min %s"
+        (format-label (:label metric))
         (format/format-scaled (:mean stat) scale)
         unit
         (format/format-scaled (:mean-minus-3sigma stat) scale)
@@ -97,8 +131,8 @@
           scale (* scale (:scale metric))]
       (println
        (format
-        "%32s: %s %s - %s %s"
-        (:label metric)
+        "%s %s %s - %s %s"
+        (format-label (:label metric))
         (format/format-scaled (:min-val stat) scale)
         unit
         (format/format-scaled (:max-val stat) scale)
@@ -107,7 +141,7 @@
 (defn print-extremes
   "Print min/max extremes for all metrics."
   [metrics stats transforms]
-  (println (format "%36s:" "Extremes"))
+  (println (format-sublabel "Extremes"))
   (doseq [metric metrics]
     (print-extreme metric (get-in stats (:path metric)) transforms)))
 
@@ -186,8 +220,8 @@
         scale (* (:scale metric) scale)]
     (when (and median-est (seq median-ci))
       (println
-       (format "%36s: %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
-               (str label " median")
+       (format "%s %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
+               (format-sublabel (str label " median"))
                (* scale (tform (:point-estimate median-est)))
                units
                (* scale (tform (-> median-ci first :value)))
@@ -195,8 +229,8 @@
                (-> median-ci first :alpha)
                (-> median-ci second :alpha))))
     (println
-     (format "%36s: %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
-             (str label " mean")
+     (format "%s %.3g %s CI [%.3g %.3g] (%.3f %.3f)"
+             (format-sublabel (str label " mean"))
              (* scale mean-val)
              units
              (* scale (tform (-> mean-ci first :value)))
@@ -205,8 +239,8 @@
              (-> mean-ci second :alpha)))
     (when (and p10-est p90-est)
       (println
-       (format "%36s: [%.3g %.3g] %s (10th-90th percentile)"
-               (str label " spread")
+       (format "%s [%.3g %.3g] %s (10th-90th percentile)"
+               (format-sublabel (str label " spread"))
                (* scale (tform (:point-estimate p10-est)))
                (* scale (tform (:point-estimate p90-est)))
                units)))))
@@ -310,8 +344,8 @@
         mc (:medcouple outliers)
         method (:outlier-method outliers)]
     (when (pos? sum)
-      (util/report "%32s: Found %d outliers in %d samples (%.3g %%)%s\n"
-                   (:label metric-config)
+      (util/report "%s Found %d outliers in %d samples (%.3g %%)%s\n"
+                   (format-label (:label metric-config))
                    sum
                    num-samples
                    (* 100.0 (/ sum num-samples))
@@ -323,8 +357,8 @@
          (name c) v (* 100.0 (/ v num-samples)))))
     (when (and show-medcouple? mc)
       (let [classification (skewness-classification mc)]
-        (util/report "%32s: medcouple %.4f (%s)\n"
-                     (:label metric-config)
+        (util/report "%s medcouple %.4f (%s)\n"
+                     (format-label (:label metric-config))
                      mc
                      (format-skewness classification))))))
 
@@ -389,8 +423,8 @@
         outlier-data (get-in outliers path)]
     (doseq [[i v] (sort-by first (:outliers outlier-data))]
       (println
-       (format "%36s[%5d] %s %s"
-               ""
+       (format "%s[%5d] %s %s"
+               (sublabel-str "")
                i
                (format/format-value
                 (:dimension metric)
@@ -411,12 +445,12 @@
         transforms (util/get-transforms data-map samples-id)]
 
     (println
-     (format "%32s: %d samples with batch-size %d"
-             "Samples"
+     (format "%s %d samples with batch-size %d"
+             (format-label "Samples")
              (:num-samples metrics-samples) (:batch-size metrics-samples)))
     (when outliers
       (doseq [metric metric-configs]
-        (println (format "%36s%s" "" (:label metric)))
+        (println (str (sublabel-str "") (:label metric)))
         (print-samples-with-outliers
          (util/metric->values metrics-samples)
          transforms
@@ -431,25 +465,24 @@
   (let [warmup (some-> data-map :warmup)
         est (some-> data-map :estimation)
         samples (-> data-map :samples)
-        fmt "%32s: %d samples with batch-size %d (%d evaluations)"]
+        fmt-val (fn [label n bs evals]
+                  (format "%s %d samples with batch-size %d (%d evaluations)"
+                          (format-label label) n bs evals))]
     (println
-     (format fmt
-             "Sample Scheme"
-             (:num-samples samples)
-             (:batch-size samples)
-             (:eval-count samples)))
+     (fmt-val "Sample Scheme"
+              (:num-samples samples)
+              (:batch-size samples)
+              (:eval-count samples)))
     (when warmup
       (println
-       (format fmt
-               "Warmup"
-               (:num-samples warmup) (:batch-size warmup)
-               (* (:num-samples warmup) (:batch-size warmup)))))
+       (fmt-val "Warmup"
+                (:num-samples warmup) (:batch-size warmup)
+                (* (:num-samples warmup) (:batch-size warmup)))))
     (when est
       (println
-       (format fmt
-               "Estimation"
-               (:num-samples est) (:batch-size est)
-               (* (:num-samples est) (:batch-size est)))))))
+       (fmt-val "Estimation"
+                (:num-samples est) (:batch-size est)
+                (* (:num-samples est) (:batch-size est)))))))
 
 ;;; Histogram
 
@@ -474,8 +507,8 @@
                            %)))]
     (doseq [h histograms]
       (println
-       (format "%32s: %s Histogram"
-               (-> h :metric-config :label)
+       (format "%s %s Histogram"
+               (format-label (-> h :metric-config :label))
                (-> h :unit)))
       (run!
        (fn [[x bin-count density]]
@@ -509,7 +542,7 @@
         modes (when modes-data (:modes modes-data))
         n-modes (when modes-data (:n-modes modes-data))
         test-results (when modes-data (:test-results modes-data))]
-    (println (format "%32s: KDE (n=%d)" label n))
+    (println (format "%s KDE (n=%d)" (format-label label) n))
     (println (format "%34s bandwidth: %s"
                      ""
                      (format/format-value dimension (* scale bw))))

--- a/bases/criterium/src/criterium/viewer/print/distribution.clj
+++ b/bases/criterium/src/criterium/viewer/print/distribution.clj
@@ -8,7 +8,8 @@
   (:require
    [criterium.metric :as metric]
    [criterium.view :as view]
-   [criterium.viewer.common.distribution :as common.distribution]))
+   [criterium.viewer.common.distribution :as common.distribution]
+   [criterium.viewer.print.core :as print-core]))
 
 (defn- format-gof-result
   "Format a goodness-of-fit test result."
@@ -60,8 +61,8 @@
   [metric-config fit-data]
   (let [{:keys [n warning distributions best-model]} fit-data
         {:keys [label]} metric-config]
-    (println (format "%32s: Distribution Models (n=%d%s)"
-                     label n
+    (println (format "%s Distribution Models (n=%d%s)"
+                     (print-core/format-label label) n
                      (if warning " - WARNING: small sample" "")))
     ;; Print each distribution result, best model first
     (when best-model
@@ -107,8 +108,8 @@
   (let [{:keys [best-model parameter-cis]} fit-data
         {:keys [label]} metric-config]
     (when (and best-model (get parameter-cis best-model))
-      (println (format "%32s: %s Parameter CIs"
-                       label
+      (println (format "%s %s Parameter CIs"
+                       (print-core/format-label label)
                        (get common.distribution/distribution-labels best-model (name best-model))))
       (print-parameter-cis best-model (get parameter-cis best-model))
       (println))))

--- a/bases/criterium/src/criterium/viewer/print/distribution.clj
+++ b/bases/criterium/src/criterium/viewer/print/distribution.clj
@@ -9,7 +9,7 @@
    [criterium.metric :as metric]
    [criterium.view :as view]
    [criterium.viewer.common.distribution :as common.distribution]
-   [criterium.viewer.print.core :as print-core]))
+   [criterium.viewer.print.core :as print-core :refer [for-each-metric-keyed]]))
 
 (defn- format-gof-result
   "Format a goodness-of-fit test result."
@@ -89,9 +89,8 @@
         (when (seq fits)
           (println "Distribution Model Comparison:")
           (if metric-configs
-            (doseq [mc metric-configs]
-              (when-let [fit-data (get fits (:path mc))]
-                (print-distribution-models-for-metric mc fit-data)))
+            (for-each-metric-keyed metric-configs fits
+                                   print-distribution-models-for-metric)
             ;; Fallback if no metric-configs available
             (doseq [[path fit-data] fits]
               (print-distribution-models-for-metric
@@ -130,9 +129,8 @@
         (when (seq fits)
           (println "Distribution Parameter Confidence Intervals:")
           (if metric-configs
-            (doseq [mc metric-configs]
-              (when-let [fit-data (get fits (:path mc))]
-                (print-distribution-parameter-cis-for-metric mc fit-data)))
+            (for-each-metric-keyed metric-configs fits
+                                   print-distribution-parameter-cis-for-metric)
             ;; Fallback if no metric-configs available
             (doseq [[path fit-data] fits]
               (print-distribution-parameter-cis-for-metric

--- a/bases/criterium/src/criterium/viewer/print/domain.clj
+++ b/bases/criterium/src/criterium/viewer/print/domain.clj
@@ -17,7 +17,8 @@
    [criterium.viewer.common.domain.comparison :as comparison]
    [criterium.viewer.common.domain.detection :as detection]
    [criterium.viewer.common.domain.extract :as extract]
-   [criterium.viewer.common.regression :as regression]))
+   [criterium.viewer.common.regression :as regression]
+   [criterium.viewer.print.core :as print.core]))
 
 (set! *unchecked-math* false)
 
@@ -101,33 +102,14 @@
   "Print a transposed table with implementation rows and metric columns.
   Takes {:heading :col-headers :rows} from prepare-*-table-transposed functions."
   [{:keys [heading col-headers rows]}]
-  (println heading)
-  (let [;; Calculate column widths
-        col-widths (mapv
-                    (fn [col-idx]
-                      (let [header (nth col-headers col-idx)
-                            values (map #(str (get % header "")) rows)]
-                        (apply max (count header) (map count values))))
-                    (range (count col-headers)))]
-    ;; Print header row
-    (print "  ")
-    (doseq [[i header] (map-indexed vector col-headers)]
-      (when (pos? i) (print " │ "))
-      (print (format (str "%" (nth col-widths i) "s") header)))
-    (println)
-    ;; Print separator
-    (print "  ")
-    (doseq [[i w] (map-indexed vector col-widths)]
-      (when (pos? i) (print "─┼─"))
-      (print (apply str (repeat w "─"))))
-    (println)
-    ;; Print data rows
-    (doseq [row rows]
-      (print "  ")
-      (doseq [[i header] (map-indexed vector col-headers)]
-        (when (pos? i) (print " │ "))
-        (print (format (str "%" (nth col-widths i) "s") (or (get row header) "-"))))
-      (println))))
+  (let [;; Convert rows from maps to vectors based on col-headers order
+        row-vectors (mapv (fn [row]
+                            (mapv #(or (get row %) "-") col-headers))
+                          rows)]
+    (print.core/print-table
+     {:heading heading
+      :columns (mapv (fn [h] {:header h}) col-headers)
+      :rows row-vectors})))
 
 ;;; Domain Extract Views
 
@@ -233,26 +215,14 @@
                              rows)
         col-headers (mapv format-axis-val columns)
         row-keys (mapv #(format-row-key (:key %)) rows)
-        col-widths (mapv (fn [col-idx]
-                           (apply max
-                                  (count (nth col-headers col-idx))
-                                  (map #(count (nth % col-idx)) formatted-vals)))
-                         (range (count columns)))
-        row-key-width (apply max 8 (map count row-keys))]
-    (println (format "Domain Comparison by %s: %s" (name axis) (pr-str metric)))
-    (print (format "  %s" (format (str "%" row-key-width "s") "")))
-    (doseq [[i header] (map-indexed vector col-headers)]
-      (print (format " │ %s" (format (str "%" (nth col-widths i) "s") header))))
-    (println)
-    (print (format "  %s" (apply str (repeat row-key-width "─"))))
-    (doseq [w col-widths]
-      (print (format "─┼─%s" (apply str (repeat w "─")))))
-    (println)
-    (doseq [[row-key vals] (map vector row-keys formatted-vals)]
-      (print (format "  %s" (format (str "%" row-key-width "s") row-key)))
-      (doseq [[i v] (map-indexed vector vals)]
-        (print (format " │ %s" (format (str "%" (nth col-widths i) "s") v))))
-      (println))))
+        table-rows (mapv (fn [row-key vals]
+                           (into [row-key] vals))
+                         row-keys formatted-vals)]
+    (print.core/print-table
+     {:heading (format "Domain Comparison by %s: %s" (name axis) (pr-str metric))
+      :row-key-col {:header ""}
+      :columns (mapv (fn [h] {:header h}) col-headers)
+      :rows table-rows})))
 
 (defn- print-single-metric-factor-table
   "Print single-metric comparison with factor display.
@@ -305,26 +275,14 @@
                                (mapv #(format-cell % row-key) col-specs))
                              all-row-keys)
         row-keys-formatted (mapv format-row-key all-row-keys)
-        col-widths (mapv (fn [col-idx]
-                           (apply max
-                                  (count (nth col-headers col-idx))
-                                  (map #(count (nth % col-idx)) formatted-rows)))
-                         (range (count col-specs)))
-        row-key-width (apply max 8 (map count row-keys-formatted))]
-    (println (format "Domain Comparison by %s: %s" (name axis) (pr-str metric)))
-    (print (format "  %s" (format (str "%" row-key-width "s") "")))
-    (doseq [[i header] (map-indexed vector col-headers)]
-      (print (format " │ %s" (format (str "%" (nth col-widths i) "s") header))))
-    (println)
-    (print (format "  %s" (apply str (repeat row-key-width "─"))))
-    (doseq [w col-widths]
-      (print (format "─┼─%s" (apply str (repeat w "─")))))
-    (println)
-    (doseq [[row-key vals] (map vector row-keys-formatted formatted-rows)]
-      (print (format "  %s" (format (str "%" row-key-width "s") row-key)))
-      (doseq [[i v] (map-indexed vector vals)]
-        (print (format " │ %s" (format (str "%" (nth col-widths i) "s") v))))
-      (println))))
+        table-rows (mapv (fn [row-key vals]
+                           (into [row-key] vals))
+                         row-keys-formatted formatted-rows)]
+    (print.core/print-table
+     {:heading (format "Domain Comparison by %s: %s" (name axis) (pr-str metric))
+      :row-key-col {:header ""}
+      :columns (mapv (fn [h] {:header h}) col-headers)
+      :rows table-rows})))
 
 (defn- print-multi-metric-comparison-table
   "Print multi-metric comparison with factor display.
@@ -356,19 +314,19 @@
                        {}
                        metrics)
         ;; Build columns: baseline metric (unit), other impl × for each metric
-        col-specs (mapcat (fn [metric-id]
-                            (let [metric-path (get-in metrics [metric-id :metric])]
-                              (cons {:type :baseline
-                                     :metric-id metric-id
-                                     :metric-path metric-path
-                                     :impl baseline-impl}
-                                    (map (fn [impl]
-                                           {:type :factor
-                                            :metric-id metric-id
-                                            :metric-path metric-path
-                                            :impl impl})
-                                         other-impls))))
-                          metric-ids)
+        col-specs (vec (mapcat (fn [metric-id]
+                                 (let [metric-path (get-in metrics [metric-id :metric])]
+                                   (cons {:type :baseline
+                                          :metric-id metric-id
+                                          :metric-path metric-path
+                                          :impl baseline-impl}
+                                         (map (fn [impl]
+                                                {:type :factor
+                                                 :metric-id metric-id
+                                                 :metric-path metric-path
+                                                 :impl impl})
+                                              other-impls))))
+                               metric-ids))
         ;; Format column headers
         col-headers (mapv (fn [{:keys [type metric-id impl]}]
                             (if (= type :baseline)
@@ -394,26 +352,14 @@
                                (mapv #(format-cell % row-key) col-specs))
                              all-row-keys)
         row-keys-formatted (mapv format-row-key all-row-keys)
-        col-widths (mapv (fn [col-idx]
-                           (apply max
-                                  (count (nth col-headers col-idx))
-                                  (map #(count (nth % col-idx)) formatted-rows)))
-                         (range (count col-specs)))
-        row-key-width (apply max 8 (map count row-keys-formatted))]
-    (println (format "Domain Comparison by %s" (name axis)))
-    (print (format "  %s" (format (str "%" row-key-width "s") "")))
-    (doseq [[i header] (map-indexed vector col-headers)]
-      (print (format " │ %s" (format (str "%" (nth col-widths i) "s") header))))
-    (println)
-    (print (format "  %s" (apply str (repeat row-key-width "─"))))
-    (doseq [w col-widths]
-      (print (format "─┼─%s" (apply str (repeat w "─")))))
-    (println)
-    (doseq [[row-key vals] (map vector row-keys-formatted formatted-rows)]
-      (print (format "  %s" (format (str "%" row-key-width "s") row-key)))
-      (doseq [[i v] (map-indexed vector vals)]
-        (print (format " │ %s" (format (str "%" (nth col-widths i) "s") v))))
-      (println))))
+        table-rows (mapv (fn [row-key vals]
+                           (into [row-key] vals))
+                         row-keys-formatted formatted-rows)]
+    (print.core/print-table
+     {:heading (format "Domain Comparison by %s" (name axis))
+      :row-key-col {:header ""}
+      :columns (mapv (fn [h] {:header h}) col-headers)
+      :rows table-rows})))
 
 (defmethod view/domain-comparison-table* :print
   [_ {:keys [comparison-id]} data-map]

--- a/bases/criterium/src/criterium/viewer/print/domain.clj
+++ b/bases/criterium/src/criterium/viewer/print/domain.clj
@@ -66,37 +66,19 @@
            (format/format-value dimension base-value)
            (format "%g" base-value)))))))
 
-(defn- sort-coords
+(defn- sort-data-by-coords
   "Sort coordinate-value pairs, using numeric sort when coord values are numbers."
   [data single-key-info]
-  (if single-key-info
-    (let [k (:key single-key-info)
-          all-numeric? (every? #(number? (get (first %) k)) data)]
-      (if all-numeric?
-        (sort-by #(get (first %) k) data)
-        (sort-by #(str (get (first %) k)) data)))
-    (sort-by #(str (first %)) data)))
+  (let [coords (map first data)
+        sorted-coords (core/sort-row-keys coords single-key-info)
+        coord-order (zipmap sorted-coords (range))]
+    (sort-by #(get coord-order (first %)) data)))
 
 (defn- format-coord-value
   "Format a coordinate for display, extracting the value for single-key maps."
   [coord single-key-info]
-  (if single-key-info
-    (str (get coord (:key single-key-info)))
-    (format-coord coord)))
-
-(defn- strip-uniform-axes
-  "Strip uniform-value axes from coordinates.
-  Only strips axes if doing so leaves at least one key in each coord.
-  Returns coords unchanged if any coord is not a map."
-  [coords]
-  (if-not (every? map? coords)
-    coords
-    (let [uniform-axes (core/detect-uniform-axes coords)
-          first-coord (first coords)
-          remaining-keys (count (apply dissoc first-coord uniform-axes))]
-      (if (and (seq uniform-axes) (pos? remaining-keys))
-        (mapv #(apply dissoc % uniform-axes) coords)
-        coords))))
+  (let [v (core/format-row-key-value coord single-key-info)]
+    (if (string? v) v (str v))))
 
 (defn- print-transposed-table
   "Print a transposed table with implementation rows and metric columns.
@@ -127,10 +109,10 @@
       (when extract
         (doseq [[_metric-id {:keys [metric data]}] (:metrics extract)]
           (let [raw-coords (map first data)
-                stripped-coords (strip-uniform-axes raw-coords)
+                stripped-coords (core/strip-uniform-axes raw-coords)
                 coord-map (zipmap raw-coords stripped-coords)
                 single-key-info (core/single-key-coord-info stripped-coords)
-                sorted-data (sort-coords data single-key-info)]
+                sorted-data (sort-data-by-coords data single-key-info)]
             (println (format "Domain Extract: %s" (pr-str metric)))
             (doseq [[coord value] sorted-data]
               (let [display-coord (get coord-map coord coord)]

--- a/bases/criterium/src/criterium/viewer/print/domain.clj
+++ b/bases/criterium/src/criterium/viewer/print/domain.clj
@@ -18,7 +18,7 @@
    [criterium.viewer.common.domain.detection :as detection]
    [criterium.viewer.common.domain.extract :as extract]
    [criterium.viewer.common.regression :as regression]
-   [criterium.viewer.print.core :as print.core]))
+   [criterium.viewer.print.table :as table]))
 
 (set! *unchecked-math* false)
 
@@ -88,7 +88,7 @@
         row-vectors (mapv (fn [row]
                             (mapv #(or (get row %) "-") col-headers))
                           rows)]
-    (print.core/print-table
+    (table/print-table
      {:heading heading
       :columns (mapv (fn [h] {:header h}) col-headers)
       :rows row-vectors})))
@@ -200,7 +200,7 @@
         table-rows (mapv (fn [row-key vals]
                            (into [row-key] vals))
                          row-keys formatted-vals)]
-    (print.core/print-table
+    (table/print-table
      {:heading (format "Domain Comparison by %s: %s" (name axis) (pr-str metric))
       :row-key-col {:header ""}
       :columns (mapv (fn [h] {:header h}) col-headers)
@@ -260,7 +260,7 @@
         table-rows (mapv (fn [row-key vals]
                            (into [row-key] vals))
                          row-keys-formatted formatted-rows)]
-    (print.core/print-table
+    (table/print-table
      {:heading (format "Domain Comparison by %s: %s" (name axis) (pr-str metric))
       :row-key-col {:header ""}
       :columns (mapv (fn [h] {:header h}) col-headers)
@@ -337,7 +337,7 @@
         table-rows (mapv (fn [row-key vals]
                            (into [row-key] vals))
                          row-keys-formatted formatted-rows)]
-    (print.core/print-table
+    (table/print-table
      {:heading (format "Domain Comparison by %s" (name axis))
       :row-key-col {:header ""}
       :columns (mapv (fn [h] {:header h}) col-headers)

--- a/bases/criterium/src/criterium/viewer/print/modal.clj
+++ b/bases/criterium/src/criterium/viewer/print/modal.clj
@@ -5,7 +5,8 @@
   (:require
    [clojure.string :as str]
    [criterium.view :as view]
-   [criterium.viewer.common.modal :as modal]))
+   [criterium.viewer.common.modal :as modal]
+   [criterium.viewer.print.core :as print-core]))
 
 (defmethod view/multimodal-warning* :print
   [_ {:keys [modes-id]} data-map]
@@ -13,13 +14,13 @@
    data-map modes-id
    (fn [{:keys [metric-config modes transforms]}]
      (println
-      (format "%32s: Multimodal distribution detected"
-              (:label metric-config)))
+      (format "%s Multimodal distribution detected"
+              (print-core/format-label (:label metric-config))))
      (when (seq modes)
        (let [locations (map #(modal/format-mode-location
                               (:location %)
                               metric-config
                               transforms)
                             modes)]
-         (println (format "%32s  Mode locations: %s" ""
+         (println (format "%s  Mode locations: %s" (print-core/label-str "")
                           (str/join ", " locations))))))))

--- a/bases/criterium/src/criterium/viewer/print/modal.clj
+++ b/bases/criterium/src/criterium/viewer/print/modal.clj
@@ -15,12 +15,12 @@
    (fn [{:keys [metric-config modes transforms]}]
      (println
       (format "%s Multimodal distribution detected"
-              (print-core/format-label (:label metric-config))))
+              (print-core/format-sublabel (:label metric-config))))
      (when (seq modes)
        (let [locations (map #(modal/format-mode-location
                               (:location %)
                               metric-config
                               transforms)
                             modes)]
-         (println (format "%s  Mode locations: %s" (print-core/label-str "")
+         (println (format "%s  Mode locations: %s" (print-core/sublabel-str "")
                           (str/join ", " locations))))))))

--- a/bases/criterium/src/criterium/viewer/print/shape.clj
+++ b/bases/criterium/src/criterium/viewer/print/shape.clj
@@ -10,37 +10,6 @@
    [criterium.viewer.common.shape :as shape]
    [criterium.viewer.print.core :as print-core :refer [get-analysis-context]]))
 
-(defn- format-skewness-class
-  "Format skewness classification for display."
-  [classification]
-  (case classification
-    :strongly-left-skewed "strongly left-skewed"
-    :moderately-left-skewed "moderately left-skewed"
-    :slightly-left-skewed "slightly left-skewed"
-    :symmetric "symmetric"
-    :slightly-right-skewed "slightly right-skewed"
-    :moderately-right-skewed "moderately right-skewed"
-    :strongly-right-skewed "strongly right-skewed"
-    (name classification)))
-
-(defn- format-kurtosis-class
-  "Format kurtosis classification for display."
-  [classification]
-  (case classification
-    :heavy-tails "heavy tails (leptokurtic)"
-    :light-tails "light tails (platykurtic)"
-    :normal-tails "normal tails (mesokurtic)"
-    (name classification)))
-
-(defn- format-cv-class
-  "Format CV classification for display."
-  [classification]
-  (case classification
-    :low-variability "low variability"
-    :moderate-variability "moderate variability"
-    :high-variability "high variability"
-    (name classification)))
-
 (defn print-shape-stats
   "Print shape statistics (skewness, kurtosis, CV) for bootstrap results."
   [view data-map]
@@ -56,13 +25,19 @@
                         cv cv-class]} shape-data]
           (println
            (format "%s skewness %s (%s)"
-                   (print-core/format-label metric) skewness (format-skewness-class skewness-class)))
+                   (print-core/format-label metric)
+                   skewness
+                   (shape/format-classification skewness-class)))
           (println
            (format "%s  kurtosis %s (%s)"
-                   (print-core/label-str "") kurtosis (format-kurtosis-class kurtosis-class)))
+                   (print-core/label-str "")
+                   kurtosis
+                   (shape/format-classification kurtosis-class)))
           (println
            (format "%s  CV %s (%s)"
-                   (print-core/label-str "") cv (format-cv-class cv-class))))))))
+                   (print-core/label-str "")
+                   cv
+                   (shape/format-classification cv-class))))))))
 
 (defmethod view/shape-stats* :print
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/shape.clj
+++ b/bases/criterium/src/criterium/viewer/print/shape.clj
@@ -14,13 +14,13 @@
   "Format skewness classification for display."
   [classification]
   (case classification
-    :highly-left-skewed "highly left-skewed"
+    :strongly-left-skewed "strongly left-skewed"
     :moderately-left-skewed "moderately left-skewed"
     :slightly-left-skewed "slightly left-skewed"
     :symmetric "symmetric"
     :slightly-right-skewed "slightly right-skewed"
     :moderately-right-skewed "moderately right-skewed"
-    :highly-right-skewed "highly right-skewed"
+    :strongly-right-skewed "strongly right-skewed"
     (name classification)))
 
 (defn- format-kurtosis-class

--- a/bases/criterium/src/criterium/viewer/print/shape.clj
+++ b/bases/criterium/src/criterium/viewer/print/shape.clj
@@ -16,26 +16,25 @@
   (when-let [{:keys [analysis-map metric-configs]}
              (get-analysis-context :bootstrap-stats-id :bootstrap-stats view data-map
                                    (metric/type-pred :quantitative))]
-    (let [bootstrap (util/bootstrap analysis-map)
+    (let [bootstrap  (util/bootstrap analysis-map)
           shape-data (shape/shape-stats-data metric-configs bootstrap)]
       (when (seq shape-data)
-        (println "Shape Statistics:")
         (doseq [{:keys [metric skewness skewness-class
                         kurtosis kurtosis-class
                         cv cv-class]} shape-data]
           (println
-           (format "%s skewness %s (%s)"
-                   (print-core/format-label metric)
+           (format "%s %s (%s)"
+                   (print-core/format-sublabel (str metric " skewness"))
                    skewness
                    (shape/format-classification skewness-class)))
           (println
-           (format "%s  kurtosis %s (%s)"
-                   (print-core/label-str "")
+           (format "%s %s (%s)"
+                   (print-core/format-sublabel "kurtosis")
                    kurtosis
                    (shape/format-classification kurtosis-class)))
           (println
-           (format "%s  CV %s (%s)"
-                   (print-core/label-str "")
+           (format "%s %s (%s)"
+                   (print-core/format-sublabel "CV")
                    cv
                    (shape/format-classification cv-class))))))))
 

--- a/bases/criterium/src/criterium/viewer/print/shape.clj
+++ b/bases/criterium/src/criterium/viewer/print/shape.clj
@@ -7,7 +7,8 @@
    [criterium.metric :as metric]
    [criterium.util.helpers :as util]
    [criterium.view :as view]
-   [criterium.viewer.common.shape :as shape]))
+   [criterium.viewer.common.shape :as shape]
+   [criterium.viewer.print.core :as print-core]))
 
 (defn- format-skewness-class
   "Format skewness classification for display."
@@ -58,14 +59,14 @@
                           kurtosis kurtosis-class
                           cv cv-class]} shape-data]
             (println
-             (format "%32s: skewness %s (%s)"
-                     metric skewness (format-skewness-class skewness-class)))
+             (format "%s skewness %s (%s)"
+                     (print-core/format-label metric) skewness (format-skewness-class skewness-class)))
             (println
-             (format "%32s  kurtosis %s (%s)"
-                     "" kurtosis (format-kurtosis-class kurtosis-class)))
+             (format "%s  kurtosis %s (%s)"
+                     (print-core/label-str "") kurtosis (format-kurtosis-class kurtosis-class)))
             (println
-             (format "%32s  CV %s (%s)"
-                     "" cv (format-cv-class cv-class)))))))))
+             (format "%s  CV %s (%s)"
+                     (print-core/label-str "") cv (format-cv-class cv-class)))))))))
 
 (defmethod view/shape-stats* :print
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/shape.clj
+++ b/bases/criterium/src/criterium/viewer/print/shape.clj
@@ -8,7 +8,7 @@
    [criterium.util.helpers :as util]
    [criterium.view :as view]
    [criterium.viewer.common.shape :as shape]
-   [criterium.viewer.print.core :as print-core]))
+   [criterium.viewer.print.core :as print-core :refer [get-analysis-context]]))
 
 (defn- format-skewness-class
   "Format skewness classification for display."
@@ -43,30 +43,26 @@
 
 (defn print-shape-stats
   "Print shape statistics (skewness, kurtosis, CV) for bootstrap results."
-  [{:keys [bootstrap-stats-id] :as _view} data-map]
-  (let [bootstrap-stats-id (or bootstrap-stats-id :bootstrap-stats)
-        bootstrap-map (data-map bootstrap-stats-id)]
-    (when bootstrap-map
-      (let [metrics-defs (-> (:metrics-defs bootstrap-map)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-            metric-configs (metric/all-metric-configs metrics-defs)
-            bootstrap (util/bootstrap bootstrap-map)
-            shape-data (shape/shape-stats-data metric-configs bootstrap)]
-        (when (seq shape-data)
-          (println "Shape Statistics:")
-          (doseq [{:keys [metric skewness skewness-class
-                          kurtosis kurtosis-class
-                          cv cv-class]} shape-data]
-            (println
-             (format "%s skewness %s (%s)"
-                     (print-core/format-label metric) skewness (format-skewness-class skewness-class)))
-            (println
-             (format "%s  kurtosis %s (%s)"
-                     (print-core/label-str "") kurtosis (format-kurtosis-class kurtosis-class)))
-            (println
-             (format "%s  CV %s (%s)"
-                     (print-core/label-str "") cv (format-cv-class cv-class)))))))))
+  [view data-map]
+  (when-let [{:keys [analysis-map metric-configs]}
+             (get-analysis-context :bootstrap-stats-id :bootstrap-stats view data-map
+                                   (metric/type-pred :quantitative))]
+    (let [bootstrap (util/bootstrap analysis-map)
+          shape-data (shape/shape-stats-data metric-configs bootstrap)]
+      (when (seq shape-data)
+        (println "Shape Statistics:")
+        (doseq [{:keys [metric skewness skewness-class
+                        kurtosis kurtosis-class
+                        cv cv-class]} shape-data]
+          (println
+           (format "%s skewness %s (%s)"
+                   (print-core/format-label metric) skewness (format-skewness-class skewness-class)))
+          (println
+           (format "%s  kurtosis %s (%s)"
+                   (print-core/label-str "") kurtosis (format-kurtosis-class kurtosis-class)))
+          (println
+           (format "%s  CV %s (%s)"
+                   (print-core/label-str "") cv (format-cv-class cv-class))))))))
 
 (defmethod view/shape-stats* :print
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/table.clj
+++ b/bases/criterium/src/criterium/viewer/print/table.clj
@@ -1,0 +1,89 @@
+(ns criterium.viewer.print.table
+  "Print viewer table formatting.
+
+  Provides generic table printing with box-drawing separators.")
+
+(set! *unchecked-math* false)
+
+(defn print-table
+  "Print a formatted table with box-drawing separators.
+
+  Takes a table specification map with:
+    :heading     - optional heading string printed before the table
+    :indent      - number of spaces to indent (default 2)
+    :row-key-col - optional {:header \"\" :width N} for leftmost row-key column
+    :columns     - vector of {:header \"Header\" :width N :align :right|:left}
+    :rows        - vector of row data, each row is a vector of cell strings
+                   If :row-key-col specified, first element is the row key
+
+  Cell alignment defaults to :right. Column widths are auto-calculated from
+  headers and data if not specified.
+
+  Example:
+    (print-table
+      {:heading \"My Table\"
+       :row-key-col {:header \"\" :width 8}
+       :columns [{:header \"A\"} {:header \"B\"}]
+       :rows [[\"key1\" \"val1\" \"val2\"]
+              [\"key2\" \"val3\" \"val4\"]]})"
+  [{:keys [heading indent row-key-col columns rows]
+    :or {indent 2}}]
+  (when heading
+    (println heading))
+  (let [indent-str (apply str (repeat indent \space))
+        ;; Calculate column widths if not provided
+        columns (mapv
+                 (fn [col-idx {:keys [header width] :as col}]
+                   (let [data-col-idx (if row-key-col (inc col-idx) col-idx)
+                         max-data-width (when (seq rows)
+                                          (apply max 0 (map #(count (str (nth % data-col-idx "")))
+                                                            rows)))
+                         calc-width (max (count header)
+                                         (or max-data-width 0))]
+                     (assoc col :width (or width calc-width))))
+                 (range)
+                 columns)
+        row-key-col (when row-key-col
+                      (let [{:keys [header width]} row-key-col
+                            max-key-width (when (seq rows)
+                                            (apply max 0 (map #(count (str (first %))) rows)))
+                            calc-width (max (count (or header ""))
+                                            (or max-key-width 0)
+                                            8)]
+                        (assoc row-key-col :width (or width calc-width))))
+        ;; Format a cell with alignment
+        format-cell (fn [{:keys [width align]} value]
+                      (let [align (or align :right)
+                            fmt (str "%" (when (= align :left) "-") width "s")]
+                        (format fmt (or value ""))))
+        ;; Print header row
+        _ (do
+            (print indent-str)
+            (when row-key-col
+              (print (format-cell row-key-col (:header row-key-col))))
+            (doseq [[i col] (map-indexed vector columns)]
+              (when (or row-key-col (pos? i))
+                (print " │ "))
+              (print (format-cell col (:header col))))
+            (println))
+        ;; Print separator line
+        _ (do
+            (print indent-str)
+            (when row-key-col
+              (print (apply str (repeat (:width row-key-col) "─"))))
+            (doseq [[i col] (map-indexed vector columns)]
+              (when (or row-key-col (pos? i))
+                (print "─┼─"))
+              (print (apply str (repeat (:width col) "─"))))
+            (println))]
+    ;; Print data rows
+    (doseq [row rows]
+      (print indent-str)
+      (when row-key-col
+        (print (format-cell row-key-col (first row))))
+      (doseq [[i col] (map-indexed vector columns)]
+        (let [data-idx (if row-key-col (inc i) i)]
+          (when (or row-key-col (pos? i))
+            (print " │ "))
+          (print (format-cell col (nth row data-idx nil)))))
+      (println))))

--- a/bases/criterium/src/criterium/viewer/print/tail.clj
+++ b/bases/criterium/src/criterium/viewer/print/tail.clj
@@ -12,7 +12,8 @@
    [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.view :as view]
-   [criterium.viewer.common.core :as core]))
+   [criterium.viewer.common.core :as core]
+   [criterium.viewer.print.core :as print-core]))
 
 (set! *unchecked-math* false)
 
@@ -44,9 +45,9 @@
       (when-let [tail-data (get tail-results (:path mc))]
         (let [summary-rows (core/tail-summary-table tail-data transforms)]
           (when (seq summary-rows)
-            (println (format "%32s:" (:label mc)))
+            (println (print-core/format-label (:label mc)))
             (doseq [{:keys [parameter value]} summary-rows]
-              (println (format "%32s  %s: %s" "" parameter value)))))))
+              (println (format "%s  %s: %s" (print-core/label-str "") parameter value)))))))
     (println)))
 
 (defmethod view/tail-summary* :print
@@ -78,11 +79,11 @@
             (let [sorted-ratios (sort-by first tail-ratios)]
               (doseq [[i [rname rval]] (map-indexed vector sorted-ratios)]
                 (if (zero? i)
-                  (println (format "%32s: %s"
-                                   (str (:label mc) " tail ratios")
+                  (println (format "%s %s"
+                                   (print-core/format-label (str (:label mc) " tail ratios"))
                                    (format-tail-ratio [rname rval] empirical-quantiles)))
-                  (println (format "%32s  %s"
-                                   ""
+                  (println (format "%s  %s"
+                                   (print-core/label-str "")
                                    (format-tail-ratio [rname rval] empirical-quantiles))))))))))
     (println)))
 
@@ -100,13 +101,13 @@
       (when-let [tail-data (get tail-results (:path mc))]
         (let [{:keys [high-quantiles]} tail-data]
           (when (seq high-quantiles)
-            (println (format "%32s:" (:label mc)))
+            (println (print-core/format-label (:label mc)))
             (doseq [[q val] (sort-by first high-quantiles)]
               (let [tval (util/transform-sample-> val transforms)
                     [scale unit] (format/scale :time tval)
                     scaled (* scale tval)]
-                (println (format "%32s  p%.4g = %s %s"
-                                 ""
+                (println (format "%s  p%.4g = %s %s"
+                                 (print-core/label-str "")
                                  (* q 100)
                                  (format/format-scaled scaled 1.0)
                                  unit))))))))

--- a/bases/criterium/src/criterium/viewer/print/tail.clj
+++ b/bases/criterium/src/criterium/viewer/print/tail.clj
@@ -13,7 +13,9 @@
    [criterium.util.helpers :as util]
    [criterium.view :as view]
    [criterium.viewer.common.core :as core]
-   [criterium.viewer.print.core :as print-core :refer [get-analysis-context]]))
+   [criterium.viewer.print.core
+    :as print-core
+    :refer [get-analysis-context for-each-metric-keyed]]))
 
 (set! *unchecked-math* false)
 
@@ -30,19 +32,23 @@
          :metric-configs metric-configs
          :transforms transforms}))))
 
+(defn- print-tail-summary-metric
+  "Print GPD/Hill summary for a single metric."
+  [mc tail-data transforms]
+  (let [summary-rows (core/tail-summary-table tail-data transforms)]
+    (when (seq summary-rows)
+      (println (print-core/format-label (:label mc)))
+      (doseq [{:keys [parameter value]} summary-rows]
+        (println (format "%s  %s: %s" (print-core/label-str "") parameter value))))))
+
 (defn print-tail-summary
   "Print GPD/Hill summary statistics for all metrics."
   [view data-map]
   (when-let [{:keys [tail-results metric-configs transforms]}
              (get-tail-context view data-map)]
     (println "Tail Summary:")
-    (doseq [mc metric-configs]
-      (when-let [tail-data (get tail-results (:path mc))]
-        (let [summary-rows (core/tail-summary-table tail-data transforms)]
-          (when (seq summary-rows)
-            (println (print-core/format-label (:label mc)))
-            (doseq [{:keys [parameter value]} summary-rows]
-              (println (format "%s  %s: %s" (print-core/label-str "") parameter value)))))))
+    (for-each-metric-keyed metric-configs tail-results
+                           #(print-tail-summary-metric %1 %2 transforms))
     (println)))
 
 (defmethod view/tail-summary* :print
@@ -61,30 +67,49 @@
                       ratio-val (double p999) (double p95))
     (format "%s = %.3f" (name ratio-name) ratio-val)))
 
+(defn- print-tail-ratios-metric
+  "Print tail ratios for a single metric."
+  [mc tail-data]
+  (let [{:keys [tail-ratios empirical-quantiles]} tail-data]
+    (when (and tail-ratios (seq tail-ratios))
+      (let [sorted-ratios (sort-by first tail-ratios)]
+        (doseq [[i [rname rval]] (map-indexed vector sorted-ratios)]
+          (if (zero? i)
+            (println (format "%s %s"
+                             (print-core/format-label (str (:label mc) " tail ratios"))
+                             (format-tail-ratio [rname rval] empirical-quantiles)))
+            (println (format "%s  %s"
+                             (print-core/label-str "")
+                             (format-tail-ratio [rname rval] empirical-quantiles)))))))))
+
 (defn print-tail-ratios
   "Print tail ratio statistics for all metrics."
   [view data-map]
   (when-let [{:keys [tail-results metric-configs]}
              (get-tail-context view data-map)]
     (println "Tail Ratios:")
-    (doseq [mc metric-configs]
-      (when-let [tail-data (get tail-results (:path mc))]
-        (let [{:keys [tail-ratios empirical-quantiles]} tail-data]
-          (when (and tail-ratios (seq tail-ratios))
-            (let [sorted-ratios (sort-by first tail-ratios)]
-              (doseq [[i [rname rval]] (map-indexed vector sorted-ratios)]
-                (if (zero? i)
-                  (println (format "%s %s"
-                                   (print-core/format-label (str (:label mc) " tail ratios"))
-                                   (format-tail-ratio [rname rval] empirical-quantiles)))
-                  (println (format "%s  %s"
-                                   (print-core/label-str "")
-                                   (format-tail-ratio [rname rval] empirical-quantiles))))))))))
+    (for-each-metric-keyed metric-configs tail-results print-tail-ratios-metric)
     (println)))
 
 (defmethod view/tail-ratios* :print
   [_ view data-map]
   (print-tail-ratios view data-map))
+
+(defn- print-tail-high-quantiles-metric
+  "Print high quantile estimates for a single metric."
+  [mc tail-data transforms]
+  (let [{:keys [high-quantiles]} tail-data]
+    (when (seq high-quantiles)
+      (println (print-core/format-label (:label mc)))
+      (doseq [[q val] (sort-by first high-quantiles)]
+        (let [tval (util/transform-sample-> val transforms)
+              [scale unit] (format/scale :time tval)
+              scaled (* scale tval)]
+          (println (format "%s  p%.4g = %s %s"
+                           (print-core/label-str "")
+                           (* q 100)
+                           (format/format-scaled scaled 1.0)
+                           unit)))))))
 
 (defn print-tail-high-quantiles
   "Print high quantile estimates from GPD extrapolation for all metrics."
@@ -92,20 +117,8 @@
   (when-let [{:keys [tail-results metric-configs transforms]}
              (get-tail-context view data-map)]
     (println "High Quantile Estimates (GPD):")
-    (doseq [mc metric-configs]
-      (when-let [tail-data (get tail-results (:path mc))]
-        (let [{:keys [high-quantiles]} tail-data]
-          (when (seq high-quantiles)
-            (println (print-core/format-label (:label mc)))
-            (doseq [[q val] (sort-by first high-quantiles)]
-              (let [tval (util/transform-sample-> val transforms)
-                    [scale unit] (format/scale :time tval)
-                    scaled (* scale tval)]
-                (println (format "%s  p%.4g = %s %s"
-                                 (print-core/label-str "")
-                                 (* q 100)
-                                 (format/format-scaled scaled 1.0)
-                                 unit))))))))
+    (for-each-metric-keyed metric-configs tail-results
+                           #(print-tail-high-quantiles-metric %1 %2 transforms))
     (println)))
 
 (defmethod view/tail-high-quantiles* :print

--- a/bases/criterium/src/criterium/viewer/print/tail.clj
+++ b/bases/criterium/src/criterium/viewer/print/tail.clj
@@ -13,33 +13,28 @@
    [criterium.util.helpers :as util]
    [criterium.view :as view]
    [criterium.viewer.common.core :as core]
-   [criterium.viewer.print.core :as print-core]))
+   [criterium.viewer.print.core :as print-core :refer [get-analysis-context]]))
 
 (set! *unchecked-math* false)
 
-(defn- get-tail-analysis-context
-  "Extract common context for tail analysis views.
+(defn- get-tail-context
+  "Extract tail analysis context using common helper plus tail-specific data.
   Returns map with :tail-results, :metric-configs, :transforms, or nil if no data."
-  [{:keys [tail-analysis-id]} data-map]
-  (let [tail-analysis-id (or tail-analysis-id :tail-analysis)
-        tail-analysis-map (data-map tail-analysis-id)]
-    (when tail-analysis-map
-      (let [metrics-defs (-> (:metrics-defs tail-analysis-map)
-                             (metric/filter-metrics
-                              (metric/type-pred :quantitative)))
-            metric-configs (metric/all-metric-configs metrics-defs)
-            tail-results (:tail-analysis tail-analysis-map)
-            transforms (util/get-transforms data-map tail-analysis-id)]
-        (when (seq tail-results)
-          {:tail-results tail-results
-           :metric-configs metric-configs
-           :transforms transforms})))))
+  [view data-map]
+  (when-let [{:keys [analysis-map metric-configs transforms]}
+             (get-analysis-context :tail-analysis-id :tail-analysis view data-map
+                                   (metric/type-pred :quantitative))]
+    (let [tail-results (:tail-analysis analysis-map)]
+      (when (seq tail-results)
+        {:tail-results tail-results
+         :metric-configs metric-configs
+         :transforms transforms}))))
 
 (defn print-tail-summary
   "Print GPD/Hill summary statistics for all metrics."
   [view data-map]
   (when-let [{:keys [tail-results metric-configs transforms]}
-             (get-tail-analysis-context view data-map)]
+             (get-tail-context view data-map)]
     (println "Tail Summary:")
     (doseq [mc metric-configs]
       (when-let [tail-data (get tail-results (:path mc))]
@@ -70,7 +65,7 @@
   "Print tail ratio statistics for all metrics."
   [view data-map]
   (when-let [{:keys [tail-results metric-configs]}
-             (get-tail-analysis-context view data-map)]
+             (get-tail-context view data-map)]
     (println "Tail Ratios:")
     (doseq [mc metric-configs]
       (when-let [tail-data (get tail-results (:path mc))]
@@ -95,7 +90,7 @@
   "Print high quantile estimates from GPD extrapolation for all metrics."
   [view data-map]
   (when-let [{:keys [tail-results metric-configs transforms]}
-             (get-tail-analysis-context view data-map)]
+             (get-tail-context view data-map)]
     (println "High Quantile Estimates (GPD):")
     (doseq [mc metric-configs]
       (when-let [tail-data (get tail-results (:path mc))]

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -18,7 +18,7 @@
   (testing "time with stats"
     (let [out (with-out-str (bench/bench 1 :limit-time-s 0.1))]
       (testing "outputs extremes on stdout"
-        (is (re-find #"Extremes:" out)))))
+        (is (re-find #"extremes:" out)))))
   (testing "time with one-shot"
     (let [out (with-out-str (bench/bench 1 :collect-plan :one-shot))]
       (testing "outputs statistics on stdout"

--- a/bases/criterium/test/criterium/viewer/common/allocation_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/allocation_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
-   [criterium.viewer.common.allocation :as allocation]))
+   [criterium.viewer.common.allocation :as allocation]
+   [criterium.viewer.common.core :as core]))
 
 ;; Tests for ASCII treemap rendering functions.
 ;; Verifies ascii-bar generates proportional bars and render-ascii-treemap
@@ -37,24 +38,69 @@
 (deftest ascii-bar-test
   (testing "ascii-bar"
     (testing "produces correct proportional bars"
-      (is (= "████████████████████" (allocation/ascii-bar 100.0 100.0 20)))
-      (is (= "██████████" (allocation/ascii-bar 50.0 100.0 20)))
-      (is (= "█████" (allocation/ascii-bar 25.0 100.0 20)))
-      (is (= "██" (allocation/ascii-bar 10.0 100.0 20))))
+      (is (= "████████████████████" (core/ascii-bar 100.0 100.0 20)))
+      (is (= "██████████" (core/ascii-bar 50.0 100.0 20)))
+      (is (= "█████" (core/ascii-bar 25.0 100.0 20)))
+      (is (= "██" (core/ascii-bar 10.0 100.0 20))))
 
     (testing "handles zero and negative values"
-      (is (= "" (allocation/ascii-bar 0.0 100.0 20)))
-      (is (= "" (allocation/ascii-bar -10.0 100.0 20)))
-      (is (= "" (allocation/ascii-bar 100.0 0.0 20)))
-      (is (= "" (allocation/ascii-bar 100.0 -10.0 20))))
+      (is (= "" (core/ascii-bar 0.0 100.0 20)))
+      (is (= "" (core/ascii-bar -10.0 100.0 20)))
+      (is (= "" (core/ascii-bar 100.0 0.0 20)))
+      (is (= "" (core/ascii-bar 100.0 -10.0 20))))
 
     (testing "respects width parameter"
-      (is (= "██████████" (allocation/ascii-bar 100.0 100.0 10)))
-      (is (= "█████" (allocation/ascii-bar 100.0 100.0 5)))
-      (is (= "██████████████████████████████" (allocation/ascii-bar 100.0 100.0 30))))
+      (is (= "██████████" (core/ascii-bar 100.0 100.0 10)))
+      (is (= "█████" (core/ascii-bar 100.0 100.0 5)))
+      (is (= "██████████████████████████████" (core/ascii-bar 100.0 100.0 30))))
 
     (testing "caps at max width when value exceeds max"
-      (is (= "████████████████████" (allocation/ascii-bar 150.0 100.0 20))))))
+      (is (= "████████████████████" (core/ascii-bar 150.0 100.0 20))))))
+
+(deftest ascii-bar-bidirectional-test
+  ;; Tests bidirectional bar rendering for ACF plots.
+  ;; Bars extend left from center for negative values, right for positive.
+  (testing "ascii-bar-bidirectional"
+    (testing "renders positive values extending right from center"
+      (let [result (core/ascii-bar-bidirectional 0.5 1.0 10)]
+        (is (= 21 (count result)) "Total width should be 2*half-width + 1")
+        (is (str/includes? result "|") "Should contain center marker")
+        (is (= 10 (.indexOf ^String result "|")) "Center marker at position 10")
+        ;; With value 0.5 and max 1.0, bar should be 5 chars
+        (is (= "          |█████     " result))))
+
+    (testing "renders negative values extending left from center"
+      (let [result (core/ascii-bar-bidirectional -0.5 1.0 10)]
+        (is (= 21 (count result)))
+        (is (= 10 (.indexOf ^String result "|")))
+        (is (= "     █████|          " result))))
+
+    (testing "renders zero as empty bar"
+      (let [result (core/ascii-bar-bidirectional 0.0 1.0 10)]
+        (is (= "          |          " result))))
+
+    (testing "scales proportionally to max-abs-value"
+      (let [result (core/ascii-bar-bidirectional 0.25 0.5 10)]
+        ;; 0.25/0.5 = 0.5, so 5 blocks
+        (is (= "          |█████     " result))))
+
+    (testing "handles max-abs-value of zero"
+      (let [result (core/ascii-bar-bidirectional 0.5 0.0 10)]
+        (is (= "          |          " result))))
+
+    (testing "caps at full width when value equals max"
+      (let [result-pos (core/ascii-bar-bidirectional 1.0 1.0 10)
+            result-neg (core/ascii-bar-bidirectional -1.0 1.0 10)]
+        (is (= "          |██████████" result-pos))
+        (is (= "██████████|          " result-neg))))
+
+    (testing "respects half-width parameter"
+      (let [result-5 (core/ascii-bar-bidirectional 0.5 1.0 5)
+            result-15 (core/ascii-bar-bidirectional 0.5 1.0 15)]
+        (is (= 11 (count result-5)))  ; 2*5 + 1
+        (is (= 31 (count result-15))) ; 2*15 + 1
+        (is (= "     |███  " result-5))  ; 0.5 * 5 = 2.5 rounds to 3
+        (is (str/starts-with? result-15 "               |"))))))
 
 (deftest render-ascii-treemap-test
   (testing "render-ascii-treemap"

--- a/bases/criterium/test/criterium/viewer/print/autocorrelation_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/autocorrelation_test.clj
@@ -171,9 +171,10 @@
         (is (str/blank? output))))))
 
 (deftest acf-plot-print-test
-  ;; Tests that acf-plot* is a no-op for print viewer.
+  ;; Tests ASCII ACF plot rendering for print viewer.
+  ;; Verifies output format, severity filtering, bar rendering, and threshold legend.
   (testing "acf-plot*"
-    (testing "returns nil for print viewer"
+    (testing "renders ACF plot when severity threshold met"
       (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
             data-map {:autocorrelation
                       {:type :criterium/autocorrelation
@@ -181,17 +182,117 @@
                        :source-id :samples
                        :autocorrelation
                        {[:elapsed-time]
-                        {:acf {1 0.12 2 0.08}
-                         :lag-1 {:value 0.12 :severity :minor}
-                         :effective-sample-size {:n-original 100
-                                                 :n-effective 88
-                                                 :ratio 0.88}
+                        {:acf {1 0.25 2 0.18 3 0.05 12 -0.22}
+                         :lag-1 {:value 0.25 :severity :moderate}
+                         :effective-sample-size {:n-original 200
+                                                 :n-effective 157
+                                                 :ratio 0.785}
                          :ci-inflation-factor 1.13
+                         :lag-severities {1 :moderate 2 :minor 3 :none 12 :minor}
+                         :thresholds {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                                      :other {:minor 0.15 :moderate 0.25 :severe 0.40}}
                          :ljung-box {:q-statistic 15.0 :df 10 :p-value 0.5}
                          :pattern :clean
                          :classification :acceptable
-                         :detected-period nil}}}}]
-        (is (nil? (view/acf-plot* :print {} data-map)))))))
+                         :detected-period nil}}}}
+            output (with-out-str
+                     (view/acf-plot* :print {:min-severity :minor} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "ACF Plot") lines)
+            "Should show ACF Plot header")
+        (is (some #(str/includes? % "n=200") lines)
+            "Should show sample count")
+        (is (some #(str/includes? % "Lag") lines)
+            "Should show Lag column header")
+        (is (some #(str/includes? % "ACF") lines)
+            "Should show ACF column header")
+        (is (some #(str/includes? % "0.25") lines)
+            "Should show lag-1 ACF value")
+        (is (some #(str/includes? % "(moderate)") lines)
+            "Should show severity annotation")
+        (is (some #(str/includes? % "|") lines)
+            "Should have bar center markers")
+        (is (some #(str/includes? % "█") lines)
+            "Should have bar characters")))
+
+    (testing "filters lags by min-severity"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:autocorrelation
+                      {:type :criterium/autocorrelation
+                       :metrics-defs metrics-defs
+                       :source-id :samples
+                       :autocorrelation
+                       {[:elapsed-time]
+                        {:acf {1 0.25 2 0.05}
+                         :lag-1 {:value 0.25 :severity :moderate}
+                         :effective-sample-size {:n-original 200
+                                                 :n-effective 157
+                                                 :ratio 0.785}
+                         :lag-severities {1 :moderate 2 :none}
+                         :thresholds {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                                      :other {:minor 0.15 :moderate 0.25 :severe 0.40}}}}}}
+            ;; With min-severity :moderate, only lag 1 should appear
+            output (with-out-str
+                     (view/acf-plot* :print {:min-severity :moderate} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(and (str/includes? % "1") (str/includes? % "0.25")) lines)
+            "Should show lag 1")
+        ;; Lag 2 with :none severity should not appear
+        (is (not (some #(str/includes? % "0.05") lines))
+            "Should not show lag 2 with :none severity")))
+
+    (testing "does not render when no lags meet severity threshold"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:autocorrelation
+                      {:type :criterium/autocorrelation
+                       :metrics-defs metrics-defs
+                       :source-id :samples
+                       :autocorrelation
+                       {[:elapsed-time]
+                        {:acf {1 0.05 2 0.03}
+                         :lag-1 {:value 0.05 :severity :none}
+                         :effective-sample-size {:n-original 200
+                                                 :n-effective 190
+                                                 :ratio 0.95}
+                         :lag-severities {1 :none 2 :none}
+                         :thresholds {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                                      :other {:minor 0.15 :moderate 0.25 :severe 0.40}}}}}}
+            ;; With default min-severity :moderate, should not render
+            output (with-out-str
+                     (view/acf-plot* :print {} data-map))]
+        (is (str/blank? output)
+            "Should not render when no lags meet severity threshold")))
+
+    (testing "shows threshold legend with crossed thresholds"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:autocorrelation
+                      {:type :criterium/autocorrelation
+                       :metrics-defs metrics-defs
+                       :source-id :samples
+                       :autocorrelation
+                       {[:elapsed-time]
+                        {:acf {1 0.25 12 0.20}
+                         :lag-1 {:value 0.25 :severity :moderate}
+                         :effective-sample-size {:n-original 200
+                                                 :n-effective 157
+                                                 :ratio 0.785}
+                         :lag-severities {1 :moderate 12 :minor}
+                         :thresholds {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                                      :other {:minor 0.15 :moderate 0.25 :severe 0.40}}}}}}
+            output (with-out-str
+                     (view/acf-plot* :print {:min-severity :minor} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Thresholds:") lines)
+            "Should show threshold legend")
+        (is (some #(str/includes? % "lag-1") lines)
+            "Should mention lag-1 thresholds")
+        (is (some #(str/includes? % "0.10") lines)
+            "Should show crossed minor threshold value")))
+
+    (testing "handles missing autocorrelation data gracefully"
+      (let [output (with-out-str
+                     (view/acf-plot* :print {} {}))]
+        (is (str/blank? output))))))
 
 (deftest print-autocorrelation-anomalous-lags-test
   ;; Tests display of anomalous lags in autocorrelation output.

--- a/bases/criterium/test/criterium/viewer/print/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/core_test.clj
@@ -419,8 +419,8 @@
                    {:outlier-counts (metrics-samples/outlier-count 0 0 0 1)
                     :medcouple nil}
                    true))))))
-      (testing "displays medcouple even without outliers"
-        (is (= ["M: medcouple 0.1500 (slightly right-skewed)"]
+      (testing "displays nothing without outliers"
+        (is (= [""]
                (trimmed-lines
                 (with-out-str
                   (print-core/print-outlier-count

--- a/bases/criterium/test/criterium/viewer/print/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/core_test.clj
@@ -145,9 +145,10 @@
 
 (deftest print-bootstrap-stat-test
   ;; Tests print-bootstrap-stat function for bootstrap statistics display.
-  ;; Covers: median with CI (first), mean with CI, and spread (10th-90th percentile).
+  ;; Covers: median with CI, mean with CI, and spread (10th-90th percentile).
+  ;; Default shows only median and spread; :show-stats controls visibility.
   (testing "print-bootstrap-stat"
-    (testing "without quantiles only prints mean"
+    (testing "with show-stats #{:mean} shows only mean"
       (is (= ["Elapsed Time mean: 100 ns CI [95.0 105] (0.050 0.950)"]
              (trimmed-lines
               (with-out-str
@@ -162,8 +163,9 @@
                              :estimate-quantiles
                              [{:value 9.0 :alpha 0.05}
                               {:value 25.0 :alpha 0.95}]}}
-                 vectorized-identity-transforms))))))
-    (testing "with quantiles prints median first, then mean, then spread"
+                 vectorized-identity-transforms
+                 #{:mean}))))))
+    (testing "with show-stats #{:median :mean :spread} shows all three"
       (is (= ["Elapsed Time median: 98.0 ns CI [93.0 103] (0.025 0.975)"
               "Elapsed Time mean: 100 ns CI [95.0 105] (0.025 0.975)"
               "Elapsed Time spread: [85.0 115] ns (10th-90th percentile)"]
@@ -193,10 +195,37 @@
                         :estimate-quantiles
                         [{:value 110.0 :alpha 0.025}
                          {:value 120.0 :alpha 0.975}]}}}
-                 vectorized-identity-transforms))))))
-    (testing "via bootstrap pipeline with degenerate data"
+                 vectorized-identity-transforms
+                 #{:median :mean :spread}))))))
+    (testing "with default show-stats (nil) shows median and spread"
+      (is (= ["Elapsed Time median: 98.0 ns CI [93.0 103] (0.025 0.975)"
+              "Elapsed Time spread: [85.0 115] ns (10th-90th percentile)"]
+             (trimmed-lines
+              (with-out-str
+                (print-core/print-bootstrap-stat
+                 {:scale 1e-9 :dimension :time :path [:elapsed-time]
+                  :label "Elapsed Time"}
+                 {:mean {:point-estimate 100.0
+                         :estimate-quantiles
+                         [{:value 95.0 :alpha 0.025}
+                          {:value 105.0 :alpha 0.975}]}
+                  :quantiles
+                  {0.1 {:point-estimate 85.0
+                        :estimate-quantiles
+                        [{:value 80.0 :alpha 0.025}
+                         {:value 90.0 :alpha 0.975}]}
+                   0.5 {:point-estimate 98.0
+                        :estimate-quantiles
+                        [{:value 93.0 :alpha 0.025}
+                         {:value 103.0 :alpha 0.975}]}
+                   0.9 {:point-estimate 115.0
+                        :estimate-quantiles
+                        [{:value 110.0 :alpha 0.025}
+                         {:value 120.0 :alpha 0.975}]}}}
+                 vectorized-identity-transforms
+                 nil))))))
+    (testing "via bootstrap pipeline with degenerate data (default shows median and spread)"
       (is (= ["Elapsed Time median: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
-              "Elapsed Time mean: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
               "Elapsed Time spread: [1.00 1.00] ns (10th-90th percentile)"]
              (let [data-map
                    {:samples
@@ -221,10 +250,35 @@
                   (->> data-map
                        bootstrap
                        (view :print))))))))
+    (testing "via bootstrap pipeline with show-stats #{:median :mean :spread}"
+      (is (= ["Elapsed Time median: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
+              "Elapsed Time mean: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
+              "Elapsed Time spread: [1.00 1.00] ns (10th-90th percentile)"]
+             (let [data-map
+                   {:samples
+                    {:type :criterium/collected-metrics-samples
+                     :metric->values {[:elapsed-time]
+                                      (arr/->double-array (double-array [1 1 1]))}
+                     :metrics-defs (select-keys
+                                    (metrics/metrics)
+                                    [:elapsed-time])
+                     :transform collect-plan/identity-transforms
+                     :batch-size 1
+                     :eval-count 1
+                     :elapsed-time 1}}
+                   bootstrap (bootstrap/bootstrap-stats
+                              {:quantiles [0.025 0.975]
+                               :estimate-quantiles [0.025 0.975]
+                               :min-samples 3})
+                   view (view/bootstrap-stats {:show-stats #{:median :mean :spread}})]
+               (trimmed-lines
+                (with-out-str
+                  (->> data-map
+                       bootstrap
+                       (view :print))))))))
     (testing "applies batch-size transform to per-execution values"
       ;; Raw samples are 10000 ns (batch of 10000), expected per-execution is 1 ns
       (is (= ["Elapsed Time median: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
-              "Elapsed Time mean: 1.00 ns CI [1.00 1.00] (0.025 0.975)"
               "Elapsed Time spread: [1.00 1.00] ns (10th-90th percentile)"]
              (let [batch-size 10000
                    data-map

--- a/bases/criterium/test/criterium/viewer/print/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/core_test.clj
@@ -96,11 +96,11 @@
 ;;; Extremes Tests
 
 (deftest print-extreme-test
-  ;; Tests print-extreme function for min/max display.
-  ;; Covers: SI unit formatting and value display.
+  ;; Tests print-extreme function for min/max display in spread format.
+  ;; Covers: SI unit formatting, bracket notation, and label formatting.
   (testing "print-extreme"
-    (testing "prints min and max values with SI units"
-      (is (= "Elapsed Time: 89.0 ns - 114 ns"
+    (testing "prints extremes in spread format with SI units"
+      (is (= "Elapsed Time extremes: [89.0 114] ns"
              (str/trim
               (with-out-str
                 (print-core/print-extreme
@@ -113,11 +113,10 @@
 
 (deftest print-extremes-test
   ;; Tests print-extremes function and view/extremes* multimethod.
-  ;; Covers: min/max display for quantitative metrics.
+  ;; Covers: min/max display in per-metric spread format without header.
   (testing "print-extremes"
-    (testing "prints via output-view"
-      (is (= ["Extremes:"
-              "Elapsed Time: 89.0 ns - 114 ns"]
+    (testing "prints per-metric extremes without header"
+      (is (= ["Elapsed Time extremes: [89.0 114] ns"]
              (trimmed-lines
               (with-out-str
                 (view/extremes*
@@ -126,8 +125,7 @@
                  (:data (test-data/bench-stats-map))))))))
 
     (testing "applies batch-size transform to per-execution values"
-      (is (= ["Extremes:"
-              "Elapsed Time: 0.500 ns - 4.50 ns"]
+      (is (= ["Elapsed Time extremes: [0.500 4.50] ns"]
              (let [data-map
                    (-> (update-in
                         (:data (test-data/samples-with-variance-12-map))

--- a/bases/criterium/test/criterium/viewer/print/shape_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/shape_test.clj
@@ -16,7 +16,6 @@
       (let [data-map (test-data/bootstrap-stats-with-shape-map)
             output (with-out-str (view/shape-stats* :print {} data-map))
             lines (trimmed-lines output)]
-        (is (some #(str/includes? % "Shape Statistics") lines))
         (is (some #(str/includes? % "skewness") lines))
         (is (some #(str/includes? % "kurtosis") lines))
         (is (some #(str/includes? % "CV") lines))
@@ -32,4 +31,4 @@
             output (with-out-str
                      (view/shape-stats* :print {:bootstrap-stats-id :my-bootstrap}
                                         custom-map))]
-        (is (str/includes? output "Shape Statistics"))))))
+        (is (str/includes? output "skewness"))))))


### PR DESCRIPTION
## Summary

Improves the print viewer with better formatting, consistency, and new visualizations:

- Add ASCII bar visualization to histograms and ACF plots
- Add `:show-stats` option to bootstrap-stats view to control which statistics are displayed
- Extract and consolidate common formatting helpers (label widths, metric iteration, classification formatting)
- Unify classification terminology (skewness, kurtosis, CV) with data-driven label maps
- Extract print-table to separate namespace for maintainability
- Change extremes view to per-metric format matching bootstrap-stats style

## Key Changes

- **New visualizations**: ASCII bar charts for histograms and bidirectional ASCII bars for ACF plots
- **Formatting consistency**: Unified label widths (32/36 chars), `format-labeled-value`, `format-sublabel` helpers
- **Code organization**: Extracted `print-table` namespace, consolidated domain coordinate helpers
- **Configuration**: `:show-stats` option accepts `#{:median :mean :spread}` set (default `#{:median :spread}`)

## Test Plan

- [x] All existing tests pass
- [x] Print viewer output verified for consistency
- [x] ASCII bar visualization renders correctly for histograms
- [x] ACF plot renders with bidirectional bars and threshold legend