### PR TITLE
perf: improve multi-mode analysis speed

### DIFF
--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -359,30 +359,42 @@
           max-k-to-test (min max-modes n-all-modes)
           ;; Run multimodality test for each k from 1 up to max-k-to-test
           ;; Use early stopping: once p-value >= alpha, we've found our validated-k
+          ;; Compute critical bandwidths incrementally: h_k < h_{k-1}, so use
+          ;; previous bandwidth as upper bound for faster binary search
           {:keys [test-results validated-k]}
           (loop [k 1
-                 results {}]
+                 results {}
+                 prev-h-crit nil]
             (if (> k max-k-to-test)
               ;; Tested all k values without finding one where H0 is not rejected
               {:test-results results :validated-k n-all-modes}
-              (let [test-result (test-fn samples-arr k
+              (let [;; Compute critical bandwidth with tighter upper bound from prev
+                    h-crit (kde/critical-bandwidth samples-arr k
+                                                   (cond-> {:n-points n-points}
+                                                     prev-h-crit (assoc :h-max prev-h-crit)))
+                    ;; Run test with pre-computed bandwidth
+                    test-result (test-fn samples-arr k
                                          {:n-bootstrap n-bootstrap
                                           :n-points n-points
-                                          :alpha alpha})
+                                          :alpha alpha
+                                          :cached-critical-bandwidth h-crit})
                     results' (assoc results k test-result)]
                 (if (>= (double (:p-value test-result)) alpha)
                   ;; Early stopping: fail to reject H0: at most k modes
                   ;; This is the validated number of modes
                   {:test-results results' :validated-k k}
-                  ;; Continue testing higher k
-                  (recur (inc k) results')))))
+                  ;; Continue testing higher k, using h-crit as upper bound
+                  (recur (inc k) results' h-crit)))))
           ;; Get mode locations based on mode-method
           {:keys [modes-with-ci mode-bandwidth antimodes]}
           (case mode-method
             :critical
             ;; Use critical bandwidth to find modes
-            (let [locate-result (kde/locate-modes samples-arr validated-k
-                                                  {:n-points n-points})
+            ;; Reuse bandwidth from test results if available
+            (let [cached-h (get-in test-results [validated-k :critical-bandwidth])
+                  locate-result (kde/locate-modes samples-arr validated-k
+                                                  (cond-> {:n-points n-points}
+                                                    cached-h (assoc :cached-critical-bandwidth cached-h)))
                   h-crit (:critical-bandwidth locate-result)
                   ;; Build mode CIs at critical bandwidth
                   [sample-min sample-max]

--- a/bases/criterium/src/criterium/analyse/metrics_samples.clj
+++ b/bases/criterium/src/criterium/analyse/metrics_samples.clj
@@ -324,6 +324,10 @@
   Takes KDE output and raw samples, runs multimodality test for k=1 up to max-modes,
   and computes confidence intervals for detected modes.
 
+  Uses early stopping: stops testing k values once p-value >= alpha (fail to reject
+  H0: at most k modes). Higher k values would also fail to reject, so testing them
+  is unnecessary.
+
   Options:
   - :method - test method, :acr (default) or :silverman
   - :mode-method - mode finding method:
@@ -352,21 +356,26 @@
           density-arr (double-array density)
           all-modes (kde/find-modes grid-arr density-arr)
           n-all-modes (long (count all-modes))
-          ;; Run multimodality test for each k from 1 to max-modes
-          test-results
-          (into {}
-                (for [k (range 1 (inc (min max-modes n-all-modes)))]
-                  [k (test-fn samples-arr k
-                              {:n-bootstrap n-bootstrap
-                               :n-points n-points
-                               :alpha alpha})]))
-          ;; Determine validated number of modes
-          ;; Find smallest k where p-value >= alpha (fail to reject H0: <= k modes)
-          validated-k (or (some (fn [k]
-                                  (when (>= (double (get-in test-results [k :p-value])) alpha)
-                                    k))
-                                (range 1 (inc (min max-modes n-all-modes))))
-                          n-all-modes)
+          max-k-to-test (min max-modes n-all-modes)
+          ;; Run multimodality test for each k from 1 up to max-k-to-test
+          ;; Use early stopping: once p-value >= alpha, we've found our validated-k
+          {:keys [test-results validated-k]}
+          (loop [k 1
+                 results {}]
+            (if (> k max-k-to-test)
+              ;; Tested all k values without finding one where H0 is not rejected
+              {:test-results results :validated-k n-all-modes}
+              (let [test-result (test-fn samples-arr k
+                                         {:n-bootstrap n-bootstrap
+                                          :n-points n-points
+                                          :alpha alpha})
+                    results' (assoc results k test-result)]
+                (if (>= (double (:p-value test-result)) alpha)
+                  ;; Early stopping: fail to reject H0: at most k modes
+                  ;; This is the validated number of modes
+                  {:test-results results' :validated-k k}
+                  ;; Continue testing higher k
+                  (recur (inc k) results')))))
           ;; Get mode locations based on mode-method
           {:keys [modes-with-ci mode-bandwidth antimodes]}
           (case mode-method
@@ -422,7 +431,7 @@
       (cond-> {:modes modes-with-significance
                :n-modes validated-k
                :test-results {:method method
-                              :k-tested (vec (keys test-results))
+                              :k-tested (vec (sort (keys test-results)))
                               :p-values (into {} (map (fn [[k v]] [k (:p-value v)])
                                                       test-results))
                               :critical-bandwidths (into {} (map (fn [[k v]]

--- a/bases/criterium/test/criterium/analyse/metrics_samples_test.clj
+++ b/bases/criterium/test/criterium/analyse/metrics_samples_test.clj
@@ -1,0 +1,89 @@
+(ns criterium.analyse.metrics-samples-test
+  ;; Tests for the metrics-samples analysis module.
+  ;; Verifies modes-for-metric early stopping behavior and correct results.
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [criterium.analyse.metrics-samples :as ms]
+   [criterium.array :as arr]
+   [criterium.stats.kde :as kde]
+   [criterium.test-utils :as tu]))
+
+(defn- darr
+  "Create a DoubleArray from a sequence."
+  [coll]
+  (arr/->double-array (double-array coll)))
+
+(deftest modes-for-metric-early-stopping-test
+  ;; Tests that modes-for-metric stops testing k values once p-value >= alpha.
+  ;; For unimodal data, it should stop after k=1 instead of testing all k.
+  (testing "modes-for-metric"
+    (testing "with unimodal data"
+      (let [;; Generate clearly unimodal Gaussian data
+            data (darr (tu/gaussian-samples 200 50.0 10.0 42))
+            ;; Compute KDE
+            kde-result (kde/kde data {:n-points 256 :n-bootstrap 10})
+            ;; Create mock metric config
+            metric-config {:path [:elapsed-time-ns]}
+            ;; Run modes analysis with reduced bootstrap for speed
+            options {:n-bootstrap 50 :n-points 256 :alpha 0.05 :max-modes 5}
+            result (ms/modes-for-metric kde-result data nil metric-config options)]
+        (testing "stops early when k=1 fails to reject H0"
+          ;; For unimodal data, k=1 should have p-value >= alpha
+          ;; So we should only test k=1 (early stopping)
+          (let [k-tested (get-in result [:test-results :k-tested])]
+            (is (vector? k-tested))
+            ;; Should only test k=1 since it should fail to reject H0
+            (is (= [1] k-tested)
+                (str "Expected only k=1 to be tested for unimodal data, "
+                     "but got: " k-tested))))
+
+        (testing "returns n-modes = 1 for unimodal data"
+          (is (= 1 (:n-modes result))))
+
+        (testing "has p-value >= alpha for k=1"
+          (let [p-value (get-in result [:test-results :p-values 1])]
+            (is (>= p-value 0.05)
+                (str "Expected p-value >= 0.05 for unimodal data, got: " p-value))))))
+
+    (testing "with bimodal data"
+      (let [;; Generate clearly bimodal data (two separated Gaussians)
+            data (darr (concat (tu/gaussian-samples 100 20.0 5.0 1)
+                               (tu/gaussian-samples 100 80.0 5.0 2)))
+            ;; Compute KDE
+            kde-result (kde/kde data {:n-points 256 :n-bootstrap 10})
+            metric-config {:path [:elapsed-time-ns]}
+            options {:n-bootstrap 50 :n-points 256 :alpha 0.05 :max-modes 5}
+            result (ms/modes-for-metric kde-result data nil metric-config options)]
+        (testing "tests k=1 and rejects it (p-value < alpha)"
+          (let [p-value-k1 (get-in result [:test-results :p-values 1])]
+            (is (< p-value-k1 0.05)
+                (str "Expected p-value < 0.05 for bimodal data at k=1, "
+                     "got: " p-value-k1))))
+
+        (testing "stops at k=2 for bimodal data"
+          ;; Should test k=1 (reject) then k=2 (fail to reject) then stop
+          (let [k-tested (get-in result [:test-results :k-tested])]
+            (is (vector? k-tested))
+            (is (= [1 2] k-tested)
+                (str "Expected k=[1,2] for bimodal data, got: " k-tested))))
+
+        (testing "returns n-modes = 2 for bimodal data"
+          (is (= 2 (:n-modes result))))))
+
+    (testing "test results match exhaustive testing"
+      ;; Verify that early stopping produces the same n-modes as testing all k
+      (let [data (darr (tu/gaussian-samples 150 50.0 10.0 123))
+            kde-result (kde/kde data {:n-points 256 :n-bootstrap 10})
+            metric-config {:path [:elapsed-time-ns]}
+            ;; Run with early stopping (default behavior)
+            result-early (ms/modes-for-metric kde-result data nil metric-config
+                                              {:n-bootstrap 30 :n-points 256
+                                               :alpha 0.05 :max-modes 3})
+            n-modes-early (:n-modes result-early)
+            k-tested-early (get-in result-early [:test-results :k-tested])]
+        ;; The validated k should be the first k where we fail to reject
+        ;; This is what we expect from the early stopping algorithm
+        (is (= 1 n-modes-early)
+            "Unimodal data should validate 1 mode")
+        (is (= [1] k-tested-early)
+            "Should stop after testing k=1 for unimodal data")))))

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -349,8 +349,8 @@
                                               (assoc opts :cached-critical-bandwidth h-crit))]
         (is (= h-crit (:critical-bandwidth result-cached))
             "cached bandwidth should be used")
-        (is (< (Math/abs (- (:critical-bandwidth result-computed)
-                            (:critical-bandwidth result-cached)))
+        (is (< (Math/abs (- (double (:critical-bandwidth result-computed))
+                            (double (:critical-bandwidth result-cached))))
                1e-10)
             "bandwidths should match")))))
 
@@ -366,8 +366,8 @@
                                         (assoc opts :cached-critical-bandwidth h-crit))]
         (is (= h-crit (:critical-bandwidth result-cached))
             "cached bandwidth should be used")
-        (is (< (Math/abs (- (:critical-bandwidth result-computed)
-                            (:critical-bandwidth result-cached)))
+        (is (< (Math/abs (- (double (:critical-bandwidth result-computed))
+                            (double (:critical-bandwidth result-cached))))
                1e-10)
             "bandwidths should match")))))
 

--- a/bases/criterium/test/criterium/util/kde_test.clj
+++ b/bases/criterium/test/criterium/util/kde_test.clj
@@ -280,6 +280,115 @@
             h2 (kde/critical-bandwidth bimodal 2 {})]
         (is (> h1 h2) "bandwidth for 1 mode should be larger than for 2")))))
 
+(deftest critical-bandwidths-test
+  ;; Tests the critical-bandwidths function that computes bandwidths for
+  ;; k=1 to max-k efficiently by using h_{k-1} as upper bound for h_k.
+  (testing "critical-bandwidths"
+    (testing "returns map with correct keys"
+      (let [data (darr (range 0 100))
+            result (kde/critical-bandwidths data (long 3) {})]
+        (is (map? result))
+        (is (= #{1 2 3} (set (keys result))))
+        (doseq [k [1 2 3]]
+          (is (pos? (get result k)) (str "h_" k " should be positive")))))
+
+    (testing "bandwidths produce valid mode counts"
+      ;; The key property: h_k should give <= k modes
+      ;; Use moderately bimodal data (not extremely separated)
+      (let [data (darr (concat (tu/gaussian-samples 50 30.0 10.0 1)
+                               (tu/gaussian-samples 50 70.0 10.0 2)))
+            result (kde/critical-bandwidths data (long 3) {:n-points 128})]
+        (doseq [k [2 3]]  ; Start at k=2 since bimodal data may not fit k=1
+          (let [h-k (double (get result k))
+                n-modes (kde/count-modes data h-k (long 128))]
+            (is (<= n-modes k)
+                (str "h_" k " = " h-k " should give <= " k " modes, got " n-modes))))))
+
+    (testing "bandwidths are monotonically decreasing"
+      (let [data (darr (concat (repeat 30 10.0) (repeat 30 50.0) (repeat 30 90.0)))
+            result (kde/critical-bandwidths data (long 3) {})]
+        (is (> (get result 1) (get result 2)) "h_1 > h_2")
+        (is (>= (get result 2) (get result 3)) "h_2 >= h_3")))))
+
+(deftest critical-bandwidth-h-max-test
+  ;; Tests that providing h-max narrows the binary search correctly.
+  (testing "critical-bandwidth with h-max"
+    (testing "result with h-max is valid and bounded"
+      ;; Use bimodal data where h_1 > h_2
+      (let [data (darr (concat (repeat 50 10.0) (repeat 50 90.0)))
+            h1 (kde/critical-bandwidth data (long 1) {:n-points 128})
+            h2-with-bound (kde/critical-bandwidth data (long 2) {:h-max h1 :n-points 128})]
+        ;; h_2 should not exceed h_1
+        (is (<= h2-with-bound h1)
+            "h_2 with bound should not exceed h_1")
+        ;; h_2 should produce <= 2 modes
+        (is (<= (kde/count-modes data h2-with-bound (long 128)) 2)
+            "h_2 should give <= 2 modes")))
+
+    (testing "handles h-max smaller than needed (uses h-max as ceiling)"
+      ;; This tests edge case where h-max is set too low
+      (let [data (darr (range 0 100))
+            h1 (kde/critical-bandwidth data (long 1) {})
+            ;; Provide a very small h-max that won't work for k=1
+            h1-with-small-max (kde/critical-bandwidth data (long 1) {:h-max (/ h1 10.0)})]
+        ;; Result should be clamped to h-max or nearby
+        (is (<= h1-with-small-max (/ h1 10.0))
+            "result should not exceed h-max")))))
+
+(deftest cached-critical-bandwidth-silverman-test
+  ;; Tests that silverman-test produces identical results with cached bandwidth.
+  (testing "silverman-test with cached-critical-bandwidth"
+    (testing "produces identical results to uncached version"
+      (let [data (darr (range 0 100))
+            h-crit (kde/critical-bandwidth data (long 1) {:n-points 128})
+            ;; Use fixed seed for reproducibility
+            opts {:n-bootstrap 50 :n-points 128}
+            ;; Both should produce same critical bandwidth
+            result-computed (kde/silverman-test data (long 1) opts)
+            result-cached (kde/silverman-test data (long 1)
+                                              (assoc opts :cached-critical-bandwidth h-crit))]
+        (is (= h-crit (:critical-bandwidth result-cached))
+            "cached bandwidth should be used")
+        (is (< (Math/abs (- (:critical-bandwidth result-computed)
+                            (:critical-bandwidth result-cached)))
+               1e-10)
+            "bandwidths should match")))))
+
+(deftest cached-critical-bandwidth-acr-test
+  ;; Tests that acr-test produces identical results with cached bandwidth.
+  (testing "acr-test with cached-critical-bandwidth"
+    (testing "produces identical results to uncached version"
+      (let [data (darr (range 0 100))
+            h-crit (kde/critical-bandwidth data (long 1) {:n-points 128})
+            opts {:n-bootstrap 50 :n-points 128}
+            result-computed (kde/acr-test data (long 1) opts)
+            result-cached (kde/acr-test data (long 1)
+                                        (assoc opts :cached-critical-bandwidth h-crit))]
+        (is (= h-crit (:critical-bandwidth result-cached))
+            "cached bandwidth should be used")
+        (is (< (Math/abs (- (:critical-bandwidth result-computed)
+                            (:critical-bandwidth result-cached)))
+               1e-10)
+            "bandwidths should match")))))
+
+(deftest cached-critical-bandwidth-locate-modes-test
+  ;; Tests that locate-modes produces identical results with cached bandwidth.
+  (testing "locate-modes with cached-critical-bandwidth"
+    (testing "produces identical results to uncached version"
+      (let [data (darr (concat (tu/gaussian-samples 50 10.0 2.0 1)
+                               (tu/gaussian-samples 50 50.0 2.0 2)))
+            h-crit (kde/critical-bandwidth data (long 2) {:n-points 128})
+            result-computed (kde/locate-modes data (long 2) {:n-points 128})
+            result-cached (kde/locate-modes data (long 2)
+                                            {:n-points 128
+                                             :cached-critical-bandwidth h-crit})]
+        (is (= h-crit (:critical-bandwidth result-cached))
+            "cached bandwidth should be used")
+        (is (= (count (:modes result-computed)) (count (:modes result-cached)))
+            "mode count should match")
+        (is (= (count (:antimodes result-computed)) (count (:antimodes result-cached)))
+            "antimode count should match")))))
+
 (deftest silverman-test-test
   ;; Tests Silverman's bootstrap test for multimodality.
   (testing "silverman-test"

--- a/components/array/src/clj/criterium/array.clj
+++ b/components/array/src/clj/criterium/array.clj
@@ -877,3 +877,111 @@
   Compares element-by-element using == for doubles/longs, = for objects."
   [^IArrayEquals arr expected]
   (.arrayEquals arr expected))
+
+;;; Primitive array literal initializers
+
+(defn make-doubles
+  "Creates a primitive double array with 1-4 explicit values.
+  Avoids ISeq iteration overhead of `(double-array [...])`."
+  {:inline-arities #{1 2 3 4}
+   :inline (fn
+             ([a] `(let [arr# (double-array 1)]
+                     (aset arr# 0 ~a)
+                     arr#))
+             ([a b] `(let [arr# (double-array 2)]
+                       (aset arr# 0 ~a)
+                       (aset arr# 1 ~b)
+                       arr#))
+             ([a b c] `(let [arr# (double-array 3)]
+                         (aset arr# 0 ~a)
+                         (aset arr# 1 ~b)
+                         (aset arr# 2 ~c)
+                         arr#))
+             ([a b c d] `(let [arr# (double-array 4)]
+                           (aset arr# 0 ~a)
+                           (aset arr# 1 ~b)
+                           (aset arr# 2 ~c)
+                           (aset arr# 3 ~d)
+                           arr#)))}
+  (^doubles [^double a]
+   (let [arr (double-array 1)]
+     (aset arr 0 a)
+     arr))
+  (^doubles [^double a ^double b]
+   (let [arr (double-array 2)]
+     (aset arr 0 a)
+     (aset arr 1 b)
+     arr))
+  (^doubles [^double a ^double b ^double c]
+   (let [arr (double-array 3)]
+     (aset arr 0 a)
+     (aset arr 1 b)
+     (aset arr 2 c)
+     arr))
+  (^doubles [^double a ^double b ^double c ^double d]
+   (let [arr (double-array 4)]
+     (aset arr 0 a)
+     (aset arr 1 b)
+     (aset arr 2 c)
+     (aset arr 3 d)
+     arr)))
+
+(defn make-longs
+  "Creates a primitive long array with 1-4 explicit values.
+  Avoids ISeq iteration overhead of `(long-array [...])`."
+  {:inline-arities #{1 2 3 4}
+   :inline (fn
+             ([a] `(let [arr# (long-array 1)]
+                     (aset arr# 0 ~a)
+                     arr#))
+             ([a b] `(let [arr# (long-array 2)]
+                       (aset arr# 0 ~a)
+                       (aset arr# 1 ~b)
+                       arr#))
+             ([a b c] `(let [arr# (long-array 3)]
+                         (aset arr# 0 ~a)
+                         (aset arr# 1 ~b)
+                         (aset arr# 2 ~c)
+                         arr#))
+             ([a b c d] `(let [arr# (long-array 4)]
+                           (aset arr# 0 ~a)
+                           (aset arr# 1 ~b)
+                           (aset arr# 2 ~c)
+                           (aset arr# 3 ~d)
+                           arr#)))}
+  (^longs [^long a]
+   (let [arr (long-array 1)]
+     (aset arr 0 a)
+     arr))
+  (^longs [^long a ^long b]
+   (let [arr (long-array 2)]
+     (aset arr 0 a)
+     (aset arr 1 b)
+     arr))
+  (^longs [^long a ^long b ^long c]
+   (let [arr (long-array 3)]
+     (aset arr 0 a)
+     (aset arr 1 b)
+     (aset arr 2 c)
+     arr))
+  (^longs [^long a ^long b ^long c ^long d]
+   (let [arr (long-array 4)]
+     (aset arr 0 a)
+     (aset arr 1 b)
+     (aset arr 2 c)
+     (aset arr 3 d)
+     arr)))
+
+(defn doubles-fill
+  "Creates a primitive double array of length n filled with value v."
+  ^doubles [^long n ^double v]
+  (let [arr (double-array n)]
+    (java.util.Arrays/fill arr v)
+    arr))
+
+(defn longs-fill
+  "Creates a primitive long array of length n filled with value v."
+  ^longs [^long n ^long v]
+  (let [arr (long-array n)]
+    (java.util.Arrays/fill arr v)
+    arr))

--- a/components/array/src/clj/criterium/transducer.clj
+++ b/components/array/src/clj/criterium/transducer.clj
@@ -18,6 +18,22 @@
     clojure.lang.IFn$DDD
     (^double invokePrim [_ ^double acc ^double x] (+ acc x))))
 
+(def prim-min
+  "Reducing function that computes minimum of primitive values."
+  (reify
+    clojure.lang.IFn$LLL
+    (^long invokePrim [_ ^long acc ^long x] (Math/min acc x))
+    clojure.lang.IFn$DDD
+    (^double invokePrim [_ ^double acc ^double x] (Math/min acc x))))
+
+(def prim-max
+  "Reducing function that computes maximum of primitive values."
+  (reify
+    clojure.lang.IFn$LLL
+    (^long invokePrim [_ ^long acc ^long x] (Math/max acc x))
+    clojure.lang.IFn$DDD
+    (^double invokePrim [_ ^double acc ^double x] (Math/max acc x))))
+
 (defn map
   "Return a transducer that applies f to each primitive element.
 

--- a/components/array/src/clj/criterium/transducer/impl.clj
+++ b/components/array/src/clj/criterium/transducer/impl.clj
@@ -113,6 +113,10 @@
       (.reduce source ^clojure.lang.IFn$LLL rf init))
     (^double reduce [_ rf ^double init ^IDDDReducible source]
       (.reduce source ^clojure.lang.IFn$DDD rf init))
+    (^Object reduce [_ rf init ^IODLOReducible source]
+      (.reduceDouble source ^clojure.lang.IFn$ODO rf init))
+    (^Object reduce [_ rf init ^IOLDOReducible source]
+      (.reduceLong source ^clojure.lang.IFn$OLO rf init))
     (^criterium.array.interfaces.ILongArray into
       [this
        ^criterium.array.interfaces.ILongArray target

--- a/components/array/src/java/criterium/transducer/interfaces/IPrimOps.java
+++ b/components/array/src/java/criterium/transducer/interfaces/IPrimOps.java
@@ -137,6 +137,32 @@ public interface IPrimOps {
   double reduce(Object rf, double init, IDDDReducible source);
 
   /**
+   * Reduces over a double source with an object accumulator.
+   *
+   * <p>Enables reduction where double elements are accumulated into an object
+   * result. Used for computing statistics with mutable accumulators.
+   *
+   * @param rf the reducing function taking (Object acc, double elem)
+   * @param init the initial accumulator value
+   * @param source the reducible double source
+   * @return the final accumulated value
+   */
+  Object reduce(Object rf, Object init, IODLOReducible source);
+
+  /**
+   * Reduces over a long source with an object accumulator.
+   *
+   * <p>Enables reduction where long elements are accumulated into an object
+   * result. Used for computing statistics with mutable accumulators.
+   *
+   * @param rf the reducing function taking (Object acc, long elem)
+   * @param init the initial accumulator value
+   * @param source the reducible long source
+   * @return the final accumulated value
+   */
+  Object reduce(Object rf, Object init, IOLDOReducible source);
+
+  /**
    * Transduces elements from source into target long array.
    *
    * @param target the target array to populate

--- a/components/array/test/criterium/array_test.clj
+++ b/components/array/test/criterium/array_test.clj
@@ -551,11 +551,11 @@
       (let [arr (arr/doubles-fill 10 0.0)]
         (is (instance? (Class/forName "[D") arr))
         (is (= 10 (alength ^doubles arr)))
-        (is (every? #(== 0.0 %) (vec arr)))))
+        (is (every? #(= 0.0 %) (vec arr)))))
     (testing "fills with non-zero value"
       (let [arr (arr/doubles-fill 5 42.5)]
         (is (= 5 (alength ^doubles arr)))
-        (is (every? #(== 42.5 %) (vec arr)))))
+        (is (every? #(= 42.5 %) (vec arr)))))
     (testing "handles length 1"
       (let [arr (arr/doubles-fill 1 3.14)]
         (is (= 1 (alength ^doubles arr)))
@@ -572,11 +572,11 @@
       (let [arr (arr/longs-fill 10 0)]
         (is (instance? (Class/forName "[J") arr))
         (is (= 10 (alength ^longs arr)))
-        (is (every? #(== 0 %) (vec arr)))))
+        (is (every? #(= 0 %) (vec arr)))))
     (testing "fills with non-zero value"
       (let [arr (arr/longs-fill 5 42)]
         (is (= 5 (alength ^longs arr)))
-        (is (every? #(== 42 %) (vec arr)))))
+        (is (every? #(= 42 %) (vec arr)))))
     (testing "handles length 1"
       (let [arr (arr/longs-fill 1 123)]
         (is (= 1 (alength ^longs arr)))

--- a/components/array/test/criterium/array_test.clj
+++ b/components/array/test/criterium/array_test.clj
@@ -484,3 +484,103 @@
         (let [^ObjectArray wrapped (arr/->object-array (object-array []))]
           (is (identical? wrapped (arr/fill! wrapped :x)))
           (is (= 0 (arr/length wrapped))))))))
+
+(deftest make-doubles-test
+  ;; Tests primitive double array literal initializers.
+  ;; Contracts: creates raw double[], supports arities 1-4, preserves values.
+  (testing "make-doubles"
+    (testing "creates arrays of correct length and values"
+      (testing "arity 1"
+        (let [arr (arr/make-doubles 1.0)]
+          (is (instance? (Class/forName "[D") arr))
+          (is (= 1 (alength ^doubles arr)))
+          (is (== 1.0 (aget ^doubles arr 0)))))
+      (testing "arity 2"
+        (let [arr (arr/make-doubles 1.0 2.0)]
+          (is (= 2 (alength ^doubles arr)))
+          (is (== 1.0 (aget ^doubles arr 0)))
+          (is (== 2.0 (aget ^doubles arr 1)))))
+      (testing "arity 3"
+        (let [arr (arr/make-doubles 1.0 2.0 3.0)]
+          (is (= 3 (alength ^doubles arr)))
+          (is (== 3.0 (aget ^doubles arr 2)))))
+      (testing "arity 4"
+        (let [arr (arr/make-doubles 1.0 2.0 3.0 4.0)]
+          (is (= 4 (alength ^doubles arr)))
+          (is (== 4.0 (aget ^doubles arr 3))))))
+    (testing "preserves negative and fractional values"
+      (let [arr (arr/make-doubles -1.5 0.0 2.5)]
+        (is (== -1.5 (aget ^doubles arr 0)))
+        (is (== 0.0 (aget ^doubles arr 1)))
+        (is (== 2.5 (aget ^doubles arr 2)))))))
+
+(deftest make-longs-test
+  ;; Tests primitive long array literal initializers.
+  ;; Contracts: creates raw long[], supports arities 1-4, preserves values.
+  (testing "make-longs"
+    (testing "creates arrays of correct length and values"
+      (testing "arity 1"
+        (let [arr (arr/make-longs 1)]
+          (is (instance? (Class/forName "[J") arr))
+          (is (= 1 (alength ^longs arr)))
+          (is (== 1 (aget ^longs arr 0)))))
+      (testing "arity 2"
+        (let [arr (arr/make-longs 1 2)]
+          (is (= 2 (alength ^longs arr)))
+          (is (== 1 (aget ^longs arr 0)))
+          (is (== 2 (aget ^longs arr 1)))))
+      (testing "arity 3"
+        (let [arr (arr/make-longs 1 2 3)]
+          (is (= 3 (alength ^longs arr)))
+          (is (== 3 (aget ^longs arr 2)))))
+      (testing "arity 4"
+        (let [arr (arr/make-longs 1 2 3 4)]
+          (is (= 4 (alength ^longs arr)))
+          (is (== 4 (aget ^longs arr 3))))))
+    (testing "preserves negative values"
+      (let [arr (arr/make-longs -10 0 10)]
+        (is (== -10 (aget ^longs arr 0)))
+        (is (== 0 (aget ^longs arr 1)))
+        (is (== 10 (aget ^longs arr 2)))))))
+
+(deftest doubles-fill-test
+  ;; Tests double array creation with fill value.
+  ;; Contracts: creates array of specified length, fills with initial value.
+  (testing "doubles-fill"
+    (testing "creates array with specified length and value"
+      (let [arr (arr/doubles-fill 10 0.0)]
+        (is (instance? (Class/forName "[D") arr))
+        (is (= 10 (alength ^doubles arr)))
+        (is (every? #(== 0.0 %) (vec arr)))))
+    (testing "fills with non-zero value"
+      (let [arr (arr/doubles-fill 5 42.5)]
+        (is (= 5 (alength ^doubles arr)))
+        (is (every? #(== 42.5 %) (vec arr)))))
+    (testing "handles length 1"
+      (let [arr (arr/doubles-fill 1 3.14)]
+        (is (= 1 (alength ^doubles arr)))
+        (is (== 3.14 (aget ^doubles arr 0)))))
+    (testing "handles length 0"
+      (let [arr (arr/doubles-fill 0 1.0)]
+        (is (= 0 (alength ^doubles arr)))))))
+
+(deftest longs-fill-test
+  ;; Tests long array creation with fill value.
+  ;; Contracts: creates array of specified length, fills with initial value.
+  (testing "longs-fill"
+    (testing "creates array with specified length and value"
+      (let [arr (arr/longs-fill 10 0)]
+        (is (instance? (Class/forName "[J") arr))
+        (is (= 10 (alength ^longs arr)))
+        (is (every? #(== 0 %) (vec arr)))))
+    (testing "fills with non-zero value"
+      (let [arr (arr/longs-fill 5 42)]
+        (is (= 5 (alength ^longs arr)))
+        (is (every? #(== 42 %) (vec arr)))))
+    (testing "handles length 1"
+      (let [arr (arr/longs-fill 1 123)]
+        (is (= 1 (alength ^longs arr)))
+        (is (== 123 (aget ^longs arr 0)))))
+    (testing "handles length 0"
+      (let [arr (arr/longs-fill 0 1)]
+        (is (= 0 (alength ^longs arr)))))))

--- a/components/array/test/criterium/transducer/impl_test.clj
+++ b/components/array/test/criterium/transducer/impl_test.clj
@@ -3,12 +3,17 @@
   ;; Contracts: deftype constructors and type predicates.
   (:require
    [clojure.test :refer [deftest is testing]]
+   [criterium.array :as arr]
+   [criterium.transducer :as tr]
    [criterium.transducer.impl :as impl])
   (:import
    [criterium.transducer.impl
     ArraySetter
     DoubleRange
-    LongRange]))
+    LongRange]
+   [criterium.transducer.interfaces
+    IODLOReducible
+    IOLDOReducible]))
 
 (deftest array-setter-type-test
   (testing "ArraySetter"
@@ -36,3 +41,41 @@
     (testing "ops range method"
       (testing "returns a DoubleRange for double args"
         (is (instance? DoubleRange (.range impl/ops 0.0 10.0 1.0)))))))
+
+;;; Object accumulator reduce tests
+
+(definterface ISumAccumulator
+  (^criterium.transducer.impl_test.ISumAccumulator addDouble [^double x])
+  (^criterium.transducer.impl_test.ISumAccumulator addLong [^long x])
+  (^double getSum []))
+
+(deftype SumAccumulator [^:unsynchronized-mutable ^double sum]
+  ISumAccumulator
+  (addDouble [this x]
+    (set! sum (+ sum x))
+    this)
+  (addLong [this x]
+    (set! sum (+ sum (double x)))
+    this)
+  (getSum [_] sum))
+
+(deftest object-accumulator-reduce-test
+  ;; Tests tr/reduce with object accumulators over primitive arrays.
+  ;; Contracts: IPrimOps.reduce with IODLOReducible and IOLDOReducible.
+  (testing "tr/reduce with object accumulator"
+    (testing "over double array"
+      (testing "accumulates correctly"
+        (let [data (arr/->double-array (double-array [1.0 2.0 3.0 4.0 5.0]))
+              acc  (SumAccumulator. 0.0)
+              rf   (fn [^ISumAccumulator acc ^double x] (.addDouble acc x))
+              result (tr/reduce rf acc ^IODLOReducible data)]
+          (is (identical? result acc) "returns the accumulator")
+          (is (== 15.0 (.getSum ^ISumAccumulator result)) "sum is correct"))))
+    (testing "over long array"
+      (testing "accumulates correctly"
+        (let [data (arr/->long-array (long-array [1 2 3 4 5]))
+              acc  (SumAccumulator. 0.0)
+              rf   (fn [^ISumAccumulator acc ^long x] (.addLong acc x))
+              result (tr/reduce rf acc ^IOLDOReducible data)]
+          (is (identical? result acc) "returns the accumulator")
+          (is (== 15.0 (.getSum ^ISumAccumulator result)) "sum is correct"))))))

--- a/components/primitive-fn/src/criterium/primitive_fn.clj
+++ b/components/primitive-fn/src/criterium/primitive_fn.clj
@@ -95,6 +95,16 @@
   [f v]
   `(.invokePrim ~(vary-meta f assoc :tag 'clojure.lang.IFn$DD) ~v))
 
+(defmacro invoke-dlold
+  "Invoke a primitive double long Object long -> double function."
+  [f d l o l2]
+  `(.invokePrim ~(vary-meta f assoc :tag 'clojure.lang.IFn$DLOLD) ~d ~l ~o ~l2))
+
+(defmacro invoke-do
+  "Invoke a primitive double -> double function."
+  [f v]
+  `(.invokePrim ~(vary-meta f assoc :tag 'clojure.lang.IFn$DO) ~v))
+
 ;;; Predicates
 
 (defpred-wrappers double

--- a/components/stats/src/criterium/stats/core.clj
+++ b/components/stats/src/criterium/stats/core.clj
@@ -11,8 +11,34 @@
    [criterium.transducer :as tr]
    [criterium.utils.interface :as utils :refer [have?]])
   (:import
-   [criterium.array.interfaces IDoubleFold]
-   [criterium.transducer.interfaces IDDDReducible]))
+   [criterium.transducer.interfaces
+    IDDDReducible
+    IODLOReducible]))
+
+(definterface IVarianceAccumulator
+  (^criterium.stats.core.IVarianceAccumulator update [^double x])
+  (^double getQ [])
+  (^long getK []))
+
+(deftype VarianceAccumulator [^:unsynchronized-mutable ^double m
+                              ^:unsynchronized-mutable ^double q
+                              ^:unsynchronized-mutable ^long k]
+  IVarianceAccumulator
+  (update [this x]
+    (let [kp1   (unchecked-inc k)
+          delta (- x m)
+          new-m (+ m (/ delta kp1))
+          new-q (+ q (/ (* k (utils/sqr delta)) kp1))]
+      (set! m new-m)
+      (set! q new-q)
+      (set! k kp1))
+    this)
+  (getQ [_] q)
+  (getK [_] k))
+
+(defn accumulate-variance!
+  ^IVarianceAccumulator [^IVarianceAccumulator acc ^double x]
+  (.update acc x))
 
 (defn transpose
   "Transpose a vector of vectors."
@@ -81,27 +107,15 @@
 
 (defn- variance-typed-array
   "Single-pass variance computation for typed arrays."
-  ^double [^IDDDReducible data ^long df]
-  (let [^doubles mq (arr/doubles-fill 2 0.0)
-        ^longs k    (arr/longs-fill 1 0)]
-    ;; Accumulate in arrays to avoid boxing
+  ^double [^IODLOReducible data ^long df]
+  (let [^IVarianceAccumulator acc (VarianceAccumulator. 0.0 0.0 0)]
     (tr/reduce
-     (fn ^double [^double _ ^double x]
-       (let [k-val (aget k 0)
-             kp1   (unchecked-inc k-val)
-             m     (aget mq 0)
-             delta (- x m)
-             new-m (+ m (/ delta kp1))
-             new-q (+ (aget mq 1) (/ (* k-val (utils/sqr delta)) kp1))]
-         (aset mq 0 new-m)
-         (aset mq 1 new-q)
-         (aset k 0 kp1)
-         0.0))
-     0.0
+     accumulate-variance!
+     acc
      data)
-    (let [k-val (aget k 0)]
-      (if (> k-val df)
-        (/ (aget mq 1) (- k-val df))
+    (let [k (.getK acc)]
+      (if (> k df)
+        (/ (.getQ acc) (- k df))
         Double/NaN))))
 
 (defn variance
@@ -166,23 +180,25 @@
      med
      (arr/get-double data q3-idx)]))
 
+(defn- interpolate-at
+  "Linear interpolation at fractional index x in data array."
+  ^double [data ^double x]
+  (let [f (Math/floor x)
+        i (long f)
+        p (- x f)]
+    (cond
+      (zero? p) (arr/get-double data i)
+      (= 1.0 p) (arr/get-double data (inc i))
+      :else     (+ (* p (arr/get-double data (inc i)))
+                   (* (- 1.0 p) (arr/get-double data i))))))
+
 (defn quantile
   "Calculate the quantile of a sorted data set.
   Requires a typed array (ITypedArray).
   References: http://en.wikipedia.org/wiki/Quantile"
   ^double [^double quantile data]
   {:pre [(have? arr/typed-array? data)]}
-  (let [n      (dec (arr/length data))
-        interp (fn ^double [^double x]
-                 (let [f (Math/floor x)
-                       i (long f)
-                       p (- x f)]
-                   (cond
-                     (zero? p) (arr/get-double data i)
-                     (= 1.0 p) (arr/get-double data (inc i))
-                     :else     (+ (* p (arr/get-double data (inc i)))
-                                  (* (- 1.0 p) (arr/get-double data i))))))]
-    (prim/invoke-dd interp (* quantile n))))
+  (interpolate-at data (* quantile (dec (arr/length data)))))
 
 (defn central-moment
   "Compute the r-th central moment: (1/n) * Σ(xᵢ - μ)^r

--- a/components/stats/src/criterium/stats/core.clj
+++ b/components/stats/src/criterium/stats/core.clj
@@ -3,14 +3,16 @@
 
   All functions require typed arrays (ITypedArray) as input.
   Primitive-optimized implementations avoid boxing overhead."
-  (:refer-clojure :exclude [min max])
+  (:refer-clojure :exclude [min max reduce])
   (:require
    [criterium.array :as arr]
    criterium.array.interfaces
    [criterium.primitive-fn :as prim]
+   [criterium.transducer :as tr]
    [criterium.utils.interface :as utils :refer [have?]])
   (:import
-   [criterium.array.interfaces IDoubleFold]))
+   [criterium.array.interfaces IDoubleFold]
+   [criterium.transducer.interfaces IDDDReducible]))
 
 (defn transpose
   "Transpose a vector of vectors."
@@ -24,7 +26,7 @@
   Requires a typed array (ITypedArray)."
   ([data]
    {:pre [(have? arr/typed-array? data)]}
-   (arr/fold-double data prim/dmin Double/MAX_VALUE))
+   (tr/reduce tr/prim-min Double/MAX_VALUE ^IDDDReducible data))
   ([data _count]
    (min data)))
 
@@ -33,7 +35,7 @@
   Requires a typed array (ITypedArray)."
   ([data]
    {:pre [(have? arr/typed-array? data)]}
-   (arr/fold-double data prim/dmax Double/MIN_VALUE))
+   (tr/reduce tr/prim-max Double/MIN_VALUE ^IDDDReducible data))
   ([data _count]
    (max data)))
 
@@ -44,17 +46,17 @@
    {:pre [(have? arr/typed-array? data)]}
    (let [c (arr/length data)]
      (when (pos? c)
-       (/ (arr/fold-double data prim/dadd-unchecked 0.0) c))))
+       (/ (tr/reduce tr/prim-sum 0.0 ^IDDDReducible data) c))))
   (^double [data ^long count]
    {:pre [(have? arr/typed-array? data)]}
-   (/ (arr/fold-double data prim/dadd-unchecked 0.0) count)))
+   (/ (tr/reduce tr/prim-sum 0.0 ^IDDDReducible data) count)))
 
 (defn sum
   "Sum of each data point.
   Requires a typed array (ITypedArray)."
   [data]
   {:pre [(have? arr/typed-array? data)]}
-  (arr/fold-double data prim/dadd-unchecked 0.0))
+  (tr/reduce tr/prim-sum 0.0 ^IDDDReducible data))
 
 (defn sum-of-squares
   "Sum of the squares of each data point.

--- a/components/stats/src/criterium/stats/core.clj
+++ b/components/stats/src/criterium/stats/core.clj
@@ -58,17 +58,17 @@
   {:pre [(have? arr/typed-array? data)]}
   (tr/reduce prim/dadd 0.0 ^IDDDReducible data))
 
-(def ^:private prim-square
+(defn- reduce-dsquare
   "Primitive squaring function for transducer map."
-  (reify clojure.lang.IFn$DD
-    (^double invokePrim [_ ^double x] (* x x))))
+  ^double [^double acc ^double x]
+  (+ acc (* x x)))
 
 (defn sum-of-squares
   "Sum of the squares of each data point.
   Requires a typed array (ITypedArray)."
   ^double [data]
   {:pre [(have? arr/typed-array? data)]}
-  (tr/transduce (tr/map prim-square) tr/prim-sum 0.0 ^IDDDReducible data))
+  (tr/reduce reduce-dsquare 0.0 ^IDDDReducible data))
 
 (defn variance*
   "Variance based on subtracting mean.
@@ -81,26 +81,28 @@
 
 (defn- variance-typed-array
   "Single-pass variance computation for typed arrays."
-  ^double [^IDoubleFold data ^long df]
-  (let [^doubles mq (double-array [0.0 0.0])
-        ^longs k (long-array [0])]
+  ^double [^IDDDReducible data ^long df]
+  (let [^doubles mq (arr/doubles-fill 2 0.0)
+        ^longs k    (arr/longs-fill 1 0)]
     ;; Accumulate in arrays to avoid boxing
-    (.fold data
-           (fn ^double [^double _ ^double x]
-             (let [k-val   (aget k 0)
-                   kp1     (unchecked-inc k-val)
-                   m       (aget mq 0)
-                   delta   (- x m)
-                   new-m   (+ m (/ delta kp1))
-                   new-q   (+ (aget mq 1) (/ (* k-val (utils/sqr delta)) kp1))]
-               (aset mq 0 new-m)
-               (aset mq 1 new-q)
-               (aset k 0 kp1)
-               0.0))
-           0.0)
+    (tr/reduce
+     (fn ^double [^double _ ^double x]
+       (let [k-val (aget k 0)
+             kp1   (unchecked-inc k-val)
+             m     (aget mq 0)
+             delta (- x m)
+             new-m (+ m (/ delta kp1))
+             new-q (+ (aget mq 1) (/ (* k-val (utils/sqr delta)) kp1))]
+         (aset mq 0 new-m)
+         (aset mq 1 new-q)
+         (aset k 0 kp1)
+         0.0))
+     0.0
+     data)
     (let [k-val (aget k 0)]
-      (when (> k-val df)
-        (/ (aget mq 1) (- k-val df))))))
+      (if (> k-val df)
+        (/ (aget mq 1) (- k-val df))
+        Double/NaN))))
 
 (defn variance
   "Return the variance of data.

--- a/components/stats/src/criterium/stats/core.clj
+++ b/components/stats/src/criterium/stats/core.clj
@@ -24,19 +24,19 @@
 (defn min
   "Minimum value in data.
   Requires a typed array (ITypedArray)."
-  ([data]
+  (^double [data]
    {:pre [(have? arr/typed-array? data)]}
-   (tr/reduce tr/prim-min Double/MAX_VALUE ^IDDDReducible data))
-  ([data _count]
+   (tr/reduce prim/dmin Double/MAX_VALUE ^IDDDReducible data))
+  (^double [data ^long _count]
    (min data)))
 
 (defn max
   "Maximum value in data.
   Requires a typed array (ITypedArray)."
-  ([data]
+  (^double [data]
    {:pre [(have? arr/typed-array? data)]}
-   (tr/reduce tr/prim-max Double/MIN_VALUE ^IDDDReducible data))
-  ([data _count]
+   (tr/reduce prim/dmax Double/MIN_VALUE ^IDDDReducible data))
+  (^double [data ^long _count]
    (max data)))
 
 (defn mean
@@ -46,25 +46,29 @@
    {:pre [(have? arr/typed-array? data)]}
    (let [c (arr/length data)]
      (when (pos? c)
-       (/ (tr/reduce tr/prim-sum 0.0 ^IDDDReducible data) c))))
+       (/ (tr/reduce prim/dadd 0.0 ^IDDDReducible data) c))))
   (^double [data ^long count]
    {:pre [(have? arr/typed-array? data)]}
-   (/ (tr/reduce tr/prim-sum 0.0 ^IDDDReducible data) count)))
+   (/ (tr/reduce prim/dadd 0.0 ^IDDDReducible data) count)))
 
 (defn sum
   "Sum of each data point.
   Requires a typed array (ITypedArray)."
-  [data]
+  ^double [data]
   {:pre [(have? arr/typed-array? data)]}
-  (tr/reduce tr/prim-sum 0.0 ^IDDDReducible data))
+  (tr/reduce prim/dadd 0.0 ^IDDDReducible data))
+
+(def ^:private prim-square
+  "Primitive squaring function for transducer map."
+  (reify clojure.lang.IFn$DD
+    (^double invokePrim [_ ^double x] (* x x))))
 
 (defn sum-of-squares
   "Sum of the squares of each data point.
   Requires a typed array (ITypedArray)."
-  [data]
+  ^double [data]
   {:pre [(have? arr/typed-array? data)]}
-  (let [f (fn ^double [^double s ^double v] (+ s (* v v)))]
-    (arr/fold-double data f 0.0)))
+  (tr/transduce (tr/map prim-square) tr/prim-sum 0.0 ^IDDDReducible data))
 
 (defn variance*
   "Variance based on subtracting mean.

--- a/components/stats/src/criterium/stats/kde.clj
+++ b/components/stats/src/criterium/stats/kde.clj
@@ -780,22 +780,23 @@
   - data: typed array of sample values
   - k: maximum number of modes
   - opts: optional map with :tol (tolerance, default 1e-6),
-          :n-points (grid size, default 512)
+          :n-points (grid size, default 512),
+          :h-max (optional upper bound, useful when computing h_k knowing h_{k-1})
 
   Requires a typed array (DoubleArray or LongArray)."
-  ^double [data ^long k {:keys [tol n-points]
+  ^double [data ^long k {:keys [tol n-points h-max]
                          :or {tol 1e-6
                               n-points 512}}]
   {:pre [(have? arr/typed-array? data)]}
   (let [n-pts (long n-points)
         tol (double tol)
         sigma (Math/sqrt (core/variance data))
-        ;; Start with range from very small to Silverman bandwidth * 2
-        h-max (* 2.0 (silverman-bandwidth data))
+        ;; Start with range from very small to provided h-max or Silverman bandwidth * 2
+        h-upper (double (or h-max (* 2.0 (silverman-bandwidth data))))
         h-min (/ sigma 100.0)]
     ;; Binary search for smallest h with <= k modes
     (loop [lo h-min
-           hi h-max
+           hi h-upper
            its 0]
       (if (or (>= its 100) (< (- hi lo) (* tol (+ hi lo) 0.5)))
         hi
@@ -806,6 +807,31 @@
             (recur lo mid (inc its))
             ;; Too many modes, need larger bandwidth
             (recur mid hi (inc its))))))))
+
+(defn critical-bandwidths
+  "Compute critical bandwidths for k=1 to max-k efficiently.
+
+  Uses h_{k-1} as upper bound for h_k since h_k < h_{k-1} (more modes
+  require less smoothing). This avoids redundant binary search iterations
+  when testing multiple k values.
+
+  Parameters:
+  - data: typed array of sample values
+  - max-k: maximum number of modes to compute bandwidth for
+  - opts: optional map with :tol (tolerance), :n-points (grid size)
+
+  Returns a map from k to critical bandwidth h_k."
+  [data ^long max-k opts]
+  {:pre [(have? arr/typed-array? data)]}
+  (loop [k 1
+         prev-h nil
+         results {}]
+    (if (> k max-k)
+      results
+      (let [h-k (critical-bandwidth data k (if prev-h
+                                             (assoc opts :h-max prev-h)
+                                             opts))]
+        (recur (inc k) h-k (assoc results k h-k))))))
 
 (defn- find-antimodes
   "Find antimodes (local minima) in a density estimate.
@@ -840,7 +866,8 @@
   - data: typed array of sample values
   - k: target number of modes
   - opts: optional map with :n-points (grid size, default 512),
-          :tol (tolerance, default 1e-6)
+          :tol (tolerance, default 1e-6),
+          :cached-critical-bandwidth (optional pre-computed bandwidth)
 
   Returns:
   {:modes [{:location, :density} ...] - sorted by location
@@ -848,12 +875,13 @@
    :critical-bandwidth h_k}
 
   Requires a typed array (DoubleArray or LongArray)."
-  [data ^long k {:keys [n-points tol]
+  [data ^long k {:keys [n-points tol cached-critical-bandwidth]
                  :or {n-points 512
                       tol 1e-6}}]
   {:pre [(have? arr/typed-array? data)]}
   (let [n-pts (long n-points)
-        h (critical-bandwidth data k {:n-points n-pts :tol tol})
+        h (double (or cached-critical-bandwidth
+                      (critical-bandwidth data k {:n-points n-pts :tol tol})))
         [x-min x-max] (data-min-max data)
         x-min (double x-min)
         x-max (double x-max)
@@ -934,6 +962,7 @@
     - :n-points (default 512)
     - :alpha (for Hall-York correction, default 0.05)
     - :tol (for critical bandwidth search, default 1e-6)
+    - :cached-critical-bandwidth (optional pre-computed bandwidth, skips search if provided)
     - :rng-factory: 0-arity fn returning WellRng1024a (default: make-well-rng-1024a)
 
   Returns map with:
@@ -943,7 +972,7 @@
   - :corrected? - whether Hall-York correction was applied
 
   Requires a typed array (DoubleArray or LongArray)."
-  [data ^long k {:keys [n-bootstrap n-points alpha tol rng-factory]
+  [data ^long k {:keys [n-bootstrap n-points alpha tol cached-critical-bandwidth rng-factory]
                  :or {n-bootstrap 200
                       n-points 512
                       alpha 0.05
@@ -951,8 +980,9 @@
                       rng-factory #(random/make-well-rng-1024a)}}]
   {:pre [(have? arr/typed-array? data)]}
   (let [n-pts (long n-points)
-        ;; Find critical bandwidth
-        h-crit (critical-bandwidth data k {:tol tol :n-points n-pts})
+        ;; Use pre-computed critical bandwidth or compute it
+        h-crit (double (or cached-critical-bandwidth
+                           (critical-bandwidth data k {:tol tol :n-points n-pts})))
         ;; Bootstrap: count how many times we get > k modes
         exceeds (atom 0)]
     (dotimes [_ n-bootstrap]
@@ -995,6 +1025,7 @@
     - :n-bootstrap (default 200)
     - :n-points (default 512)
     - :tol (for critical bandwidth search, default 1e-6)
+    - :cached-critical-bandwidth (optional pre-computed bandwidth, skips search if provided)
     - :rng-factory: 0-arity fn returning WellRng1024a (default: make-well-rng-1024a)
 
   Returns map with:
@@ -1007,15 +1038,16 @@
   bandwidth and excess mass' TEST 28, 900-919
 
   Requires a typed array (DoubleArray or LongArray)."
-  [data ^long k {:keys [n-bootstrap n-points tol rng-factory]
+  [data ^long k {:keys [n-bootstrap n-points tol cached-critical-bandwidth rng-factory]
                  :or {n-bootstrap 200
                       n-points 512
                       tol 1e-6
                       rng-factory #(random/make-well-rng-1024a)}}]
   {:pre [(have? arr/typed-array? data)]}
   (let [n-pts (long n-points)
-        ;; Find critical bandwidth
-        h-crit (critical-bandwidth data k {:tol tol :n-points n-pts})
+        ;; Use pre-computed critical bandwidth or compute it
+        h-crit (double (or cached-critical-bandwidth
+                           (critical-bandwidth data k {:tol tol :n-points n-pts})))
         ;; Compute observed excess mass statistic
         observed-em (:statistic (excess-mass data k {:rng-factory rng-factory}))
         observed-em (double observed-em)

--- a/components/stats/src/criterium/stats/kde.clj
+++ b/components/stats/src/criterium/stats/kde.clj
@@ -792,10 +792,11 @@
   - k: maximum number of modes
   - opts: optional map with :tol (tolerance, default 1e-6),
           :n-points (grid size, default 512),
-          :h-max (optional upper bound, useful when computing h_k knowing h_{k-1})
+          :h-max (optional upper bound, useful when computing h_k knowing h_{k-1}),
+          :data-bounds (optional [min max], avoids redundant data scan)
 
   Requires a typed array (DoubleArray or LongArray)."
-  ^double [data ^long k {:keys [tol n-points h-max]
+  ^double [data ^long k {:keys [tol n-points h-max data-bounds]
                          :or {tol 1e-6
                               n-points 512}}]
   {:pre [(have? arr/typed-array? data)]}
@@ -803,7 +804,7 @@
         tol (double tol)
         sigma (Math/sqrt (core/variance data))
         ;; Pre-compute grid once for all binary search iterations
-        [x-min x-max] (data-min-max data)
+        [x-min x-max] (or data-bounds (data-min-max data))
         grid (make-mode-counting-grid x-min x-max n-pts)
         ;; Start with range from very small to provided h-max or Silverman bandwidth * 2
         h-upper (double (or h-max (* 2.0 (silverman-bandwidth data))))
@@ -837,15 +838,18 @@
   Returns a map from k to critical bandwidth h_k."
   [data ^long max-k opts]
   {:pre [(have? arr/typed-array? data)]}
-  (loop [k 1
-         prev-h nil
-         results {}]
-    (if (> k max-k)
-      results
-      (let [h-k (critical-bandwidth data k (if prev-h
-                                             (assoc opts :h-max prev-h)
-                                             opts))]
-        (recur (inc k) h-k (assoc results k h-k))))))
+  ;; Compute data bounds once for all k values
+  (let [data-bounds (data-min-max data)
+        opts (assoc opts :data-bounds data-bounds)]
+    (loop [k 1
+           prev-h nil
+           results {}]
+      (if (> k max-k)
+        results
+        (let [h-k (critical-bandwidth data k (if prev-h
+                                               (assoc opts :h-max prev-h)
+                                               opts))]
+          (recur (inc k) h-k (assoc results k h-k)))))))
 
 (defn- find-antimodes
   "Find antimodes (local minima) in a density estimate.
@@ -881,7 +885,8 @@
   - k: target number of modes
   - opts: optional map with :n-points (grid size, default 512),
           :tol (tolerance, default 1e-6),
-          :cached-critical-bandwidth (optional pre-computed bandwidth)
+          :cached-critical-bandwidth (optional pre-computed bandwidth),
+          :data-bounds (optional [min max], avoids redundant data scan)
 
   Returns:
   {:modes [{:location, :density} ...] - sorted by location
@@ -889,32 +894,26 @@
    :critical-bandwidth h_k}
 
   Requires a typed array (DoubleArray or LongArray)."
-  [data ^long k {:keys [n-points tol cached-critical-bandwidth]
+  [data ^long k {:keys [n-points tol cached-critical-bandwidth data-bounds]
                  :or {n-points 512
                       tol 1e-6}}]
   {:pre [(have? arr/typed-array? data)]}
   (let [n-pts (long n-points)
+        [x-min x-max] (or data-bounds (data-min-max data))
         h (double (or cached-critical-bandwidth
-                      (critical-bandwidth data k {:n-points n-pts :tol tol})))
-        [x-min x-max] (data-min-max data)
-        x-min (double x-min)
-        x-max (double x-max)
-        margin (/ (- x-max x-min) 10.0)
-        g-min (- x-min margin)
-        g-max (+ x-max margin)
-        g-range (- g-max g-min)
-        grid (double-array n-pts)]
-    (dotimes [i n-pts]
-      (aset grid i (+ g-min (* g-range (/ (double i) (double (dec n-pts)))))))
-    (let [density (gaussian-kde data h grid)
-          modes (->> (find-modes grid density)
-                     (map #(dissoc % :index))
-                     (sort-by :location)
-                     vec)
-          antimodes (find-antimodes grid density)]
-      {:modes modes
-       :antimodes antimodes
-       :critical-bandwidth h})))
+                      (critical-bandwidth data k {:n-points n-pts
+                                                  :tol tol
+                                                  :data-bounds [x-min x-max]})))
+        grid (make-mode-counting-grid x-min x-max n-pts)
+        density (gaussian-kde data h grid)
+        modes (->> (find-modes grid density)
+                   (map #(dissoc % :index))
+                   (sort-by :location)
+                   vec)
+        antimodes (find-antimodes grid density)]
+    {:modes modes
+     :antimodes antimodes
+     :critical-bandwidth h}))
 
 (defn silverman-bootstrap-sample
   "Generate a smoothed bootstrap sample for Silverman's test.

--- a/components/stats/src/criterium/stats/kde.clj
+++ b/components/stats/src/criterium/stats/kde.clj
@@ -751,6 +751,26 @@
 
 ;;; Silverman's test for multimodality
 
+(defn- count-modes-with-grid
+  "Count modes using a pre-computed grid. Internal helper for critical-bandwidth.
+  Avoids recomputing grid bounds when same data is used with different bandwidths."
+  ^long [data ^double bandwidth ^doubles grid]
+  (let [density (gaussian-kde data bandwidth grid)]
+    (count (find-modes grid density))))
+
+(defn- make-mode-counting-grid
+  "Create grid for mode counting from data bounds.
+  Grid extends 10% beyond data range on each side."
+  ^doubles [^double x-min ^double x-max ^long n-points]
+  (let [margin (/ (- x-max x-min) 10.0)
+        g-min (- x-min margin)
+        g-max (+ x-max margin)
+        g-range (- g-max g-min)
+        grid (double-array n-points)]
+    (dotimes [i n-points]
+      (aset grid i (+ g-min (* g-range (/ (double i) (double (dec n-points)))))))
+    grid))
+
 (defn count-modes
   "Count number of modes in KDE with given bandwidth.
   Creates a grid and counts local maxima in the density estimate.
@@ -758,17 +778,8 @@
   ^long [data ^double bandwidth ^long n-points]
   {:pre [(have? arr/typed-array? data)]}
   (let [[x-min x-max] (data-min-max data)
-        x-min (double x-min)
-        x-max (double x-max)
-        margin (/ (- x-max x-min) 10.0)
-        g-min (- x-min margin)
-        g-max (+ x-max margin)
-        g-range (- g-max g-min)
-        grid (double-array n-points)]
-    (dotimes [i n-points]
-      (aset grid i (+ g-min (* g-range (/ (double i) (double (dec n-points)))))))
-    (let [density (gaussian-kde data bandwidth grid)]
-      (count (find-modes grid density)))))
+        grid (make-mode-counting-grid x-min x-max n-points)]
+    (count-modes-with-grid data bandwidth grid)))
 
 (defn critical-bandwidth
   "Find smallest bandwidth giving at most k modes via binary search.
@@ -791,6 +802,9 @@
   (let [n-pts (long n-points)
         tol (double tol)
         sigma (Math/sqrt (core/variance data))
+        ;; Pre-compute grid once for all binary search iterations
+        [x-min x-max] (data-min-max data)
+        grid (make-mode-counting-grid x-min x-max n-pts)
         ;; Start with range from very small to provided h-max or Silverman bandwidth * 2
         h-upper (double (or h-max (* 2.0 (silverman-bandwidth data))))
         h-min (/ sigma 100.0)]
@@ -801,7 +815,7 @@
       (if (or (>= its 100) (< (- hi lo) (* tol (+ hi lo) 0.5)))
         hi
         (let [mid (* 0.5 (+ lo hi))
-              n-modes (count-modes data mid n-pts)]
+              n-modes (count-modes-with-grid data mid grid)]
           (if (<= n-modes k)
             ;; Can achieve <= k modes, try smaller bandwidth
             (recur lo mid (inc its))

--- a/components/stats/src/criterium/stats/kde.clj
+++ b/components/stats/src/criterium/stats/kde.clj
@@ -119,58 +119,71 @@
         col-offset (- j i 1)]
     (aget dist-arr (+ row-start col-offset))))
 
-(defn- compute-interval-distances
-  "Compute minimum cumulative distances for k disjoint intervals.
+(defn- compute-interval-distances-k1
+  "Compute minimum cumulative distances for k=1 (single interval).
+  For each span s, finds the minimum interval width covering s+1 points.
+  Returns array where element i is the min distance for span (i+1)."
+  ^doubles [^doubles dist-arr ^long n]
+  (let [result (double-array (dec n))]
+    (dotimes [span (dec n)]
+      (let [interval-size (long (inc span))
+            min-d (double
+                   (loop [start (long 0)
+                          md Double/MAX_VALUE]
+                     (if (< (+ start interval-size) n)
+                       (let [end (+ start interval-size)
+                             d (distance-at dist-arr n start end)]
+                         (recur (inc start) (Math/min md d)))
+                       md)))]
+        (aset result (int span) min-d)))
+    result))
 
-  For each 'span' (total points covered by k intervals), find the
-  minimum total distance (sum of interval widths) achievable.
+(defn- compute-interval-distances-next
+  "Compute minimum cumulative distances for k intervals given k-1 results.
+  Returns array where element i is the min distance for span (i+k)."
+  ^doubles [^doubles dist-arr ^long n ^long k ^doubles prev-mins]
+  (let [prev-len (long (alength prev-mins))
+        result-len (- n k)
+        result (double-array result-len)]
+    (dotimes [span result-len]
+      (let [total-span (long (+ span k 1))
+            min-d (double
+                   (loop [new-int-size (long 2)
+                          md Double/MAX_VALUE]
+                     (if (<= new-int-size (- total-span (* 2 (dec k))))
+                       (let [prev-span (long (- total-span new-int-size))
+                             prev-idx (long (- prev-span k))
+                             prev-d (if (and (>= prev-idx 0) (< prev-idx prev-len))
+                                      (aget prev-mins prev-idx)
+                                      Double/MAX_VALUE)
+                             new-d (loop [start (long (- total-span new-int-size))
+                                          nd Double/MAX_VALUE]
+                                     (if (>= start prev-span)
+                                       (if (< (+ start new-int-size) n)
+                                         (let [end (+ start (dec new-int-size))
+                                               d (distance-at dist-arr n start end)]
+                                           (recur (dec start) (Math/min nd d)))
+                                         (recur (dec start) nd))
+                                       nd))]
+                         (recur (inc new-int-size) (Math/min md (+ prev-d (double new-d)))))
+                       md)))]
+        (aset result (int span) min-d)))
+    result))
 
-  Returns vector where element i is the min distance for span (i+k)."
-  ^doubles [^doubles dist-arr ^long n ^long k]
-  (if (= k 1)
-    ;; For k=1, min distance for span s is simply the min interval of that span
-    (let [result (double-array (- n 1))]
-      (dotimes [span (- n 1)]
-        (let [interval-size (long (inc span))
-              min-d (double
-                     (loop [start (long 0)
-                            md Double/MAX_VALUE]
-                       (if (< (+ start interval-size) n)
-                         (let [end (+ start interval-size)
-                               d (distance-at dist-arr n start end)]
-                           (recur (inc start) (Math/min md d)))
-                         md)))]
-          (aset result (int span) min-d)))
-      result)
-    ;; For k>1, build on k-1 solution
-    (let [^doubles prev-mins (compute-interval-distances dist-arr n (dec k))
-          prev-len (long (alength prev-mins))
-          result-len (- n k)
-          result (double-array result-len)]
-      (dotimes [span result-len]
-        (let [total-span (long (+ span k 1))
-              min-d (double
-                     (loop [new-int-size (long 2)
-                            md Double/MAX_VALUE]
-                       (if (<= new-int-size (- total-span (* 2 (dec k))))
-                         (let [prev-span (long (- total-span new-int-size))
-                               prev-idx (long (- prev-span k))
-                               prev-d (if (and (>= prev-idx 0) (< prev-idx prev-len))
-                                        (aget prev-mins prev-idx)
-                                        Double/MAX_VALUE)
-                               new-d (loop [start (long (- total-span new-int-size))
-                                            nd Double/MAX_VALUE]
-                                       (if (>= start prev-span)
-                                         (if (< (+ start new-int-size) n)
-                                           (let [end (+ start (dec new-int-size))
-                                                 d (distance-at dist-arr n start end)]
-                                             (recur (dec start) (Math/min nd d)))
-                                           (recur (dec start) nd))
-                                         nd))]
-                           (recur (inc new-int-size) (Math/min md (+ prev-d (double new-d)))))
-                         md)))]
-          (aset result (int span) min-d)))
-      result)))
+(defn- compute-all-interval-distances
+  "Compute minimum cumulative distances for 1 to max-k disjoint intervals.
+  Bottom-up computation that avoids redundant recursive calls.
+  Returns a vector of arrays, where element i is the result for k=i+1."
+  [^doubles dist-arr ^long n ^long max-k]
+  (loop [k 1
+         results []]
+    (if (> k max-k)
+      results
+      (let [result (if (= k 1)
+                     (compute-interval-distances-k1 dist-arr n)
+                     (compute-interval-distances-next
+                      dist-arr n k (nth results (- k 2))))]
+        (recur (inc k) (conj results result))))))
 
 (defn excess-mass
   "Compute excess mass statistic for testing k modes.
@@ -222,9 +235,10 @@
            ;; Build distance matrix
            dist-arr (build-distance-matrix sorted-data)
            nd (double n)
-           ;; Compute min distances for spans of k and k+1 intervals
-           ^doubles min-dist-k (compute-interval-distances dist-arr n k)
-           ^doubles min-dist-k1 (compute-interval-distances dist-arr n (inc k))
+           ;; Compute min distances for spans of 1 to k+1 intervals in one pass
+           all-dists (compute-all-interval-distances dist-arr n (inc k))
+           ^doubles min-dist-k (nth all-dists (dec k))
+           ^doubles min-dist-k1 (nth all-dists k)
            len-k (long (alength min-dist-k))
            len-k1 (long (alength min-dist-k1))
            ;; Find all possible lambda values where transitions occur

--- a/components/stats/src/criterium/stats/kde.clj
+++ b/components/stats/src/criterium/stats/kde.clj
@@ -165,7 +165,8 @@
                                            (recur (dec start) (Math/min nd d)))
                                          (recur (dec start) nd))
                                        nd))]
-                         (recur (inc new-int-size) (Math/min md (+ prev-d (double new-d)))))
+                         (recur (inc new-int-size)
+                                (Math/min md (+ prev-d (double new-d)))))
                        md)))]
         (aset result (int span) min-d)))
     result))
@@ -280,15 +281,19 @@
            max-diff (double
                      (if (empty? lambda-vec)
                        (let [lam 1.0
-                             ^double em-k (compute-em lam k min-dist-k len-k)
-                             ^double em-k1 (compute-em lam (inc k) min-dist-k1 len-k1)]
+                             em-k (pf/invoke-dlold
+                                   compute-em lam k min-dist-k len-k)
+                             em-k1 (pf/invoke-dlold
+                                    compute-em lam (inc k) min-dist-k1 len-k1)]
                          (- em-k1 em-k))
                        (loop [idx (long 0)
                               max-d Double/NEGATIVE_INFINITY]
                          (if (< idx (count lambda-vec))
                            (let [lam (nth lambda-vec idx)
-                                 ^double em-k (compute-em lam k min-dist-k len-k)
-                                 ^double em-k1 (compute-em lam (inc k) min-dist-k1 len-k1)
+                                 em-k (pf/invoke-dlold
+                                       compute-em lam k min-dist-k len-k)
+                                 em-k1 (pf/invoke-dlold
+                                        compute-em lam (inc k) min-dist-k1 len-k1)
                                  d (- em-k1 em-k)]
                              (recur (inc idx) (Math/max max-d d)))
                            max-d))))]
@@ -393,7 +398,7 @@
                         (aset weights i-high (+ (aget weights i-high) w-high))))]
     (arr/dfold data
                (fn [_ ^double x]
-                 (add-weight! x)
+                 (pf/invoke-do add-weight! x)
                  nil)
                nil)
     ;; Normalize to sum to 1

--- a/components/stats/test/criterium/stats/kde_test.clj
+++ b/components/stats/test/criterium/stats/kde_test.clj
@@ -1,4 +1,4 @@
-(ns criterium.util.kde-test
+(ns criterium.stats.kde-test
   ;; Tests for the KDE (Kernel Density Estimation) module.
   ;; Verifies ISJ bandwidth selection, Gaussian KDE evaluation,
   ;; mode detection, and bootstrap confidence intervals.

--- a/development/src/criterium/kde_benchmark.clj
+++ b/development/src/criterium/kde_benchmark.clj
@@ -1,0 +1,216 @@
+(ns criterium.kde-benchmark
+  "Benchmark notebook for KDE functions to identify allocation hotspots.
+
+  Uses `:with-allocation-trace true` to capture both timing and allocation
+  data for criterium.stats.kde functions."
+  (:require
+   [criterium.array :as arr]
+   [criterium.bench :as bench]
+   [criterium.stats.kde :as kde]))
+
+;; # KDE Function Benchmarks
+;;
+;; This notebook benchmarks KDE functions to identify allocation hotspots
+;; and verify which functions are garbage-free.
+
+;; ## Test Data Helpers
+
+(defn unimodal-data
+  "Create unimodal test data (uniform distribution)."
+  [n]
+  (arr/->double-array (double-array (range n))))
+
+(defn bimodal-data
+  "Create bimodal test data with two clusters."
+  [n]
+  (let [n (long n)
+        half (quot n 2)]
+    (arr/->double-array
+     (double-array
+      (concat (range half)
+              (range (* 3 half) (* 4 half)))))))
+
+(defn normal-like-data
+  "Create roughly normal-distributed test data."
+  [n]
+  (let [n (long n)
+        center (/ (double n) 2.0)
+        scale (/ (double n) 4.0)]
+    (arr/->double-array
+     (double-array
+      (for [_ (range n)]
+        (+ center (* scale (- (double (rand)) 0.5))))))))
+
+;; Sample data for benchmarks
+(def ^:private data-20 (unimodal-data 20))
+(def ^:private data-30 (unimodal-data 30))
+(def ^:private bimodal-30 (bimodal-data 30))
+
+;; Standard grid for KDE evaluation
+(def ^:private grid-256
+  (double-array (for [i (range 256)]
+                  (/ (double i) 255.0))))
+
+(def ^:private grid-512
+  (double-array (for [i (range 512)]
+                  (* 100.0 (/ (double i) 511.0)))))
+
+;; ## Bandwidth Selection Functions
+
+;; ### silverman-bandwidth
+
+(bench/bench (kde/silverman-bandwidth data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### isj-bandwidth
+
+(bench/bench (kde/isj-bandwidth data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Core KDE Functions
+
+;; ### linear-bin
+
+(bench/bench (kde/linear-bin data-30 grid-256)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### dct-ii
+
+(let [binned (kde/linear-bin data-30 grid-256)]
+  (bench/bench (kde/dct-ii binned)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### gaussian-kde (uses gaussian-kde-fft internally)
+
+(bench/bench (kde/gaussian-kde data-30 1.0 grid-256)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Mode Detection Functions
+
+;; ### find-modes
+
+(let [density (kde/gaussian-kde data-30 5.0 grid-512)]
+  (bench/bench (kde/find-modes grid-512 density)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### count-modes
+
+(bench/bench (kde/count-modes data-30 5.0 256)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Critical Bandwidth Functions
+
+;; ### critical-bandwidth (single k)
+
+(bench/bench (kde/critical-bandwidth data-30 1 {:n-points 256})
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### critical-bandwidths (multiple k values)
+
+(bench/bench (kde/critical-bandwidths data-30 3 {:n-points 256})
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### locate-modes
+
+(bench/bench (kde/locate-modes data-30 2 {:n-points 256})
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Excess Mass and Multimodality Tests
+
+;; ### excess-mass
+
+(bench/bench (kde/excess-mass data-30 1)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; excess-mass with k=2
+
+(bench/bench (kde/excess-mass bimodal-30 2)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### silverman-test
+;;
+;; Note: This is slow due to bootstrap iterations. Using reduced n-bootstrap.
+
+(bench/bench (kde/silverman-test data-20 1 {:n-bootstrap 20 :n-points 256})
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### acr-test
+;;
+;; Note: This is slow due to bootstrap iterations. Using reduced n-bootstrap.
+
+(bench/bench (kde/acr-test data-20 1 {:n-bootstrap 20 :n-points 256})
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## High-Level API
+
+;; ### kde (full analysis)
+;;
+;; Note: Uses reduced bootstrap for speed.
+
+(bench/bench (kde/kde data-30 {:n-points 256 :n-bootstrap 20})
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Internal Function Benchmarks
+;;
+;; These access private functions to benchmark performance-critical internals.
+
+;; ### build-distance-matrix
+
+(let [sorted-data (double-array (sort (seq (.array ^criterium.array.DoubleArray data-30))))]
+  (bench/bench (#'kde/build-distance-matrix sorted-data)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### compute-all-interval-distances
+
+(let [sorted-data (double-array (sort (seq (.array ^criterium.array.DoubleArray data-30))))
+      dist-arr (#'kde/build-distance-matrix sorted-data)
+      n (alength sorted-data)]
+  (bench/bench (#'kde/compute-all-interval-distances dist-arr n 3)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### count-modes-with-grid
+
+(let [[x-min x-max] (#'kde/data-min-max data-30)
+      grid (#'kde/make-mode-counting-grid x-min x-max 256)]
+  (bench/bench (#'kde/count-modes-with-grid data-30 5.0 grid)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### dct-via-fft
+
+(let [binned (kde/linear-bin data-30 grid-256)]
+  (bench/bench (#'kde/dct-via-fft binned)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### gaussian-kde-fft
+
+(bench/bench (#'kde/gaussian-kde-fft data-30 1.0 grid-256)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Summary
+;;
+;; Functions to watch for allocations:
+;; - build-distance-matrix: O(n^2) array allocation
+;; - compute-all-interval-distances: Multiple array allocations per k
+;; - gaussian-kde-fft: FFT arrays
+;; - critical-bandwidth: Grid allocation per binary search iteration
+;; - bootstrap tests: Many iterations each allocating samples

--- a/development/src/criterium/kde_benchmark.clj
+++ b/development/src/criterium/kde_benchmark.clj
@@ -8,6 +8,8 @@
    [criterium.bench :as bench]
    [criterium.stats.kde :as kde]))
 
+(bench/set-default-viewer! :kindly)
+
 ;; # KDE Function Benchmarks
 ;;
 ;; This notebook benchmarks KDE functions to identify allocation hotspots
@@ -22,9 +24,8 @@
 
 (defn bimodal-data
   "Create bimodal test data with two clusters."
-  [n]
-  (let [n (long n)
-        half (quot n 2)]
+  [^long n]
+  (let [half (quot n 2)]
     (arr/->double-array
      (double-array
       (concat (range half)
@@ -32,10 +33,9 @@
 
 (defn normal-like-data
   "Create roughly normal-distributed test data."
-  [n]
-  (let [n (long n)
-        center (/ (double n) 2.0)
-        scale (/ (double n) 4.0)]
+  [^long n]
+  (let [center (/ (double n) 2.0)
+        scale  (/ (double n) 4.0)]
     (arr/->double-array
      (double-array
       (for [_ (range n)]

--- a/development/src/criterium/stats_core_benchmark.clj
+++ b/development/src/criterium/stats_core_benchmark.clj
@@ -1,0 +1,164 @@
+(ns criterium.stats-core-benchmark
+  "Benchmark notebook for stats.core functions to identify allocation hotspots.
+
+  Uses `:with-allocation-trace true` to capture both timing and allocation
+  data for criterium.stats.core functions."
+  (:require
+   [criterium.array :as arr]
+   [criterium.bench :as bench]
+   [criterium.stats.core :as stats]))
+
+(bench/set-default-viewer! :kindly)
+
+;; # Stats Core Function Benchmarks
+;;
+;; This notebook benchmarks stats.core functions to identify allocation
+;; hotspots and verify which functions are garbage-free.
+
+;; ## Test Data Helpers
+
+(defn unimodal-data
+  "Create unimodal test data from sequential values."
+  [n]
+  (arr/->double-array (double-array (range n))))
+
+;; Sample data for benchmarks (30 samples)
+(def ^:private data-30 (unimodal-data 30))
+
+;; Pre-sorted data for order statistics
+(def ^:private sorted-30
+  (arr/->double-array
+   (double-array (sort (seq (.array ^criterium.array.DoubleArray data-30))))))
+
+;; ## Basic Aggregation Functions
+
+;; ### min
+
+(bench/bench (stats/min data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### max
+
+(bench/bench (stats/max data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### mean
+
+(bench/bench (stats/mean data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### sum
+
+(bench/bench (stats/sum data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### sum-of-squares
+
+(bench/bench (stats/sum-of-squares data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Variance
+
+;; ### variance (sample, default df=1)
+
+(bench/bench (stats/variance data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### variance (population, df=0)
+
+(bench/bench (stats/variance data-30 0)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Order Statistics (pre-sorted data)
+
+;; ### median-value
+
+(bench/bench (stats/median-value sorted-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### median
+
+(bench/bench (stats/median sorted-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### quartiles
+
+(bench/bench (stats/quartiles sorted-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### quantile (0.5 - median)
+
+(bench/bench (stats/quantile 0.5 sorted-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### quantile (0.95)
+
+(bench/bench (stats/quantile 0.95 sorted-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Moments and Shape Statistics
+
+;; ### central-moment (r=2)
+
+(let [mu (stats/mean data-30)]
+  (bench/bench (stats/central-moment data-30 mu 2)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### central-moment (r=3)
+
+(let [mu (stats/mean data-30)]
+  (bench/bench (stats/central-moment data-30 mu 3)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### central-moment (r=4)
+
+(let [mu (stats/mean data-30)]
+  (bench/bench (stats/central-moment data-30 mu 4)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; ### skewness (type 2, default)
+
+(bench/bench (stats/skewness data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### kurtosis (type 2, default)
+
+(bench/bench (stats/kurtosis data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ### cv (coefficient of variation)
+
+(bench/bench (stats/cv data-30)
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Summary
+;;
+;; Expected allocation behavior:
+;; - min, max: garbage-free (fold-double with primitives)
+;; - mean, sum, sum-of-squares: garbage-free (fold-based)
+;; - variance: allocates small arrays for single-pass algorithm
+;; - median-value: garbage-free (direct array access)
+;; - median: allocates result vector [median nil nil]
+;; - quartiles: allocates result vector [q1 median q3]
+;; - quantile: garbage-free (direct array access)
+;; - central-moment: garbage-free (fold-based)
+;; - skewness, kurtosis: multiple central-moment calls
+;; - cv: combines mean and variance calls


### PR DESCRIPTION
## Summary

Improve performance of `:modes` analysis in criterium by eliminating redundant computations in the multimodality testing pipeline.

**Changes:**
- Add early stopping in `modes-for-metric` - stops testing k values once p-value ≥ alpha
- Refactor `compute-interval-distances` from recursive to bottom-up approach, avoiding redundant recomputation
- Cache critical bandwidths across k value tests using incremental bounds (h_{k-1} as upper bound for h_k)
- Pre-compute grid once in `critical-bandwidth` binary search and reuse across iterations
- Add `:data-bounds` option to avoid redundant min/max scans of data

## Test plan
- [x] All existing tests pass
- [x] Statistical accuracy maintained (same test results)
- [x] Performance improvements verified through profiling