### PR TITLE
refactor(bench-plans): rationalise bench plans

### DIFF
--- a/README.ALPHA.md
+++ b/README.ALPHA.md
@@ -45,7 +45,7 @@ If you are using portal, try:
 (require '[criterium.bench :as bench])
 (bench/bench (criterium.jvm/wait 10000)
   :viewer :portal
-  :benchmark criterium.benchmarks/log-histogram)
+  :bench-plan criterium.bench-plans/histogram)
 ```
 
 ## New features

--- a/bases/criterium/src/criterium/bench/config.clj
+++ b/bases/criterium/src/criterium/bench/config.clj
@@ -119,15 +119,15 @@
       (= scheme-type :with-jit-warmup)
       (assoc :analyse (or analyse
                           (:analyse bench-plan)
-                          (:analyse bench-plans/default-with-warmup))
+                          (:analyse bench-plans/default))
              :view (or view
                        (:view bench-plan)
-                       (:view bench-plans/default-with-warmup)))
+                       (:view bench-plans/default)))
 
       (= scheme-type :one-shot)
       (assoc :analyse (or analyse
                           (:analyse bench-plan)
-                          (:analyse bench-plans/default-one-shot))
+                          (:analyse bench-plans/one-shot))
              :view (or view
                        (:view bench-plan)
-                       (:view bench-plans/default-one-shot))))))
+                       (:view bench-plans/one-shot))))))

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -5,7 +5,7 @@
   {:stages []
    :terminator :elapsed-time})
 
-(def default-one-shot
+(def one-shot
   {:collector-config default-collector-config
    :analyse [:event-stats
              :allocation-summary
@@ -19,7 +19,7 @@
           :allocation-hotspots]
    :viewer :print})
 
-(def default-with-warmup
+(def default
   {:collector-config default-collector-config
    :analyse [:transform-log
              [:autocorrelation {:id :autocorrelation-raw}]
@@ -161,7 +161,7 @@
   "Benchmark plan with KDE analysis for density estimation and mode detection.
 
   Includes histogram and KDE analysis for visualizing sample distributions.
-  Not part of default-with-warmup; use explicitly when density analysis is needed."
+  Not part of the default bench plan; use explicitly when density analysis is needed."
   {:collector-config default-collector-config
    :analyse [:transform-log
              [:autocorrelation {:id :autocorrelation-raw}]

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -64,57 +64,20 @@
              {:warn-threshold 0.01}]]
    :viewer :print})
 
-(def log-histogram
-  {:collector-config default-collector-config
-   :analyse [:transform-log
-             [:autocorrelation {:id :autocorrelation-raw}]
-             [:autocorrelation-classification {:id :autocorrelation-classification-raw
-                                               :autocorrelation-id :autocorrelation-raw}]
-             [:quantiles {:quantiles [0.9 0.99]}]
-             :outliers
-             [:autocorrelation {:id :autocorrelation-filtered
-                                :outlier-id :outliers}]
-             [:effective-sample-size-analysis {:id :effective-sample-size-filtered
-                                               :autocorrelation-id :autocorrelation-filtered}]
-             [:stats {}]
-             [:stats {:samples-id :log-samples :id :log-stats}]
-             [:bootstrap-stats {:quantiles [0.99]
-                                :estimate-quantiles [0.025 0.975]
-                                :ess-id :effective-sample-size-filtered}]
-             :histogram
-             :event-stats
-             :allocation-summary
-             [:allocation-hotspots {:limit 10}]
-             :allocation-by-type
-             :allocation-treemap]
-   :view [[:stats {:metric-ids [:memory]}]
-          :bootstrap-stats
-          [:autocorrelation-classification {:classification-id :autocorrelation-classification-raw}]
-          [:effective-sample-size {:ess-id :effective-sample-size-filtered}]
-          [:acf-plot {:autocorrelation-id :autocorrelation-raw
-                      :min-severity :moderate}]
-          :extremes
-          :quantiles
-          :event-stats
-          :outlier-counts
-          :collect-plan
-          [:histogram {:stats-id :log-stats}]
-          :sample-percentiles
-          :samples
-          :allocation-summary
-          :allocation-hotspots
-          :allocation-by-type
-          :allocation-treemap]
-   :viewer :print})
+(def histogram
+  "Non-parametric distribution analysis with histogram visualization.
 
-(def knuth-histogram
-  "Benchmark plan using Knuth's Bayesian optimal histogram binning.
+  Consolidates histogram, KDE density estimation, and mode detection into a
+  single comprehensive plan. Uses Knuth's Bayesian optimal binning.
 
-  Uses Knuth's method to automatically determine the optimal number of
-  histogram bins by maximizing a log-posterior. Better than Freedman-Diaconis
-  for distributions with complex structure.
+  Includes:
+  - Histogram with automatic bin optimization via Knuth's method
+  - KDE (Kernel Density Estimation) overlay for smooth density visualization
+  - Mode detection with statistical validation (ACR test)
+  - Full statistical summary with bootstrap confidence intervals
 
-  The histogram includes :optimal-bins and :log-posterior keys."
+  Use when investigating sample distribution shape, detecting multimodality,
+  or visualizing benchmark latency distributions."
   {:collector-config default-collector-config
    :analyse [:transform-log
              [:autocorrelation {:id :autocorrelation-raw}]
@@ -132,106 +95,6 @@
                                 :estimate-quantiles [0.025 0.975]
                                 :ess-id :effective-sample-size-filtered}]
              [:histogram {:method :knuth}]
-             :event-stats
-             :allocation-summary
-             [:allocation-hotspots {:limit 10}]
-             :allocation-by-type
-             :allocation-treemap]
-   :view [[:stats {:metric-ids [:memory]}]
-          :bootstrap-stats
-          [:autocorrelation-classification {:classification-id :autocorrelation-classification-raw}]
-          [:effective-sample-size {:ess-id :effective-sample-size-filtered}]
-          [:acf-plot {:autocorrelation-id :autocorrelation-raw
-                      :min-severity :moderate}]
-          :extremes
-          :quantiles
-          :event-stats
-          :outlier-counts
-          :collect-plan
-          [:histogram {:stats-id :log-stats}]
-          :sample-percentiles
-          :samples
-          :allocation-summary
-          :allocation-hotspots
-          :allocation-by-type
-          :allocation-treemap]
-   :viewer :print})
-
-(def kde-histogram
-  "Benchmark plan with KDE analysis for density estimation and mode detection.
-
-  Includes histogram and KDE analysis for visualizing sample distributions.
-  Not part of the default bench plan; use explicitly when density analysis is needed."
-  {:collector-config default-collector-config
-   :analyse [:transform-log
-             [:autocorrelation {:id :autocorrelation-raw}]
-             [:autocorrelation-classification {:id :autocorrelation-classification-raw
-                                               :autocorrelation-id :autocorrelation-raw}]
-             [:quantiles {:quantiles [0.9 0.99]}]
-             :outliers
-             [:autocorrelation {:id :autocorrelation-filtered
-                                :outlier-id :outliers}]
-             [:effective-sample-size-analysis {:id :effective-sample-size-filtered
-                                               :autocorrelation-id :autocorrelation-filtered}]
-             [:stats {}]
-             [:stats {:samples-id :log-samples :id :log-stats}]
-             [:bootstrap-stats {:quantiles [0.99]
-                                :estimate-quantiles [0.025 0.975]
-                                :ess-id :effective-sample-size-filtered}]
-             :histogram
-             :kde
-             :kde-stats
-             :event-stats
-             :allocation-summary
-             [:allocation-hotspots {:limit 10}]
-             :allocation-by-type
-             :allocation-treemap]
-   :view [[:stats {:metric-ids [:memory]}]
-          :bootstrap-stats
-          [:autocorrelation-classification {:classification-id :autocorrelation-classification-raw}]
-          [:effective-sample-size {:ess-id :effective-sample-size-filtered}]
-          [:acf-plot {:autocorrelation-id :autocorrelation-raw
-                      :min-severity :moderate}]
-          :extremes
-          [:stats {:stats-id :kde-stats}]
-          :quantiles
-          :event-stats
-          :outlier-counts
-          :collect-plan
-          [:histogram {:stats-id :log-stats}]
-          [:kde {:histogram-id :histograms}]
-          :sample-percentiles
-          :samples
-          :allocation-summary
-          :allocation-hotspots
-          :allocation-by-type
-          :allocation-treemap]
-   :viewer :print})
-
-(def kde-modes
-  "Benchmark plan with KDE and mode detection using ACR test.
-
-  Includes histogram, KDE, and statistically validated mode analysis.
-  Use when you need to detect and validate multimodality in sample distributions.
-  Mode detection tests from k=1 up to max-modes. Supports ACR (default) and
-  Silverman test methods via :modes analysis options."
-  {:collector-config default-collector-config
-   :analyse [:transform-log
-             [:autocorrelation {:id :autocorrelation-raw}]
-             [:autocorrelation-classification {:id :autocorrelation-classification-raw
-                                               :autocorrelation-id :autocorrelation-raw}]
-             [:quantiles {:quantiles [0.9 0.99]}]
-             :outliers
-             [:autocorrelation {:id :autocorrelation-filtered
-                                :outlier-id :outliers}]
-             [:effective-sample-size-analysis {:id :effective-sample-size-filtered
-                                               :autocorrelation-id :autocorrelation-filtered}]
-             [:stats {}]
-             [:stats {:samples-id :log-samples :id :log-stats}]
-             [:bootstrap-stats {:quantiles [0.99]
-                                :estimate-quantiles [0.025 0.975]
-                                :ess-id :effective-sample-size-filtered}]
-             :histogram
              :kde
              :kde-stats
              :modes

--- a/bases/criterium/src/criterium/bench_plans.clj
+++ b/bases/criterium/src/criterium/bench_plans.clj
@@ -6,6 +6,19 @@
    :terminator :elapsed-time})
 
 (def one-shot
+  "Single execution profiling without warmup or sampling.
+
+  Runs a single batch without JVM warmup or statistical sampling. Primarily
+  useful for allocation analysis and quick exploratory checks.
+
+  Includes:
+  - Basic execution metrics and timing
+  - Detailed allocation tracking: summary, hotspots, by-type breakdown
+  - JVM event statistics (compilation, class loading)
+
+  Use when you want to see raw allocation patterns without the overhead of
+  statistical analysis, or for a quick sanity check before running a full
+  benchmark."
   {:collector-config default-collector-config
    :analyse [:event-stats
              :allocation-summary
@@ -20,6 +33,22 @@
    :viewer :print})
 
 (def default
+  "Standard benchmarking with full statistical analysis.
+
+  The recommended plan for typical performance measurement. Includes warmup,
+  multiple sampling iterations, and comprehensive statistical analysis.
+
+  Includes:
+  - Bootstrap confidence intervals for mean, variance, and other statistics
+  - Outlier detection and classification
+  - Autocorrelation analysis with effective sample size computation
+  - KDE and mode detection for multimodal warnings (no histogram display)
+  - Memory and allocation tracking (summary, hotspots, treemap)
+  - JVM event statistics (compilation, class loading)
+
+  The analysis detects multimodal distributions and autocorrelation patterns,
+  displaying warnings when results may be unreliable. Use this plan for
+  everyday benchmarking where you need statistically sound results."
   {:collector-config default-collector-config
    :analyse [:transform-log
              [:autocorrelation {:id :autocorrelation-raw}]

--- a/bases/criterium/test/criterium/bench/config_test.clj
+++ b/bases/criterium/test/criterium/bench/config_test.clj
@@ -12,7 +12,7 @@
     (measured/invoke measured (measured/args measured) 1)
     (testing "config-map provides defaults"
       (is (= (merge
-              bench-plans/default-with-warmup
+              bench-plans/default
               {:collector-config
                (->>
                 collector-configs/default-collector-config
@@ -25,7 +25,7 @@
              (bench-config/config-map {}))))
     (testing "config-map can specify the pipeline stages"
       (is (= (-> (merge
-                  bench-plans/default-with-warmup
+                  bench-plans/default
                   {:collector-config
                    (->>
                     {:stages     [:class-loader
@@ -45,7 +45,7 @@
                             :garbage-collector]}))))
     (testing "config-map can specify the sample scheme"
       (is (= (-> (merge
-                  bench-plans/default-one-shot
+                  bench-plans/one-shot
                   {:collector-config
                    (->>
                     {:stages     []

--- a/bases/criterium/test/criterium/bench_plans_test.clj
+++ b/bases/criterium/test/criterium/bench_plans_test.clj
@@ -59,12 +59,12 @@
        (remove nil?)
        first))
 
-(deftest default-with-warmup-test
-  ;; Tests verify dual autocorrelation analysis in default-with-warmup:
+(deftest default-test
+  ;; Tests verify dual autocorrelation analysis in default:
   ;; - autocorrelation-raw for pattern detection
   ;; - autocorrelation-filtered for effective sample size
-  (testing "default-with-warmup"
-    (let [plan bench-plans/default-with-warmup]
+  (testing "default"
+    (let [plan bench-plans/default]
 
       (testing "includes :autocorrelation-raw in analyse"
         (is (some? (find-analyse-entry-by-id plan :autocorrelation-raw))))
@@ -203,11 +203,11 @@
           (is (some? ess-entry))
           (is (= :effective-sample-size-raw (:ess-id (second ess-entry)))))))))
 
-(deftest default-one-shot-test
-  ;; Tests verify that default-one-shot does NOT include autocorrelation.
+(deftest one-shot-test
+  ;; Tests verify that one-shot does NOT include autocorrelation.
   ;; One-shot benchmarks don't have enough samples for meaningful autocorrelation.
-  (testing "default-one-shot"
-    (let [plan bench-plans/default-one-shot]
+  (testing "one-shot"
+    (let [plan bench-plans/one-shot]
 
       (testing "does NOT include :autocorrelation in analyse"
         (is (nil? (find-analyse-entry plan :autocorrelation)))
@@ -225,7 +225,7 @@
   ;; view, which is responsible for displaying anomalous lags when present.
   ;; See Task 890: anomalous lags display is integrated into autocorrelation-classification.
   (testing "all warmup-based plans include autocorrelation-classification"
-    (let [warmup-plans [bench-plans/default-with-warmup
+    (let [warmup-plans [bench-plans/default
                         bench-plans/log-histogram
                         bench-plans/knuth-histogram
                         bench-plans/kde-histogram
@@ -241,7 +241,7 @@
   ;; ACF plot is displayed only when moderate or above severity is detected.
   ;; All warmup-based bench-plans should include the acf-plot view with :min-severity :moderate.
   (testing "all warmup-based plans include acf-plot with :min-severity :moderate"
-    (let [warmup-plans [bench-plans/default-with-warmup
+    (let [warmup-plans [bench-plans/default
                         bench-plans/log-histogram
                         bench-plans/knuth-histogram
                         bench-plans/kde-histogram
@@ -258,7 +258,7 @@
             (is (= :autocorrelation-raw (:autocorrelation-id (second entry)))
                 "acf-plot should use :autocorrelation-raw")))))))
 
-(deftest default-one-shot-excludes-acf-plot-test
-  (testing "default-one-shot does NOT include acf-plot"
-    (let [plan bench-plans/default-one-shot]
+(deftest one-shot-excludes-acf-plot-test
+  (testing "one-shot does NOT include acf-plot"
+    (let [plan bench-plans/one-shot]
       (is (nil? (find-view-entry plan :acf-plot))))))

--- a/bases/criterium/test/criterium/bench_plans_test.clj
+++ b/bases/criterium/test/criterium/bench_plans_test.clj
@@ -101,9 +101,13 @@
           (is (some? entry))
           (is (= :effective-sample-size-filtered (:ess-id (second entry)))))))))
 
-(deftest log-histogram-test
-  (testing "log-histogram"
-    (let [plan bench-plans/log-histogram]
+(deftest histogram-test
+  ;; Tests verify the unified histogram plan includes:
+  ;; - autocorrelation for pattern detection and effective sample size
+  ;; - histogram with Knuth binning
+  ;; - KDE and mode detection
+  (testing "histogram"
+    (let [plan bench-plans/histogram]
 
       (testing "includes both autocorrelation analyses"
         (is (some? (find-analyse-entry-by-id plan :autocorrelation-raw)))
@@ -115,55 +119,18 @@
 
       (testing "includes separate views"
         (is (some? (find-view-entry plan :autocorrelation-classification)))
-        (is (some? (find-view-entry plan :effective-sample-size)))))))
+        (is (some? (find-view-entry plan :effective-sample-size))))
 
-(deftest knuth-histogram-test
-  (testing "knuth-histogram"
-    (let [plan bench-plans/knuth-histogram]
+      (testing "uses Knuth histogram method"
+        (let [hist-entry (find-analyse-entry plan :histogram)]
+          (is (vector? hist-entry))
+          (is (= :knuth (:method (second hist-entry))))))
 
-      (testing "includes both autocorrelation analyses"
-        (is (some? (find-analyse-entry-by-id plan :autocorrelation-raw)))
-        (is (some? (find-analyse-entry-by-id plan :autocorrelation-filtered))))
+      (testing "includes KDE analysis"
+        (is (some? (find-analyse-entry plan :kde))))
 
-      (testing "configures bootstrap-stats with :ess-id :effective-sample-size-filtered"
-        (let [bs-entry (find-analyse-entry plan :bootstrap-stats)]
-          (is (= :effective-sample-size-filtered (:ess-id (second bs-entry))))))
-
-      (testing "includes separate views"
-        (is (some? (find-view-entry plan :autocorrelation-classification)))
-        (is (some? (find-view-entry plan :effective-sample-size)))))))
-
-(deftest kde-histogram-test
-  (testing "kde-histogram"
-    (let [plan bench-plans/kde-histogram]
-
-      (testing "includes both autocorrelation analyses"
-        (is (some? (find-analyse-entry-by-id plan :autocorrelation-raw)))
-        (is (some? (find-analyse-entry-by-id plan :autocorrelation-filtered))))
-
-      (testing "configures bootstrap-stats with :ess-id :effective-sample-size-filtered"
-        (let [bs-entry (find-analyse-entry plan :bootstrap-stats)]
-          (is (= :effective-sample-size-filtered (:ess-id (second bs-entry))))))
-
-      (testing "includes separate views"
-        (is (some? (find-view-entry plan :autocorrelation-classification)))
-        (is (some? (find-view-entry plan :effective-sample-size)))))))
-
-(deftest kde-modes-test
-  (testing "kde-modes"
-    (let [plan bench-plans/kde-modes]
-
-      (testing "includes both autocorrelation analyses"
-        (is (some? (find-analyse-entry-by-id plan :autocorrelation-raw)))
-        (is (some? (find-analyse-entry-by-id plan :autocorrelation-filtered))))
-
-      (testing "configures bootstrap-stats with :ess-id :effective-sample-size-filtered"
-        (let [bs-entry (find-analyse-entry plan :bootstrap-stats)]
-          (is (= :effective-sample-size-filtered (:ess-id (second bs-entry))))))
-
-      (testing "includes separate views"
-        (is (some? (find-view-entry plan :autocorrelation-classification)))
-        (is (some? (find-view-entry plan :effective-sample-size)))))))
+      (testing "includes mode detection"
+        (is (some? (find-analyse-entry plan :modes)))))))
 
 (deftest distribution-analysis-test
   (testing "distribution-analysis"
@@ -226,10 +193,7 @@
   ;; See Task 890: anomalous lags display is integrated into autocorrelation-classification.
   (testing "all warmup-based plans include autocorrelation-classification"
     (let [warmup-plans [bench-plans/default
-                        bench-plans/log-histogram
-                        bench-plans/knuth-histogram
-                        bench-plans/kde-histogram
-                        bench-plans/kde-modes
+                        bench-plans/histogram
                         bench-plans/distribution-analysis
                         bench-plans/tail-analysis]]
       (doseq [plan warmup-plans]
@@ -242,10 +206,7 @@
   ;; All warmup-based bench-plans should include the acf-plot view with :min-severity :moderate.
   (testing "all warmup-based plans include acf-plot with :min-severity :moderate"
     (let [warmup-plans [bench-plans/default
-                        bench-plans/log-histogram
-                        bench-plans/knuth-histogram
-                        bench-plans/kde-histogram
-                        bench-plans/kde-modes
+                        bench-plans/histogram
                         bench-plans/distribution-analysis
                         bench-plans/tail-analysis]]
       (doseq [plan warmup-plans]

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -58,11 +58,11 @@
       (is (empty? @kindly/accumulated)
           "accumulator is empty after flush"))
 
-    (testing "with full benchmark and log-histogram plan"
+    (testing "with full benchmark and histogram plan"
       (reset! kindly/accumulated [])
       (bench/bench (+ 1 1)
                    :viewer :kindly
-                   :bench-plan bench-plans/log-histogram
+                   :bench-plan bench-plans/histogram
                    :limit-time-s 0.2)
       (is (empty? @kindly/accumulated)
           "accumulator is empty after flush - fragment was returned by flush-viewer"))
@@ -84,20 +84,20 @@
           (is (pos? (count fragment))
               "fragment contains accumulated views"))))
 
-    (testing "with log-histogram plan produces full output"
+    (testing "with histogram plan produces full output"
       ;; Get benchmark data using :print viewer
       ;; Strip :viewer key since it was added by the previous bench call
       (let [data-map (dissoc
                       (:data (do (with-out-str
                                    (bench/bench (+ 1 1)
                                                 :viewer :print
-                                                :bench-plan bench-plans/log-histogram
+                                                :bench-plan bench-plans/histogram
                                                 :limit-time-s 0.2))
                                  (bench/last-bench)))
                       :viewer)]
         ;; View with :kindly - bench/view returns the fragment
         (reset! kindly/accumulated [])
-        (let [fragment (bench/view (:view bench-plans/log-histogram) :kindly data-map)]
+        (let [fragment (bench/view (:view bench-plans/histogram) :kindly data-map)]
           (is (= :kind/fragment (:kindly/kind (meta fragment)))
               "view returns kind/fragment for kindly viewer")
           (is (>= (count fragment) 10)
@@ -237,16 +237,16 @@
     (let [config (bench-config/config-map {:with-allocation-trace true})]
       (is (true? (:with-allocation-trace config))))))
 
-(deftest ^:slow knuth-histogram-bench-plan-test
-  ;; Integration test verifying the knuth-histogram bench plan produces
-  ;; correct histogram output with Bayesian optimal binning.
-  (testing "knuth-histogram bench plan"
+(deftest ^:slow histogram-bench-plan-test
+  ;; Integration test verifying the histogram bench plan produces
+  ;; correct histogram output with Knuth binning, KDE, and mode detection.
+  (testing "histogram bench plan"
     (testing "produces histogram with Knuth binning"
       (let [result (atom nil)
             out (with-out-str
                   (reset! result
                           (bench/bench (+ 1 1)
-                                       :bench-plan bench-plans/knuth-histogram
+                                       :bench-plan bench-plans/histogram
                                        :limit-time-s 0.1)))
             data (:data (bench/last-bench))
             histogram-data (:histograms data)

--- a/bases/criterium/test/criterium/bench_test.clj
+++ b/bases/criterium/test/criterium/bench_test.clj
@@ -272,20 +272,20 @@
           (is (re-find #"Histogram" out)
               "stdout should contain histogram output"))))))
 
-(deftest ^:slow default-with-warmup-kde-modes-test
-  ;; Integration test verifying that default-with-warmup includes KDE and modes
+(deftest ^:slow default-kde-modes-test
+  ;; Integration test verifying that the default bench plan includes KDE and modes
   ;; analysis, and that multimodal-warning view is present in the pipeline.
   ;; This test validates the full pipeline from bench to view output.
-  (testing "default-with-warmup bench plan"
+  (testing "default bench plan"
     (testing "includes :kde and :modes in analyse plan"
-      (is (some #{:kde} (:analyse bench-plans/default-with-warmup))
+      (is (some #{:kde} (:analyse bench-plans/default))
           ":kde should be in analyse plan")
-      (is (some #{:modes} (:analyse bench-plans/default-with-warmup))
+      (is (some #{:modes} (:analyse bench-plans/default))
           ":modes should be in analyse plan"))
 
     (testing "includes :multimodal-warning in view plan"
       (is (some #(and (vector? %) (= :multimodal-warning (first %)))
-                (:view bench-plans/default-with-warmup))
+                (:view bench-plans/default))
           "[:multimodal-warning ...] should be in view plan"))
 
     (testing "produces KDE and modes analysis"

--- a/bases/criterium/test/criterium/viewer/kindly_clay_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_clay_test.clj
@@ -50,11 +50,11 @@
             (is (str/includes? html "Elapsed Time")
                 "HTML contains elapsed time metric")))))
 
-    (testing "renders log-histogram benchmark with charts"
+    (testing "renders histogram benchmark with charts"
       (with-temp-dir [temp-dir]
         (let [fragment (bench/bench (reduce + (range 100))
                                     :viewer :kindly
-                                    :bench-plan bench-plans/log-histogram
+                                    :bench-plan bench-plans/histogram
                                     :limit-time-s 0.5)]
           (is (= :kind/fragment (:kindly/kind (meta fragment)))
               "bench returns Kindly fragment")

--- a/bases/notebooks/src/criterium/bench_options_notebook.clj
+++ b/bases/notebooks/src/criterium/bench_options_notebook.clj
@@ -57,51 +57,37 @@
 ;; Bench plans combine collect plans with analysis and view configurations.
 ;; The `criterium.bench-plans` namespace provides ready-to-use configurations.
 
-;; ### default-one-shot
+;; ### one-shot
 ;;
 ;; Minimal benchmarking without statistical analysis:
 
-bench-plans/default-one-shot
+bench-plans/one-shot
 
-;; ### default-with-warmup
+;; ### default
 ;;
 ;; Standard benchmarking with full statistics:
 
-bench-plans/default-with-warmup
+bench-plans/default
 
-;; ### log-histogram
+;; ### histogram
 ;;
-;; Extended analysis with histogram visualization:
+;; Non-parametric distribution analysis with histogram visualization, KDE
+;; density estimation, and mode detection. Uses Knuth's Bayesian optimal
+;; binning for data-driven bin selection.
 
-bench-plans/log-histogram
+bench-plans/histogram
 
-;; Using the log-histogram bench plan provides additional output:
+;; Using the histogram bench plan provides additional output:
 ;; - Quantiles (p50, p90, p99)
 ;; - Outlier counts by category
 ;; - Sample percentiles
-;; - Histogram visualization
+;; - Histogram visualization with Knuth optimal binning
+;; - KDE density estimation
+;; - Mode detection with confidence intervals
 
 ^:kindly/hide-code
 (bench-display
- (bench/bench (reduce + (range 1000)) :bench-plan bench-plans/log-histogram))
-
-;; ### knuth-histogram
-;;
-;; Histogram analysis with Knuth's Bayesian optimal binning. Instead of using
-;; the rule-based Freedman-Diaconis method, Knuth's algorithm finds the optimal
-;; number of bins by maximizing a log-posterior over possible bin counts. This
-;; provides data-driven bin selection that adapts to the structure of your data.
-
-bench-plans/knuth-histogram
-
-;; The knuth-histogram plan includes additional output:
-;; - `:optimal-bins` — the number of bins selected by Knuth's algorithm
-;; - `:log-posterior` — the log-posterior value for the selected bin count
-;; - Standard histogram visualization with the optimal binning
-
-^:kindly/hide-code
-(bench-display
- (bench/bench (reduce + (range 1000)) :bench-plan bench-plans/knuth-histogram))
+ (bench/bench (reduce + (range 1000)) :bench-plan bench-plans/histogram))
 
 ;; ## Viewer Options
 ;;
@@ -159,7 +145,7 @@ bench-plans/knuth-histogram
 
 (bench/bench (reduce + (range 1000))
              :viewer :kindly
-             :bench-plan bench-plans/log-histogram)
+             :bench-plan bench-plans/histogram)
 
 ;; Kindly viewer features:
 ;; - Tables with `:kind/table` metadata for stats, quantiles, outliers
@@ -289,9 +275,9 @@ bench-plans/knuth-histogram
 (bench-display
  (bench/bench (reduce + (range 1000))
               :viewer :print
-              :view (conj (:view bench-plans/log-histogram)
+              :view (conj (:view bench-plans/histogram)
                           [:outlier-counts {:show-medcouple true}])
-              :bench-plan bench-plans/log-histogram))
+              :bench-plan bench-plans/histogram))
 
 ;; Medcouple interpretation:
 ;; - MC ≈ 0: Symmetric distribution

--- a/bases/notebooks/src/criterium/distribution_fitting_notebook.clj
+++ b/bases/notebooks/src/criterium/distribution_fitting_notebook.clj
@@ -201,7 +201,7 @@
 ;;
 ;; **Consider alternatives when:**
 ;; - You only need mean/variance (use default bench plan)
-;; - You suspect multimodality (use `kde-modes` bench plan)
+;; - You suspect multimodality (use `histogram` bench plan)
 ;; - Sample size is very small (< 30 samples)
 
 ;; ## Best Practices
@@ -244,6 +244,6 @@
                :bench-plan bench-plans/distribution-analysis
                :viewer :portal)
 
-  ;; Compare with KDE modes for multimodal detection
+  ;; Compare with histogram for multimodal detection
   (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-modes))
+               :bench-plan bench-plans/histogram))

--- a/bases/notebooks/src/criterium/kde_analysis_notebook.clj
+++ b/bases/notebooks/src/criterium/kde_analysis_notebook.clj
@@ -18,33 +18,21 @@
 ;; - Identifying modes with confidence intervals
 ;; - Understanding the shape of timing distributions
 
-;; ## Using the kde-histogram Bench Plan
+;; ## Using the histogram Bench Plan
 ;;
-;; The `kde-histogram` bench plan includes histogram and KDE analysis.
-;; This is not part of the default plan; use it explicitly when density
-;; analysis is needed.
+;; The `histogram` bench plan includes histogram, KDE analysis, and mode
+;; detection. This is not part of the default plan; use it explicitly when
+;; distribution analysis is needed.
 
 ^:kindly/hide-code
 (bench-display
  (bench/bench (reduce + (range 1000))
-              :bench-plan bench-plans/kde-histogram))
+              :bench-plan bench-plans/histogram))
 
 ;; The output includes:
 ;; - Standard statistics (mean, standard deviation)
-;; - Histogram visualization
+;; - Histogram visualization with Knuth optimal binning
 ;; - KDE density curve overlaid on the histogram
-
-;; ## Using the kde-modes Bench Plan
-;;
-;; For statistically validated mode detection, use the `kde-modes` bench plan.
-;; This includes multimodality testing to validate the number of distribution modes.
-
-^:kindly/hide-code
-(bench-display
- (bench/bench (reduce + (range 1000))
-              :bench-plan bench-plans/kde-modes))
-
-;; The kde-modes plan adds:
 ;; - Mode detection with confidence intervals
 ;; - ACR test p-values for each k (number of modes)
 ;; - Validated mode count based on statistical significance
@@ -73,7 +61,7 @@
 
 ;; ## Understanding Modes Output
 ;;
-;; Mode analysis (from the `kde-modes` plan) provides statistically validated
+;; Mode analysis (from the `histogram` plan) provides statistically validated
 ;; peaks in the density curve:
 
 ;; ### Multimodality Testing Methods
@@ -139,7 +127,7 @@
 
 (do
   (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-modes
+               :bench-plan bench-plans/histogram
                :viewer :none)
   (let [data (:data (bench/last-bench))
         kde-result (:kde data)
@@ -199,8 +187,8 @@
 ;;
 ;; Create a custom bench plan with modified options:
 
-(def custom-kde-modes-plan
-  (-> bench-plans/kde-modes
+(def custom-histogram-plan
+  (-> bench-plans/histogram
       (assoc :analyse
              [:transform-log
               [:quantiles {:quantiles [0.9 0.99]}]
@@ -216,14 +204,14 @@
 ^:kindly/hide-code
 (bench-display
  (bench/bench (reduce + (range 1000))
-              :bench-plan custom-kde-modes-plan))
+              :bench-plan custom-histogram-plan))
 
 ;; ### Using Critical Bandwidth for Mode Finding
 ;;
 ;; The critical bandwidth approach can provide more stable mode locations:
 
 (def critical-modes-plan
-  (-> bench-plans/kde-modes
+  (-> bench-plans/histogram
       (assoc :analyse
              [:transform-log
               [:quantiles {:quantiles [0.25 0.5 0.75]}]
@@ -259,7 +247,7 @@
 (add-tap #'p/submit)
 
 (bench/bench (reduce + (range 1000))
-             :bench-plan bench-plans/kde-modes
+             :bench-plan bench-plans/histogram
              :viewer :portal)")
 
 ;; ### Kindly Viewer
@@ -268,7 +256,7 @@
 
 (bench/bench
  (reduce + (range 1000))
- :bench-plan bench-plans/kde-modes
+ :bench-plan bench-plans/histogram
  :viewer :kindly)
 
 ;; ## Detecting Multimodality
@@ -299,7 +287,7 @@
 
 (bench/bench
  (variable-work 100 (zero? (long (mod (rand-int 100) 3))))
- :bench-plan bench-plans/kde-modes
+ :bench-plan bench-plans/histogram
  :viewer :kindly)
 
 ;; ### Comparing ACR and Silverman Results
@@ -310,11 +298,11 @@
   "Run both ACR and Silverman tests and compare results.
   Takes a measured (created with measured/callable or measured/expr)."
   [m]
-  (let [silverman-plan (assoc-in bench-plans/kde-modes
+  (let [silverman-plan (assoc-in bench-plans/histogram
                                  [:analyse 7] [:modes {:method :silverman}])]
     ;; Run with ACR (default method)
     (bench/bench-measured
-     (bench/options->bench-plan :bench-plan bench-plans/kde-modes :viewer :none)
+     (bench/options->bench-plan :bench-plan bench-plans/histogram :viewer :none)
      m)
     (let [acr-result (get-in (:data (bench/last-bench))
                              [:modes :modes [:elapsed-time]])]
@@ -350,37 +338,30 @@
 
 ;; ## Best Practices
 ;;
-;; 1. **Use kde-histogram for density visualization** - When you just need
-;;    to see the distribution shape without statistical mode validation.
+;; 1. **Use the `histogram` plan for distribution analysis** - The histogram
+;;    plan includes KDE density visualization and mode detection.
 ;;
-;; 2. **Use kde-modes for mode detection** - When you need statistically
-;;    validated mode counts with the ACR test.
-;;
-;; 3. **Check test p-values** - Low p-values for k=1 indicate evidence
+;; 2. **Check test p-values** - Low p-values for k=1 indicate evidence
 ;;    against unimodality. The `test-results` map contains p-values for each k.
 ;;
-;; 4. **Use ACR over Silverman** - ACR provides better calibrated p-values
+;; 3. **Use ACR over Silverman** - ACR provides better calibrated p-values
 ;;    and is less sensitive to noise in the density estimate.
 ;;
-;; 5. **Consider :mode-method :critical** - When you need stable mode
+;; 4. **Consider :mode-method :critical** - When you need stable mode
 ;;    locations and want to identify antimodes (valleys between peaks).
 ;;
-;; 6. **Consider computation cost** - Mode analysis involves multiple rounds
-;;    of bootstrap resampling. Use `kde-histogram` when you only need the
-;;    density curve.
+;; 5. **Consider computation cost** - Mode analysis involves multiple rounds
+;;    of bootstrap resampling. Use the `default` plan when you only need
+;;    basic statistics.
 
 ;; ## Running Examples
 ;;
 ;; Execute benchmarks with KDE and mode analysis:
 
 (comment
-  ;; Basic KDE analysis (no mode testing)
+  ;; Histogram with KDE and mode detection
   (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-histogram)
-
-  ;; KDE with mode detection and ACR test (default)
-  (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-modes)
+               :bench-plan bench-plans/histogram)
 
   ;; Access modes results programmatically
   (let [data (:data (bench/last-bench))]
@@ -391,19 +372,19 @@
 
   ;; Use Silverman test instead of ACR
   (bench/bench (reduce + (range 1000))
-               :bench-plan (assoc-in bench-plans/kde-modes
+               :bench-plan (assoc-in bench-plans/histogram
                                      [:analyse 7] [:modes {:method :silverman}]))
 
   ;; Use critical bandwidth for mode finding
   (bench/bench (reduce + (range 1000))
-               :bench-plan (assoc-in bench-plans/kde-modes
+               :bench-plan (assoc-in bench-plans/histogram
                                      [:analyse 7] [:modes {:mode-method :critical}]))
 
   ;; Custom options
   (bench/bench (reduce + (range 1000))
-               :bench-plan custom-kde-modes-plan)
+               :bench-plan custom-histogram-plan)
 
   ;; With Portal visualization
   (bench/bench (reduce + (range 1000))
-               :bench-plan bench-plans/kde-modes
+               :bench-plan bench-plans/histogram
                :viewer :portal))

--- a/skills/criterium/SKILL.md
+++ b/skills/criterium/SKILL.md
@@ -124,21 +124,35 @@ Default output fields:
 
 Bench plans configure what analysis and output criterium produces. The default plan handles most cases.
 
-### default-with-warmup (Default)
+### default
 
 Used automatically. Provides:
 - JIT warmup phase
 - Bootstrap confidence intervals
 - Outlier detection
-- KDE density estimation
+- KDE density estimation (for multimodal warnings)
 
-### distribution-analysis
+### histogram
 
-Use when you need to understand the shape of your timing distribution:
+Non-parametric distribution analysis with histogram visualization:
 
 ```clojure
 (require '[criterium.bench-plans :as plans])
 
+(bench/bench (my-function)
+             :bench-plan plans/histogram)
+```
+
+Includes:
+- Histogram with Knuth optimal binning
+- KDE density estimation
+- Mode detection for multimodal distributions
+
+### distribution-analysis
+
+Parametric distribution fitting for understanding timing variability:
+
+```clojure
 (bench/bench (my-function)
              :bench-plan plans/distribution-analysis)
 ```
@@ -148,12 +162,6 @@ Adds:
 - Shape statistics (skewness, kurtosis)
 - Goodness-of-fit tests
 - Q-Q plots (with appropriate viewer)
-
-### Other Plans
-
-- `log-histogram` - Histogram visualization
-- `kde-histogram` - KDE density estimation with histogram
-- `kde-modes` - Mode detection for multimodal distributions
 
 ### Custom Plans
 
@@ -378,7 +386,7 @@ The JIT compiler optimizes code during execution. Criterium handles warmup autom
 
 - First benchmark in a session may be slower (class loading, JIT)
 - Run benchmarks multiple times if results seem inconsistent
-- The `default-with-warmup` plan (default) includes warmup phases
+- The `default` plan includes warmup phases
 
 ### Avoiding Measurement Pitfalls
 
@@ -426,7 +434,7 @@ The JIT compiler optimizes code during execution. Criterium handles warmup autom
 
 | Situation | Plan |
 |-----------|------|
-| Quick measurement | `default-with-warmup` (default) |
+| Quick measurement | `default` |
 | Understanding distribution shape | `distribution-analysis` |
 | Comparing implementations | `implementation-comparison` (domain) |
 | Analyzing complexity | `complexity-analysis` (domain) |


### PR DESCRIPTION
## Summary

Consolidate the four histogram-variant bench plans into a single unified `histogram` plan and rename existing plans for clarity.

### Changes

**Renamed plans:**
- `default-one-shot` → `one-shot` - Single execution profiling without warmup
- `default-with-warmup` → `default` - Standard benchmarking with full statistical analysis

**Consolidated plans:**
- Removed: `log-histogram`, `knuth-histogram`, `kde-histogram`, `kde-modes`
- Added: `histogram` - Non-parametric distribution analysis with Knuth binning, KDE, and mode detection

**Documentation:**
- Added comprehensive docstrings to `one-shot` and `default` plans
- Updated README.ALPHA.md, SKILL.md, and notebooks to reference new plan names

### Standard Bench Plans After This Change

1. **`one-shot`** - Single execution profiling without warmup or sampling
2. **`default`** - Standard benchmarking with full statistical analysis
3. **`histogram`** - Non-parametric distribution analysis with histogram visualization
4. **`distribution-analysis`** - Parametric distribution fitting via MLE
5. **`tail-analysis`** - Extreme value analysis for worst-case latency

## Test plan

- [ ] All existing tests pass
- [ ] New plan names work correctly in bench calls
- [ ] Documentation references are accurate