### PR TITLE
feat(benchmark): enable simple timing of analyse steps

### DIFF
--- a/bases/criterium/src/criterium/benchmark.clj
+++ b/bases/criterium/src/criterium/benchmark.clj
@@ -34,20 +34,21 @@
       (let [start (System/nanoTime)
             result (f data-map)
             elapsed (- (System/nanoTime) start)]
-        (println (pr-str spec) (format-elapsed-ms elapsed) "ms")
+        (println (format-elapsed-ms elapsed) "ms" (pr-str spec))
         result)
       (f data-map))))
 
 (defn- resolve-analyse-fn
-  "Resolves a single analysis function specification.
+  "Resolves a single analysis function specification and wraps with timing.
    If x is a sequence, treats first element as function and rest as args.
    Otherwise treats x as a function name to resolve.
-   Returns a function of one argument (the sampled data)."
+   Returns a function of one argument (the sampled data) wrapped with timing."
   [x]
-  (let [options {:default-ns 'criterium.analyse}]
-    (if (sequential? x)
-      (apply (util/maybe-var-get (first x) options) (rest x))
-      ((util/maybe-var-get x options)))))
+  (let [options {:default-ns 'criterium.analyse}
+        f (if (sequential? x)
+            (apply (util/maybe-var-get (first x) options) (rest x))
+            ((util/maybe-var-get x options)))]
+    (wrap-with-timing x f)))
 
 (defn- resolve-view-fn
   "Resolves a single view function specification.

--- a/bases/criterium/src/criterium/benchmark.clj
+++ b/bases/criterium/src/criterium/benchmark.clj
@@ -7,6 +7,37 @@
    [criterium.util.invariant :refer [have have?]]
    [criterium.view :as view]))
 
+(def ^:dynamic *time-analyse*
+  "When true, print elapsed time for each analysis function."
+  false)
+
+(defn- format-elapsed-ms
+  "Format elapsed time in milliseconds to 4 significant figures."
+  ^String [^double elapsed-ns]
+  (let [elapsed-ms (/ elapsed-ns 1e6)]
+    (cond
+      (>= elapsed-ms 1000.0) (format "%.1f" elapsed-ms)
+      (>= elapsed-ms 100.0) (format "%.2f" elapsed-ms)
+      (>= elapsed-ms 10.0) (format "%.3f" elapsed-ms)
+      (>= elapsed-ms 1.0) (format "%.4f" elapsed-ms)
+      (>= elapsed-ms 0.1) (format "%.4f" elapsed-ms)
+      (>= elapsed-ms 0.01) (format "%.5f" elapsed-ms)
+      :else (format "%.6f" elapsed-ms))))
+
+(defn wrap-with-timing
+  "Wrap an analysis function with timing instrumentation.
+   When *time-analyse* is truthy, prints the spec and elapsed time to *out*.
+   Returns a function that takes data-map and returns the analysis result."
+  [spec f]
+  (fn [data-map]
+    (if *time-analyse*
+      (let [start (System/nanoTime)
+            result (f data-map)
+            elapsed (- (System/nanoTime) start)]
+        (println (pr-str spec) (format-elapsed-ms elapsed) "ms")
+        result)
+      (f data-map))))
+
 (defn- resolve-analyse-fn
   "Resolves a single analysis function specification.
    If x is a sequence, treats first element as function and rest as args.

--- a/bases/criterium/test/criterium/benchmark_test.clj
+++ b/bases/criterium/test/criterium/benchmark_test.clj
@@ -1,0 +1,83 @@
+(ns criterium.benchmark-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [criterium.benchmark :as benchmark]))
+
+;; Tests for wrap-with-timing
+;; Contract: wrap-with-timing takes a spec and a function, returning a wrapper
+;; that times execution and optionally prints results when *time-analyse* is true.
+
+(deftest wrap-with-timing-test
+  (testing "wrap-with-timing"
+    (testing "when *time-analyse* is false"
+      (testing "does not produce output"
+        (let [f (fn [x] (assoc x :result 42))
+              wrapped (benchmark/wrap-with-timing :test-spec f)
+              output (with-out-str (wrapped {:input 1}))]
+          (is (= "" output))))
+
+      (testing "returns the result unchanged"
+        (let [f (fn [x] (assoc x :result 42))
+              wrapped (benchmark/wrap-with-timing :test-spec f)
+              result (wrapped {:input 1})]
+          (is (= {:input 1 :result 42} result)))))
+
+    (testing "when *time-analyse* is true"
+      (testing "produces timing output"
+        (let [f (fn [x] (assoc x :result 42))
+              wrapped (benchmark/wrap-with-timing :test-spec f)
+              output (binding [benchmark/*time-analyse* true]
+                       (with-out-str (wrapped {:input 1})))]
+          (is (str/includes? output ":test-spec"))
+          (is (str/includes? output "ms"))))
+
+      (testing "returns the result unchanged"
+        (let [f (fn [x] (assoc x :result 42))
+              wrapped (benchmark/wrap-with-timing :test-spec f)
+              result (binding [benchmark/*time-analyse* true]
+                       (wrapped {:input 1}))]
+          (is (= {:input 1 :result 42} result))))
+
+      (testing "prints spec using pr-str format"
+        (let [spec [:quantiles {:quantiles [0.025 0.975]}]
+              f identity
+              wrapped (benchmark/wrap-with-timing spec f)
+              output (binding [benchmark/*time-analyse* true]
+                       (with-out-str (wrapped {})))]
+          (is (str/includes? output "[:quantiles {:quantiles [0.025 0.975]}]"))))
+
+      (testing "prints elapsed time in milliseconds"
+        (let [f (fn [x]
+                  (Thread/sleep 10)
+                  x)
+              wrapped (benchmark/wrap-with-timing :slow-fn f)
+              output (binding [benchmark/*time-analyse* true]
+                       (with-out-str (wrapped {})))]
+          (is (re-find #"\d+\.\d+ ms" output)
+              "output should include numeric elapsed time"))))))
+
+(deftest format-elapsed-ms-test
+  (testing "format-elapsed-ms"
+    (testing "formats to 4 significant figures"
+      ;; 1234567890 ns = 1234.56789 ms -> "1234.6"
+      (is (= "1234.6"
+             (#'benchmark/format-elapsed-ms 1234567890.0)))
+      ;; 123456789 ns = 123.456789 ms -> "123.46"
+      (is (= "123.46"
+             (#'benchmark/format-elapsed-ms 123456789.0)))
+      ;; 12345678 ns = 12.345678 ms -> "12.346"
+      (is (= "12.346"
+             (#'benchmark/format-elapsed-ms 12345678.0)))
+      ;; 1234567 ns = 1.234567 ms -> "1.2346"
+      (is (= "1.2346"
+             (#'benchmark/format-elapsed-ms 1234567.0)))
+      ;; 123456 ns = 0.123456 ms -> "0.1235"
+      (is (= "0.1235"
+             (#'benchmark/format-elapsed-ms 123456.0)))
+      ;; 12345 ns = 0.012345 ms -> "0.01235"
+      (is (= "0.01235"
+             (#'benchmark/format-elapsed-ms 12345.0)))
+      ;; 1234.5 ns = 0.0012345 ms -> "0.001235"
+      (is (= "0.001235"
+             (#'benchmark/format-elapsed-ms 1234.5))))))

--- a/bases/criterium/test/criterium/benchmark_test.clj
+++ b/bases/criterium/test/criterium/benchmark_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
-   [criterium.benchmark :as benchmark]))
+   [criterium.benchmark :as benchmark]
+   [criterium.test-data :as test-data]))
 
 ;; Tests for wrap-with-timing
 ;; Contract: wrap-with-timing takes a spec and a function, returning a wrapper
@@ -56,6 +57,45 @@
                        (with-out-str (wrapped {})))]
           (is (re-find #"\d+\.\d+ ms" output)
               "output should include numeric elapsed time"))))))
+
+(deftest resolve-analyse-fn-timing-integration-test
+  ;; Tests that resolve-analyse-fn integrates timing wrapper correctly.
+  ;; Contract: resolved analysis functions print timing when *time-analyse* is true.
+  (testing "resolve-analyse-fn timing integration"
+    (testing "when *time-analyse* is true"
+      (testing "prints timing output for keyword specs"
+        (let [analyse-fn (benchmark/->analyse [:stats])
+              data-map (:data (test-data/samples-with-variance-12-map))
+              output (binding [benchmark/*time-analyse* true]
+                       (with-out-str (analyse-fn data-map)))]
+          (is (str/includes? output ":stats"))
+          (is (str/includes? output "ms"))))
+
+      (testing "prints timing output for vector specs"
+        (let [analyse-fn (benchmark/->analyse [[:quantiles {:quantiles [0.5]}]])
+              data-map (:data (test-data/samples-with-variance-12-map))
+              output (binding [benchmark/*time-analyse* true]
+                       (with-out-str (analyse-fn data-map)))]
+          (is (str/includes? output "[:quantiles"))
+          (is (str/includes? output "ms"))))
+
+      (testing "prints timing for each step in multi-step analysis"
+        (let [analyse-fn (benchmark/->analyse [[:quantiles {:quantiles [0.5]}]
+                                               :stats])
+              data-map (:data (test-data/samples-with-variance-12-map))
+              output (binding [benchmark/*time-analyse* true]
+                       (with-out-str (analyse-fn data-map)))]
+          (is (str/includes? output ":stats"))
+          (is (str/includes? output "[:quantiles"))
+          (is (= 2 (count (re-seq #"ms" output)))
+              "should print timing for both analysis steps"))))
+
+    (testing "when *time-analyse* is false (default)"
+      (testing "produces no timing output"
+        (let [analyse-fn (benchmark/->analyse [:stats])
+              data-map (:data (test-data/samples-with-variance-12-map))
+              output (with-out-str (analyse-fn data-map))]
+          (is (= "" output)))))))
 
 (deftest format-elapsed-ms-test
   (testing "format-elapsed-ms"


### PR DESCRIPTION
## Summary

Add optional timing instrumentation for analyse functions in the benchmark pipeline for development and debugging purposes.

- Add `*time-analyse*` dynamic var in `criterium.benchmark` namespace (default `false`)
- When enabled, each analysis function prints its elapsed time to `*out*`
- Output format: elapsed ms followed by spec (e.g., `0.1234 ms :stats`)
- Uses 4 significant figures for timing values

## Implementation

- `wrap-with-timing` function wraps analysis functions to capture and report timing
- Integrated into `resolve-analyse-fn` so all analysis functions are automatically wrapped
- Timing uses `System/nanoTime` for precision

## Test plan

- [x] Test that timing output appears when `*time-analyse*` is bound to `true`
- [x] Test that no output appears when `false` (default)