### PR TITLE
feat(viewer): add ASCII plot implementation for :print and :pprint viewers

### DIFF
--- a/bases/criterium/src/criterium/viewer/common/ascii_chart.clj
+++ b/bases/criterium/src/criterium/viewer/common/ascii_chart.clj
@@ -1,0 +1,343 @@
+(ns criterium.viewer.common.ascii-chart
+  "ASCII chart rendering for terminal-based visualization.
+
+  Provides LTTB (Largest Triangle Three Buckets) downsampling and
+  ASCII line/scatter plot rendering for use in :print and :pprint viewers.
+
+  Main entry points:
+  - `lttb-downsample` - reduce points while preserving visual shape
+  - `render-chart` - render points as ASCII chart, returns vector of strings"
+  (:require
+   [criterium.util.format :as format]))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+;;; LTTB Downsampling Algorithm
+
+(defn- triangle-area
+  "Calculate area of triangle formed by three points using cross product.
+  Returns absolute area * 2 (sufficient for comparison)."
+  ^double [[^double x1 ^double y1] [^double x2 ^double y2] [^double x3 ^double y3]]
+  (Math/abs
+   (- (* (- x1 x3) (- y2 y1))
+      (* (- x1 x2) (- y3 y1)))))
+
+(defn- bucket-average
+  "Calculate average point of points in a bucket."
+  [points]
+  (let [n (count points)]
+    (if (zero? n)
+      [0.0 0.0]
+      (let [^double sum-x (reduce (fn [^double acc [^double x _]] (+ acc x)) 0.0 points)
+            ^double sum-y (reduce (fn [^double acc [_ ^double y]] (+ acc y)) 0.0 points)
+            nd (double n)]
+        [(/ sum-x nd) (/ sum-y nd)]))))
+
+(defn lttb-downsample
+  "Downsample points using Largest Triangle Three Buckets algorithm.
+
+  LTTB preserves the visual shape of the data by selecting points that
+  form the largest triangles, keeping visually significant features.
+
+  Parameters:
+    points - sequence of [x y] coordinate pairs (must be sorted by x)
+    target-count - desired number of output points
+
+  Returns:
+    Vector of [x y] pairs with at most target-count points.
+    If points count <= target-count, returns points unchanged.
+
+  Algorithm:
+    1. Always keep first and last points
+    2. Divide middle points into (target-count - 2) buckets
+    3. For each bucket, select point forming largest triangle with
+       previous selected point and average of next bucket"
+  [points ^long target-count]
+  (let [points (vec points)
+        n (count points)]
+    (cond
+      (<= n target-count) points
+      (<= target-count 2) [(first points) (last points)]
+      :else
+      (let [bucket-size (/ (double (- n 2)) (double (- target-count 2)))]
+        (loop [result (transient [(first points)])
+               i 0
+               prev-selected (first points)]
+          (if (>= i (- target-count 2))
+            (persistent! (conj! result (last points)))
+            (let [;; Current bucket range
+                  bucket-start (long (+ 1 (* i bucket-size)))
+                  bucket-end (long (min (+ 1 (* (inc i) bucket-size)) (dec n)))
+                  ;; Next bucket for average calculation
+                  next-start bucket-end
+                  next-end (long (min (+ 1 (* (+ i 2) bucket-size)) n))
+                  next-avg (bucket-average (subvec points next-start next-end))
+                  ;; Find point in current bucket with largest triangle
+                  best-point
+                  (reduce
+                   (fn [best idx]
+                     (let [point (points idx)
+                           area (triangle-area prev-selected point next-avg)]
+                       (if (> area (double (first best)))
+                         [area point]
+                         best)))
+                   [Double/NEGATIVE_INFINITY nil]
+                   (range bucket-start bucket-end))
+                  selected (second best-point)]
+              (recur (conj! result selected) (inc i) selected))))))))
+
+;;; Axis Label Formatting
+
+(defn- compute-axis-labels
+  "Compute axis labels with SI unit scaling.
+
+  Parameters:
+    min-val - minimum value on axis
+    max-val - maximum value on axis
+    dimension - :time, :memory, or nil for plain numbers
+    num-labels - target number of labels
+
+  Returns:
+    {:labels [formatted-strings...]
+     :positions [0.0-1.0 positions...]
+     :unit string-or-nil}"
+  [^double min-val ^double max-val dimension ^long num-labels]
+  (if (= min-val max-val)
+    {:labels [(format "%.3g" min-val)]
+     :positions [0.5]
+     :unit nil}
+    (let [[^double scale unit] (if dimension
+                                 (format/scale dimension (/ (+ min-val max-val) 2.0))
+                                 [1.0 nil])
+          range-val (- max-val min-val)
+          step (/ range-val (double (max 1 (dec num-labels))))
+          labels (mapv
+                  (fn [^long i]
+                    (let [val (+ min-val (* i step))
+                          scaled (* val scale)]
+                      (format "%.3g" scaled)))
+                  (range num-labels))
+          positions (mapv
+                     (fn [^long i]
+                       (/ (double i) (double (max 1 (dec num-labels)))))
+                     (range num-labels))]
+      {:labels labels
+       :positions positions
+       :unit unit})))
+
+(defn- max-label-width
+  "Calculate maximum width of labels."
+  ^long [labels]
+  (reduce (fn [^long acc s] (max acc (count s))) 0 labels))
+
+;;; Chart Grid Rendering
+
+(defn- map-to-grid
+  "Map a value from data range to grid position.
+  Returns position in [0, size-1] range."
+  ^long [^double val ^double min-val ^double max-val ^long size]
+  (if (= min-val max-val)
+    (quot size 2)
+    (let [normalized (/ (- val min-val) (- max-val min-val))
+          pos (* normalized (double (dec size)))]
+      (max 0 (min (dec size) (Math/round pos))))))
+
+(defn- create-grid
+  "Create a 2D character grid initialized with spaces.
+  Grid is indexed as [row][col] where row 0 is top."
+  [^long width ^long height]
+  (vec (repeat height (vec (repeat width \space)))))
+
+(defn- grid-set
+  "Set a character in the grid. Row 0 is top of chart."
+  [grid ^long row ^long col ch]
+  (if (and (>= row 0) (< row (count grid))
+           (>= col 0) (< col (count (first grid))))
+    (assoc-in grid [row col] ch)
+    grid))
+
+(defn- plot-point
+  "Plot a single point on the grid.
+  Y is inverted: high values at top (low row index)."
+  [grid x y plot-height point-char]
+  (let [x (long x)
+        y (long y)
+        plot-height (long plot-height)
+        row (- (dec plot-height) y)]
+    (grid-set grid row x point-char)))
+
+(defn- plot-line-segment
+  "Plot a line segment between two points using Bresenham's algorithm."
+  [grid [x0 y0] [x1 y1] plot-height line-char]
+  (let [x0 (long x0)
+        y0 (long y0)
+        x1 (long x1)
+        y1 (long y1)
+        plot-height (long plot-height)
+        dx (long (Math/abs (- x1 x0)))
+        dy (long (Math/abs (- y1 y0)))
+        sx (long (if (< x0 x1) 1 -1))
+        sy (long (if (< y0 y1) 1 -1))]
+    (loop [grid grid
+           x x0
+           y y0
+           err (- dx dy)]
+      (let [grid (plot-point grid x y plot-height line-char)]
+        (if (and (= x x1) (= y y1))
+          grid
+          (let [e2 (* 2 err)
+                step-x? (> e2 (- dy))
+                step-y? (< e2 dx)
+                new-err (cond-> err
+                          step-x? (- dy)
+                          step-y? (+ dx))
+                new-x (if step-x? (+ x sx) x)
+                new-y (if step-y? (+ y sy) y)]
+            (recur grid new-x new-y new-err)))))))
+
+;;; Main Rendering Functions
+
+(defn render-chart
+  "Render points as an ASCII chart.
+
+  Parameters:
+    points - sequence of [x y] coordinate pairs
+    opts - options map:
+      :width - total chart width in characters (default 80)
+      :height - total chart height in lines (default 20)
+      :x-label - x-axis label (optional)
+      :y-label - y-axis label (optional)
+      :dimension - :time or :memory for SI unit formatting (optional)
+      :point-char - character for points (default \\*)
+      :line-char - character for lines, nil to disable (default \\.)
+      :title - chart title (optional)
+
+  Returns:
+    Vector of strings, one per line, representing the chart.
+    Empty vector if points is empty or has fewer than 1 point."
+  [points {:keys [^long width ^long height x-label y-label dimension
+                  point-char line-char title]
+           :or {width 80
+                height 20
+                point-char \*
+                line-char \.}}]
+  (if (empty? points)
+    []
+    (let [points (vec points)
+          ;; Extract bounds
+          xs (mapv first points)
+          ys (mapv second points)
+          x-min (apply min xs)
+          x-max (apply max xs)
+          y-min (apply min ys)
+          y-max (apply max ys)
+
+          ;; Compute y-axis labels (left side)
+          num-y-labels (min 5 height)
+          y-axis-info (compute-axis-labels y-min y-max dimension num-y-labels)
+          y-label-width (max-label-width (:labels y-axis-info))
+          y-axis-width (+ y-label-width 2) ; labels + " |"
+
+          ;; Compute x-axis labels (bottom)
+          x-axis-height 2 ; axis line + labels
+
+          ;; Plot area dimensions
+          plot-width (- width y-axis-width)
+          plot-height (- height x-axis-height)
+
+          ;; Downsample if needed
+          points (if (> (count points) plot-width)
+                   (lttb-downsample points plot-width)
+                   points)
+
+          ;; Map points to grid coordinates
+          grid-points (mapv
+                       (fn [[x y]]
+                         [(map-to-grid x x-min x-max plot-width)
+                          (map-to-grid y y-min y-max plot-height)])
+                       points)
+
+          ;; Create and populate grid
+          grid (create-grid plot-width plot-height)
+
+          ;; Plot lines between consecutive points
+          grid (if line-char
+                 (reduce
+                  (fn [g [p1 p2]]
+                    (plot-line-segment g p1 p2 plot-height line-char))
+                  grid
+                  (partition 2 1 grid-points))
+                 grid)
+
+          ;; Plot points (on top of lines)
+          grid (reduce
+                (fn [g [x y]]
+                  (plot-point g x y plot-height point-char))
+                grid
+                grid-points)
+
+          ;; Build output lines
+          lines (transient [])
+
+          ;; Add title if provided
+          _ (when title
+              (conj! lines title))
+
+          ;; Build chart lines with y-axis
+          y-label-positions (zipmap
+                             (mapv #(Math/round (* % (double (dec plot-height))))
+                                   (:positions y-axis-info))
+                             (:labels y-axis-info))
+
+          _ (doseq [row (range plot-height)]
+              (let [y-grid-pos (- (dec plot-height) row)
+                    y-label (get y-label-positions y-grid-pos "")
+                    padded-label (format (str "%" y-label-width "s") y-label)
+                    row-chars (apply str (grid row))]
+                (conj! lines (str padded-label " |" row-chars))))
+
+          ;; Add x-axis line
+          x-axis-line (str (apply str (repeat y-axis-width \space))
+                           (apply str (repeat plot-width \-)))
+          _ (conj! lines x-axis-line)
+
+          ;; Add x-axis labels
+          num-x-labels (min 5 (quot plot-width 10))
+          x-axis-info (compute-axis-labels x-min x-max nil num-x-labels)
+          x-labels-line (let [sb (StringBuilder.)
+                              _ (.append sb (apply str (repeat y-axis-width \space)))]
+                          (doseq [[^long i label] (map-indexed vector (:labels x-axis-info))]
+                            (let [pos (long (* (nth (:positions x-axis-info) i)
+                                               (double (dec plot-width))))
+                                  current-len (.length sb)
+                                  target-pos (+ y-axis-width pos)
+                                  padding (max 0 (- target-pos current-len))]
+                              (when (pos? padding)
+                                (.append sb (apply str (repeat padding \space))))
+                              (.append sb label)))
+                          (.toString sb))
+          _ (conj! lines x-labels-line)
+
+          ;; Add axis labels if provided
+          _ (when (or x-label y-label (:unit y-axis-info))
+              (let [unit-str (when (:unit y-axis-info)
+                               (str "(" (:unit y-axis-info) ")"))
+                    label-line (str (when y-label (str y-label " "))
+                                    unit-str
+                                    (when x-label
+                                      (str (apply str (repeat (- (quot width 2) 10) \space))
+                                           "x: " x-label)))]
+                (when (seq label-line)
+                  (conj! lines label-line))))]
+
+      (persistent! lines))))
+
+(defn render-chart-simple
+  "Simplified chart rendering for quick visualizations.
+
+  Takes just points and optional width, using sensible defaults.
+  Returns vector of strings."
+  ([points]
+   (render-chart-simple points 80))
+  ([points width]
+   (render-chart points {:width width :height (quot width 4)})))

--- a/bases/criterium/src/criterium/viewer/common/ascii_chart.clj
+++ b/bases/criterium/src/criterium/viewer/common/ascii_chart.clj
@@ -285,12 +285,13 @@
 
           ;; Build chart lines with y-axis
           y-label-positions (zipmap
-                             (mapv #(Math/round (* % (double (dec plot-height))))
+                             (mapv (fn [^double pos]
+                                     (Math/round (* pos (double (dec plot-height)))))
                                    (:positions y-axis-info))
                              (:labels y-axis-info))
 
           _ (doseq [row (range plot-height)]
-              (let [y-grid-pos (- (dec plot-height) row)
+              (let [y-grid-pos (- (dec plot-height) (long row))
                     y-label (get y-label-positions y-grid-pos "")
                     padded-label (format (str "%" y-label-width "s") y-label)
                     row-chars (apply str (grid row))]
@@ -305,9 +306,10 @@
           num-x-labels (min 5 (quot plot-width 10))
           x-axis-info (compute-axis-labels x-min x-max nil num-x-labels)
           x-labels-line (let [sb (StringBuilder.)
-                              _ (.append sb (apply str (repeat y-axis-width \space)))]
+                              _ (.append sb (apply str (repeat y-axis-width \space)))
+                              positions (vec (:positions x-axis-info))]
                           (doseq [[^long i label] (map-indexed vector (:labels x-axis-info))]
-                            (let [pos (long (* (nth (:positions x-axis-info) i)
+                            (let [pos (long (* ^double (positions i)
                                                (double (dec plot-width))))
                                   current-len (.length sb)
                                   target-pos (+ y-axis-width pos)
@@ -339,5 +341,5 @@
   Returns vector of strings."
   ([points]
    (render-chart-simple points 80))
-  ([points width]
+  ([points ^long width]
    (render-chart points {:width width :height (quot width 4)})))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -173,70 +173,75 @@
    [:phase :num-samples :batch-size :num-evals]
    (core/collect-plan-data data-map)))
 
+;; When :show-chart is true, delegates to :print for ASCII chart rendering
 (defmethod view/samples* :pprint
-  [_ {:keys [] :as view} banech-map]
-  (let [quant-samples-id (:samples-id view :samples)
-        event-samples-id (:event-samples-id view quant-samples-id)
-        outlier-analysis-id (:outlier-id view :outliers)
-        quant-samples (banech-map quant-samples-id)
-        event-samples (banech-map event-samples-id)
-        outlier-analysis (banech-map outlier-analysis-id)
+  [viewer {:keys [show-chart] :as view} banech-map]
+  (if show-chart
+    ;; Delegate to :print for chart rendering
+    ((get-method view/samples* :print) viewer view banech-map)
+    ;; Default pprint table output
+    (let [quant-samples-id (:samples-id view :samples)
+          event-samples-id (:event-samples-id view quant-samples-id)
+          outlier-analysis-id (:outlier-id view :outliers)
+          quant-samples (banech-map quant-samples-id)
+          event-samples (banech-map event-samples-id)
+          outlier-analysis (banech-map outlier-analysis-id)
 
-        metric-defs (metric/filter-metrics
-                     (:metrics-defs quant-samples)
-                     (metric/type-pred :quantitative))
-        event-metrics-defs (metric/filter-metrics
-                            (:metrics-defs event-samples)
-                            (metric/type-pred :event))
+          metric-defs (metric/filter-metrics
+                       (:metrics-defs quant-samples)
+                       (metric/type-pred :quantitative))
+          event-metrics-defs (metric/filter-metrics
+                              (:metrics-defs event-samples)
+                              (metric/type-pred :event))
 
-        metric-configs (metric/all-metric-configs metric-defs)
-        transforms (util/get-transforms banech-map quant-samples-id)
+          metric-configs (metric/all-metric-configs metric-defs)
+          transforms (util/get-transforms banech-map quant-samples-id)
 
-        quant-ids (mapv (comp last :path) metric-configs)
-        event-keys (into
-                    []
-                    (mapcat
-                     (fn [[k metric-group]]
-                       (reduce
-                        (fn [res metric-config]
-                          (conj res
-                                (core/composite-key
-                                 [(if-let [group (:group metric-config)]
-                                    group
-                                    k)
-                                  (last (:path metric-config))])))
-                        []
-                        (or (:values metric-group)
-                            (mapcat :values
-                                    (vals (:groups metric-group)))))))
-                    event-metrics-defs)
-        outlier-keys (when outlier-analysis
-                       (mapv
-                        #(core/composite-key [(last %) :outlier])
-                        (mapv :path metric-configs)))
+          quant-ids (mapv (comp last :path) metric-configs)
+          event-keys (into
+                      []
+                      (mapcat
+                       (fn [[k metric-group]]
+                         (reduce
+                          (fn [res metric-config]
+                            (conj res
+                                  (core/composite-key
+                                   [(if-let [group (:group metric-config)]
+                                      group
+                                      k)
+                                    (last (:path metric-config))])))
+                          []
+                          (or (:values metric-group)
+                              (mapcat :values
+                                      (vals (:groups metric-group))))))
+                       event-metrics-defs))
+          outlier-keys (when outlier-analysis
+                         (mapv
+                          #(core/composite-key [(last %) :outlier])
+                          (mapv :path metric-configs)))
 
-        all-keys (reduce into [:index] [quant-ids outlier-keys event-keys])
-        data (mapv
-              (fn [index]
-                (reduce
-                 merge
-                 {:index index}
-                 [(reduce
-                   (fn [res path]
-                     (into
-                      (assoc res (last path)
-                             (util/transform-sample->
-                              (get (get quant-samples path) index)
-                              transforms))
-                      (outlier-values outlier-analysis path index)))
-                   {}
-                   (mapv :path metric-configs))
-                  (flatten-events
-                   event-samples event-metrics-defs index)]))
-              (range (-> quant-samples
-                         (get (:path (first metric-configs)))
-                         count)))]
-    (pprint/print-table all-keys data)))
+          all-keys (reduce into [:index] [quant-ids outlier-keys event-keys])
+          data (mapv
+                (fn [index]
+                  (reduce
+                   merge
+                   {:index index}
+                   [(reduce
+                     (fn [res path]
+                       (into
+                        (assoc res (last path)
+                               (util/transform-sample->
+                                (get (get quant-samples path) index)
+                                transforms))
+                        (outlier-values outlier-analysis path index)))
+                     {}
+                     (mapv :path metric-configs))
+                    (flatten-events
+                     event-samples event-metrics-defs index)]))
+                (range (-> quant-samples
+                           (get (:path (first metric-configs)))
+                           count)))]
+      (pprint/print-table all-keys data))))
 
 (defmethod view/histogram* :pprint
   [_ {:keys [histogram-id] :as _view} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -326,10 +326,10 @@
       ;; Rows already use string keys matching column headers
       (pprint/print-table (into [coord-header] col-headers) rows))))
 
+;; Delegates to :print for ASCII chart rendering
 (defmethod view/domain-extract-chart* :pprint
-  [_ _ _]
-  ;; Pprint viewer doesn't render charts
-  nil)
+  [viewer view-opts data-map]
+  ((get-method view/domain-extract-chart* :print) viewer view-opts data-map))
 
 (defmethod view/domain-grouped* :pprint
   [_ {:keys [grouped-id]} data-map]
@@ -349,10 +349,10 @@
         (println heading)
         (pprint/print-table (into [coord-header] col-headers) rows)))))
 
+;; Delegates to :print for ASCII chart rendering
 (defmethod view/domain-comparison-chart* :pprint
-  [_ _ _]
-  ;; Pprint viewer doesn't render charts
-  nil)
+  [viewer view-opts data-map]
+  ((get-method view/domain-comparison-chart* :print) viewer view-opts data-map))
 
 (defmethod view/domain-regression* :pprint
   [_ {:keys [regression-id tolerance]} data-map]

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -312,10 +312,15 @@
           (when-let [kde-data (get kdes (:path metric-config))]
             (pprint-kde-metric metric-config kde-data transforms)))))))
 
+;; Delegates to :print for ASCII chart rendering
 (defmethod view/sample-percentiles* :pprint
-  [_ _view _banch-map]
-  ;; TODO
-  )
+  [viewer view-opts data-map]
+  ((get-method view/sample-percentiles* :print) viewer view-opts data-map))
+
+;; Delegates to :print for ASCII chart rendering
+(defmethod view/sample-diffs* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/sample-diffs* :print) viewer view-opts data-map))
 (defmethod view/domain-extract-table* :pprint
   [_ {:keys [extract-id]} data-map]
   (let [extract-id (or extract-id :extract)

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -543,7 +543,7 @@
                    (util/transform-sample-> (arr/get-at values i) transforms)))
                (name v))))))
 
-(defn- render-samples-chart
+(defn- render-sample-chart
   "Render an ASCII scatter plot of sample values by index.
   Returns vector of strings representing the chart."
   [metric->values transforms metric-config chart-width chart-height]
@@ -601,7 +601,7 @@
     ;; Render chart if requested
     (when show-chart
       (doseq [metric metric-configs]
-        (when-let [chart-lines (render-samples-chart
+        (when-let [chart-lines (render-sample-chart
                                 (util/metric->values metrics-samples)
                                 transforms
                                 metric

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -19,6 +19,7 @@
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have have?]]
    [criterium.view :as view]
+   [criterium.viewer.common.ascii-chart :as ascii-chart]
    [criterium.viewer.common.core :as core]
    [criterium.viewer.common.shape :as shape]
    [criterium.viewer.print.table :as table]))
@@ -542,8 +543,37 @@
                    (util/transform-sample-> (arr/get-at values i) transforms)))
                (name v))))))
 
+(defn- render-samples-chart
+  "Render an ASCII scatter plot of sample values by index.
+  Returns vector of strings representing the chart."
+  [metric->values transforms metric-config chart-width chart-height]
+  (let [path (:path metric-config)
+        values (metric->values path)
+        n (arr/length values)
+        scale (:scale metric-config)
+        points (arr/indexed-dfold
+                values
+                (fn [acc ^long idx ^double val]
+                  (conj acc [(double idx)
+                             (* scale (util/transform-sample-> val transforms))]))
+                [])]
+    (when (pos? n)
+      (ascii-chart/render-chart
+       points
+       {:width chart-width
+        :height chart-height
+        :dimension (:dimension metric-config)
+        :title (str (:label metric-config) " samples")
+        :x-label "sample index"
+        :y-label (:label metric-config)}))))
+
 (defmethod view/samples* :print
-  [_ {:keys [samples-id outliers-id] :as _view} data-map]
+  [_ {:keys [samples-id outliers-id show-chart chart-width chart-height]
+      :or {show-chart false
+           chart-width 80
+           chart-height 15}
+      :as _view}
+   data-map]
   (let [samples-id (or samples-id :samples)
         outliers-id (or outliers-id :outliers)
         metrics-samples (data-map samples-id)
@@ -566,7 +596,20 @@
          transforms
          (util/outliers outliers)
          metric))
-      (println))))
+      (println))
+
+    ;; Render chart if requested
+    (when show-chart
+      (doseq [metric metric-configs]
+        (when-let [chart-lines (render-samples-chart
+                                (util/metric->values metrics-samples)
+                                transforms
+                                metric
+                                chart-width
+                                chart-height)]
+          (doseq [line chart-lines]
+            (println line))
+          (println))))))
 
 ;;; Collect Plan
 
@@ -746,6 +789,121 @@
 
 ;;; Sample Percentiles
 
+(defn- render-sample-percentiles-chart
+  "Render an ASCII chart of sample percentiles.
+  X-axis: percentile rank (0-100), Y-axis: sample value.
+  Returns vector of strings representing the chart."
+  [metric->values transforms metric-config chart-width chart-height]
+  (let [path (:path metric-config)
+        values (metric->values path)
+        scale (:scale metric-config)
+        ;; Transform values
+        transformed (arr/dmap values
+                              (fn ^double [^double x]
+                                (* scale (util/transform-sample-> x transforms))))
+        sorted-arr (arr/sorted transformed)
+        n (arr/length sorted-arr)]
+    (when (pos? n)
+      (let [points (arr/indexed-dfold
+                    sorted-arr
+                    (fn [acc ^long idx ^double val]
+                      (let [percentile (if (= n 1)
+                                         50.0
+                                         (* 100.0 (/ (double idx) (double (dec n)))))]
+                        (conj acc [percentile val])))
+                    [])]
+        (ascii-chart/render-chart
+         points
+         {:width chart-width
+          :height chart-height
+          :dimension (:dimension metric-config)
+          :title (str (:label metric-config) " percentiles")
+          :x-label "percentile"
+          :y-label (:label metric-config)})))))
+
 (defmethod view/sample-percentiles* :print
-  [_ _view _sampled])
-  ;; TODO
+  [_ {:keys [samples-id chart-width chart-height]
+      :or {chart-width 80
+           chart-height 15}
+      :as _view}
+   data-map]
+  (let [samples-id (or samples-id :samples)
+        metrics-samples (data-map samples-id)
+        metrics-defs (-> (:metrics-defs metrics-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        transforms (util/get-transforms data-map samples-id)]
+    (doseq [metric metric-configs]
+      (when-let [chart-lines (render-sample-percentiles-chart
+                              (util/metric->values metrics-samples)
+                              transforms
+                              metric
+                              chart-width
+                              chart-height)]
+        (doseq [line chart-lines]
+          (println line))
+        (println)))))
+
+;;; Sample Diffs
+
+(defn- render-sample-diffs-chart
+  "Render an ASCII chart of sorted unique differences from minimum.
+  X-axis: index, Y-axis: difference from minimum value.
+  Returns vector of strings representing the chart."
+  [metric->values transforms metric-config chart-width chart-height]
+  (let [path (:path metric-config)
+        values (metric->values path)
+        scale (:scale metric-config)
+        ;; Transform and sort values
+        transformed (arr/dmap values
+                              (fn ^double [^double x]
+                                (* scale (util/transform-sample-> x transforms))))
+        sorted-arr (arr/sorted transformed)
+        n (arr/length sorted-arr)]
+    (when (pos? n)
+      (let [min-val (arr/first-double sorted-arr)
+            ;; Compute unique differences from minimum
+            diffs (->> (arr/dfold
+                        sorted-arr
+                        (fn [acc ^double v]
+                          (conj acc (- v min-val)))
+                        [])
+                       distinct
+                       vec)
+            points (mapv (fn [idx diff] [(double idx) diff])
+                         (range)
+                         diffs)]
+        (when (seq points)
+          (ascii-chart/render-chart
+           points
+           {:width chart-width
+            :height chart-height
+            :dimension (:dimension metric-config)
+            :title (str (:label metric-config) " differences from minimum")
+            :x-label "index"
+            :y-label "diff"}))))))
+
+(defmethod view/sample-diffs* :print
+  [_ {:keys [samples-id chart-width chart-height]
+      :or {chart-width 80
+           chart-height 15}
+      :as _view}
+   data-map]
+  (let [samples-id (or samples-id :samples)
+        metrics-samples (data-map samples-id)
+        metrics-defs (-> (:metrics-defs metrics-samples)
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        transforms (util/get-transforms data-map samples-id)]
+    (doseq [metric metric-configs]
+      (when-let [chart-lines (render-sample-diffs-chart
+                              (util/metric->values metrics-samples)
+                              transforms
+                              metric
+                              chart-width
+                              chart-height)]
+        (doseq [line chart-lines]
+          (println line))
+        (println)))))

--- a/bases/criterium/src/criterium/viewer/print/domain.clj
+++ b/bases/criterium/src/criterium/viewer/print/domain.clj
@@ -13,6 +13,7 @@
    [criterium.domain.types :as domain.types]
    [criterium.util.format :as format]
    [criterium.view :as view]
+   [criterium.viewer.common.ascii-chart :as ascii-chart]
    [criterium.viewer.common.core :as core]
    [criterium.viewer.common.domain.comparison :as comparison]
    [criterium.viewer.common.domain.detection :as detection]
@@ -121,10 +122,47 @@
                                  (format-extract-value value metric)))))
             (println)))))))
 
+(defn- render-extract-ascii-chart
+  "Render ASCII chart for domain extract data.
+  Groups data by implementation and renders one chart per impl per metric."
+  [line-data-seq {:keys [chart-width chart-height]
+                  :or {chart-width 80 chart-height 15}}]
+  (doseq [{:keys [metric-id x-title y-title data]} line-data-seq]
+    ;; Group data by implementation
+    (let [impl-groups (group-by #(get % "impl") data)]
+      (doseq [[impl-name impl-data] (sort-by key impl-groups)]
+        ;; Convert to [x y] points sorted by x
+        (let [points (->> impl-data
+                          (map (fn [d] [(get d "x") (get d "y")]))
+                          (filter (fn [[x y]] (and (some? x) (some? y))))
+                          (sort-by first)
+                          vec)
+              title (str (name metric-id)
+                         (when impl-name (str " [" impl-name "]")))
+              chart-lines (ascii-chart/render-chart
+                           points
+                           {:width chart-width
+                            :height chart-height
+                            :x-label x-title
+                            :y-label y-title
+                            :title title})]
+          (when (seq chart-lines)
+            (doseq [line chart-lines]
+              (println line))
+            (println)))))))
+
 (defmethod view/domain-extract-chart* :print
-  [_ _ _]
-  ;; Print viewer doesn't render charts
-  nil)
+  [_ opts data-map]
+  (let [extract-id (or (:extract-id opts) :extract)
+        extract (data-map extract-id)]
+    (when extract
+      (case (detection/visualization-strategy extract)
+        :multi-point
+        (let [line-data (comparison/prepare-line-chart-data extract)]
+          (render-extract-ascii-chart line-data opts))
+
+        ;; Single-point and default-table strategies don't render charts
+        (:single-point :default-table) nil))))
 
 ;;; Domain Grouped Views
 

--- a/bases/criterium/src/criterium/viewer/print/domain.clj
+++ b/bases/criterium/src/criterium/viewer/print/domain.clj
@@ -123,7 +123,7 @@
             (println)))))))
 
 (defn- render-extract-ascii-chart
-  "Render ASCII chart for domain extract data.
+  "Render ASCII chart for domain extract or comparison data.
   Groups data by implementation and renders one chart per impl per metric."
   [line-data-seq {:keys [chart-width chart-height]
                   :or {chart-width 80 chart-height 15}}]
@@ -137,7 +137,11 @@
                           (filter (fn [[x y]] (and (some? x) (some? y))))
                           (sort-by first)
                           vec)
-              title (str (name metric-id)
+              ;; Use metric-id if available, otherwise derive from y-title
+              metric-label (if metric-id
+                             (name metric-id)
+                             (or y-title "value"))
+              title (str metric-label
                          (when impl-name (str " [" impl-name "]")))
               chart-lines (ascii-chart/render-chart
                            points
@@ -423,9 +427,17 @@
                                (name axis) (pr-str metric))))))))))
 
 (defmethod view/domain-comparison-chart* :print
-  [_ _ _]
-  ;; Print viewer doesn't render charts
-  nil)
+  [_ opts data-map]
+  (let [comparison-id (or (:comparison-id opts) :comparison)
+        comparison (data-map comparison-id)]
+    (when comparison
+      (case (detection/comparison-visualization-strategy comparison)
+        :multi-point
+        (let [line-data (comparison/prepare-comparison-line-data comparison)]
+          (render-extract-ascii-chart line-data opts))
+
+        ;; Single-point and default-table strategies don't render charts
+        (:single-point :default-table) nil))))
 
 ;;; Domain Regression Views
 

--- a/bases/criterium/test/criterium/viewer/common/ascii_chart_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/ascii_chart_test.clj
@@ -26,7 +26,7 @@
         (is (= [5 25] (last result)))))
 
     (testing "returns correct count"
-      (let [points (mapv (fn [x] [x (* x x)]) (range 100))]
+      (let [points (mapv (fn [x] (let [x (long x)] [x (* x x)])) (range 100))]
         (is (= 10 (count (ascii-chart/lttb-downsample points 10))))
         (is (= 20 (count (ascii-chart/lttb-downsample points 20))))
         (is (= 50 (count (ascii-chart/lttb-downsample points 50))))))
@@ -39,7 +39,7 @@
             result (ascii-chart/lttb-downsample points 5)
             y-values (mapv second result)]
         ;; The peak should be preserved
-        (is (some #(> % 50) y-values))))
+        (is (some #(> (double %) 50.0) y-values))))
 
     (testing "handles single point"
       (is (= [[5 10]] (ascii-chart/lttb-downsample [[5 10]] 3))))
@@ -159,7 +159,7 @@
 (deftest render-chart-downsampling-test
   (testing "render-chart automatic downsampling"
     (let [;; 200 points, but width only allows ~30 plot columns
-          points (mapv (fn [x] [x (Math/sin (/ x 10.0))]) (range 200))
+          points (mapv (fn [x] [x (Math/sin (/ (double x) 10.0))]) (range 200))
           result (ascii-chart/render-chart points {:width 40 :height 10})]
       ;; Should render without error
       (is (vector? result))
@@ -207,7 +207,7 @@
 
 (deftest render-chart-many-points-test
   (testing "render-chart with many points"
-    (let [points (mapv (fn [x] [x (* x x)]) (range 1000))
+    (let [points (mapv (fn [x] (let [x (long x)] [x (* x x)])) (range 1000))
           result (ascii-chart/render-chart points {:width 80 :height 20})]
       (is (vector? result))
       (is (pos? (count result)))

--- a/bases/criterium/test/criterium/viewer/common/ascii_chart_test.clj
+++ b/bases/criterium/test/criterium/viewer/common/ascii_chart_test.clj
@@ -1,0 +1,215 @@
+(ns criterium.viewer.common.ascii-chart-test
+  ;; Tests for ASCII chart rendering and LTTB downsampling.
+  ;; Validates: LTTB correctness, chart dimensions, axis labeling, edge cases.
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [criterium.viewer.common.ascii-chart :as ascii-chart]))
+
+;;; LTTB Downsampling Tests
+
+(deftest lttb-downsample-test
+  (testing "lttb-downsample"
+    (testing "returns points unchanged when count <= target"
+      (let [points [[0 0] [1 1] [2 4]]]
+        (is (= points (ascii-chart/lttb-downsample points 5)))
+        (is (= points (ascii-chart/lttb-downsample points 3)))))
+
+    (testing "returns first and last when target is 2"
+      (let [points [[0 0] [1 1] [2 4] [3 9] [4 16]]]
+        (is (= [[0 0] [4 16]] (ascii-chart/lttb-downsample points 2)))))
+
+    (testing "preserves first and last points"
+      (let [points [[0 0] [1 1] [2 4] [3 9] [4 16] [5 25]]
+            result (ascii-chart/lttb-downsample points 4)]
+        (is (= [0 0] (first result)))
+        (is (= [5 25] (last result)))))
+
+    (testing "returns correct count"
+      (let [points (mapv (fn [x] [x (* x x)]) (range 100))]
+        (is (= 10 (count (ascii-chart/lttb-downsample points 10))))
+        (is (= 20 (count (ascii-chart/lttb-downsample points 20))))
+        (is (= 50 (count (ascii-chart/lttb-downsample points 50))))))
+
+    (testing "preserves peaks in data"
+      ;; Data with a clear peak at x=5
+      (let [points [[0 0] [1 1] [2 2] [3 3] [4 4]
+                    [5 100] ; peak
+                    [6 4] [7 3] [8 2] [9 1] [10 0]]
+            result (ascii-chart/lttb-downsample points 5)
+            y-values (mapv second result)]
+        ;; The peak should be preserved
+        (is (some #(> % 50) y-values))))
+
+    (testing "handles single point"
+      (is (= [[5 10]] (ascii-chart/lttb-downsample [[5 10]] 3))))
+
+    (testing "handles two points"
+      (is (= [[0 0] [1 1]] (ascii-chart/lttb-downsample [[0 0] [1 1]] 5))))))
+
+;;; Chart Rendering Tests
+
+(deftest render-chart-empty-test
+  (testing "render-chart"
+    (testing "returns empty vector for empty points"
+      (is (= [] (ascii-chart/render-chart [] {}))))
+
+    (testing "returns empty vector for nil points"
+      (is (= [] (ascii-chart/render-chart nil {}))))))
+
+(deftest render-chart-dimensions-test
+  (testing "render-chart dimensions"
+    (testing "respects width and height options"
+      (let [points [[0 0] [10 10]]
+            result (ascii-chart/render-chart points {:width 40 :height 10})]
+        ;; Height should be approximately 10 lines (may vary slightly with labels)
+        (is (<= 10 (count result) 12))
+        ;; Width of plot lines should not exceed 40
+        (is (every? #(<= (count %) 45) result))))
+
+    (testing "uses default dimensions when not specified"
+      (let [points [[0 0] [10 10]]
+            result (ascii-chart/render-chart points {})]
+        ;; Default height is 20
+        (is (<= 20 (count result) 22))))))
+
+(deftest render-chart-single-point-test
+  (testing "render-chart with single point"
+    (let [points [[5 10]]
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      ;; Should render without error
+      (is (vector? result))
+      (is (pos? (count result)))
+      ;; Should contain at least one point character
+      (is (some #(str/includes? % "*") result)))))
+
+(deftest render-chart-constant-y-test
+  (testing "render-chart with constant y values"
+    (let [points [[0 5] [1 5] [2 5] [3 5]]
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      ;; Should render without error
+      (is (vector? result))
+      (is (pos? (count result))))))
+
+(deftest render-chart-constant-x-test
+  (testing "render-chart with constant x values"
+    (let [points [[5 0] [5 1] [5 2] [5 3]]
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      ;; Should render without error
+      (is (vector? result))
+      (is (pos? (count result))))))
+
+(deftest render-chart-axis-labels-test
+  (testing "render-chart axis labels"
+    (testing "includes y-axis labels"
+      (let [points [[0 0] [10 100]]
+            result (ascii-chart/render-chart points {:width 60 :height 15})]
+        ;; Y-axis should have numeric labels
+        (is (some #(re-find #"\d" %) result))))
+
+    (testing "includes x-axis labels on bottom line"
+      (let [points [[0 0] [100 100]]
+            result (ascii-chart/render-chart points {:width 60 :height 15})
+            bottom-lines (take-last 2 result)]
+        ;; Bottom should have x-axis labels
+        (is (some #(re-find #"\d" %) bottom-lines))))))
+
+(deftest render-chart-si-units-test
+  (testing "render-chart with SI units"
+    (testing "formats time dimension"
+      (let [points [[0 0.001] [1 0.002]] ; values in seconds (1-2ms range)
+            result (ascii-chart/render-chart points {:width 60
+                                                     :height 15
+                                                     :dimension :time})]
+        ;; Should include time unit indicator in output
+        (is (some #(or (str/includes? % "ms")
+                       (str/includes? % "µs")
+                       (str/includes? % "s"))
+                  result))))))
+
+(deftest render-chart-point-char-test
+  (testing "render-chart custom point character"
+    (let [points [[0 0] [10 10]]
+          result (ascii-chart/render-chart points {:width 40
+                                                   :height 10
+                                                   :point-char \o})]
+      ;; Should contain custom point character
+      (is (some #(str/includes? % "o") result)))))
+
+(deftest render-chart-no-line-test
+  (testing "render-chart without line interpolation"
+    (let [points [[0 0] [5 5] [10 0]]
+          result (ascii-chart/render-chart points {:width 40
+                                                   :height 10
+                                                   :line-char nil})]
+      ;; Should render without error
+      (is (vector? result))
+      ;; Should contain point markers
+      (is (some #(str/includes? % "*") result)))))
+
+(deftest render-chart-title-test
+  (testing "render-chart with title"
+    (let [points [[0 0] [10 10]]
+          result (ascii-chart/render-chart points {:width 40
+                                                   :height 10
+                                                   :title "Test Chart"})]
+      ;; Title should be first line
+      (is (= "Test Chart" (first result))))))
+
+(deftest render-chart-downsampling-test
+  (testing "render-chart automatic downsampling"
+    (let [;; 200 points, but width only allows ~30 plot columns
+          points (mapv (fn [x] [x (Math/sin (/ x 10.0))]) (range 200))
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      ;; Should render without error
+      (is (vector? result))
+      (is (pos? (count result))))))
+
+;;; Render Chart Simple Tests
+
+(deftest render-chart-simple-test
+  (testing "render-chart-simple"
+    (testing "renders with default width"
+      (let [points [[0 0] [10 10]]
+            result (ascii-chart/render-chart-simple points)]
+        (is (vector? result))
+        (is (pos? (count result)))))
+
+    (testing "renders with custom width"
+      (let [points [[0 0] [10 10]]
+            result (ascii-chart/render-chart-simple points 40)]
+        (is (vector? result))
+        ;; Height should be width/4 = 10
+        (is (<= 10 (count result) 12))))))
+
+;;; Edge Cases
+
+(deftest render-chart-negative-values-test
+  (testing "render-chart with negative values"
+    (let [points [[-10 -5] [0 0] [10 5]]
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      (is (vector? result))
+      (is (pos? (count result))))))
+
+(deftest render-chart-large-range-test
+  (testing "render-chart with large value range"
+    (let [points [[0 0] [1000000 1000000]]
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      (is (vector? result))
+      (is (pos? (count result))))))
+
+(deftest render-chart-small-range-test
+  (testing "render-chart with small value range"
+    (let [points [[0.001 0.001] [0.002 0.002]]
+          result (ascii-chart/render-chart points {:width 40 :height 10})]
+      (is (vector? result))
+      (is (pos? (count result))))))
+
+(deftest render-chart-many-points-test
+  (testing "render-chart with many points"
+    (let [points (mapv (fn [x] [x (* x x)]) (range 1000))
+          result (ascii-chart/render-chart points {:width 80 :height 20})]
+      (is (vector? result))
+      (is (pos? (count result)))
+      ;; Should downsample and still render quickly
+      (is (some #(str/includes? % "*") result)))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -811,3 +811,71 @@
 
     (testing "returns nil for nil comparison"
       (is (nil? (view/domain-comparison-chart* :pprint {} {:comparison nil}))))))
+
+;;; Sample Chart Delegation Tests
+
+(deftest sample-percentiles-pprint-test
+  ;; Tests that pprint viewer delegates sample-percentiles* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "sample-percentiles*"
+    (testing "renders ASCII chart (same as :print)"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 200 150 300 250]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 5
+                       :eval-count 5
+                       :elapsed-time 1000}}
+            pprint-output (with-out-str
+                            (view/sample-percentiles* :pprint
+                                                      {:chart-width 60
+                                                       :chart-height 10}
+                                                      data-map))
+            print-output (with-out-str
+                           (view/sample-percentiles* :print
+                                                     {:chart-width 60
+                                                      :chart-height 10}
+                                                     data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "percentiles"))
+        (is (str/includes? pprint-output "|"))))))
+
+(deftest sample-diffs-pprint-test
+  ;; Tests that pprint viewer delegates sample-diffs* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "sample-diffs*"
+    (testing "renders ASCII chart (same as :print)"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 200 150 300 100]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 5
+                       :eval-count 5
+                       :elapsed-time 850}}
+            pprint-output (with-out-str
+                            (view/sample-diffs* :pprint
+                                                {:chart-width 60
+                                                 :chart-height 10}
+                                                data-map))
+            print-output (with-out-str
+                           (view/sample-diffs* :print
+                                               {:chart-width 60
+                                                :chart-height 10}
+                                               data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "differences"))
+        (is (str/includes? pprint-output "|"))))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -879,3 +879,54 @@
             ":pprint should produce same output as :print")
         (is (str/includes? pprint-output "differences"))
         (is (str/includes? pprint-output "|"))))))
+
+(deftest samples-show-chart-pprint-test
+  ;; Tests that pprint viewer delegates samples* to :print when :show-chart true.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "samples*"
+    (testing "delegates to :print when :show-chart is true"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 200 150 300 250]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 5
+                       :eval-count 5
+                       :elapsed-time 1000}
+                      :outliers
+                      {:type :criterium/outliers
+                       :metrics-defs metrics-defs
+                       :transform collect-plan/identity-transforms
+                       :source-id :samples
+                       :quantiles-id :quantiles
+                       :num-samples 5
+                       :outliers {[:elapsed-time]
+                                  {:low-severe 0
+                                   :low-mild 0
+                                   :high-mild 0
+                                   :high-severe 0
+                                   :low-severe-indices []
+                                   :low-mild-indices []
+                                   :high-mild-indices []
+                                   :high-severe-indices []}}}}
+            pprint-output (with-out-str
+                            (view/samples* :pprint
+                                           {:show-chart true
+                                            :chart-width 60
+                                            :chart-height 10}
+                                           data-map))
+            print-output (with-out-str
+                           (view/samples* :print
+                                          {:show-chart true
+                                           :chart-width 60
+                                           :chart-height 10}
+                                          data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print when :show-chart true")
+        (is (str/includes? pprint-output "Samples"))
+        (is (str/includes? pprint-output "|"))))))

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -655,7 +655,8 @@
         (is (str/includes? output "Domain Extract"))))))
 
 (deftest domain-extract-chart-pprint-test
-  ;; Tests that pprint viewer returns nil for charts (text viewers don't render charts).
+  ;; Tests that pprint viewer delegates to :print for ASCII chart rendering.
+  ;; Charts are rendered for multi-point strategy; single-point returns nil.
   (testing "domain-extract-chart*"
     (testing "returns nil for single-point strategy"
       (is (nil? (view/domain-extract-chart*
@@ -670,20 +671,25 @@
                               :data [[{:n 100 :impl :foo} 1e-7]
                                      [{:n 100 :impl :bar} 2e-7]]}}}}))))
 
-    (testing "returns nil for multi-point strategy"
-      (is (nil? (view/domain-extract-chart*
-                 :pprint
-                 {}
-                 {:extract
-                  {:type :criterium/domain-extract
-                   :impl-axis :impl
-                   :implementations [:foo :bar]
-                   :metrics {:elapsed-time
-                             {:metric [:stats :elapsed-time :mean]
-                              :data [[{:n 100 :impl :foo} 1e-7]
-                                     [{:n 200 :impl :foo} 2e-7]
-                                     [{:n 100 :impl :bar} 2e-7]
-                                     [{:n 200 :impl :bar} 4e-7]]}}}}))))
+    (testing "renders ASCII chart for multi-point strategy (same as :print)"
+      (let [data-map {:extract
+                      {:type :criterium/domain-extract
+                       :impl-axis :impl
+                       :implementations [:foo :bar]
+                       :metrics {:elapsed-time
+                                 {:metric [:stats :elapsed-time :mean]
+                                  :data [[{:n 100 :impl :foo} 1e-7]
+                                         [{:n 200 :impl :foo} 2e-7]
+                                         [{:n 100 :impl :bar} 2e-7]
+                                         [{:n 200 :impl :bar} 4e-7]]}}}}
+            pprint-output (with-out-str
+                            (view/domain-extract-chart* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/domain-extract-chart* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "[foo]"))
+        (is (str/includes? pprint-output "[bar]"))))
 
     (testing "returns nil for nil extract"
       (is (nil? (view/domain-extract-chart* :pprint {} {:extract nil}))))))
@@ -765,7 +771,8 @@
         (is (str/includes? output "Domain Comparison"))))))
 
 (deftest domain-comparison-chart-pprint-test
-  ;; Tests that pprint viewer returns nil for charts (text viewers don't render charts).
+  ;; Tests that pprint viewer delegates to :print for ASCII chart rendering.
+  ;; Charts are rendered for multi-point strategy; single-point returns nil.
   (testing "domain-comparison-chart*"
     (testing "returns nil for single-point strategy"
       (is (nil? (view/domain-comparison-chart*
@@ -780,20 +787,27 @@
                    {:foo [{:coord {:impl :foo} :value 1e-7}]
                     :bar [{:coord {:impl :bar} :value 2e-7}]}}}))))
 
-    (testing "returns nil for multi-point strategy"
-      (is (nil? (view/domain-comparison-chart*
-                 :pprint
-                 {}
-                 {:comparison
-                  {:type :criterium/domain-comparison
-                   :axis :impl
-                   :metric [:stats :elapsed-time :mean]
-                   :implementations [:foo :bar]
-                   :data
-                   {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
-                          {:coord {:n 200 :impl :foo} :value 2e-7}]
-                    :bar [{:coord {:n 100 :impl :bar} :value 2e-7}
-                          {:coord {:n 200 :impl :bar} :value 4e-7}]}}}))))
+    (testing "renders ASCII chart for multi-point strategy (same as :print)"
+      (let [data-map {:comparison
+                      {:type :criterium/domain-comparison
+                       :axis :impl
+                       :metric [:stats :elapsed-time :mean]
+                       :implementations [:foo :bar]
+                       :data
+                       {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
+                              {:coord {:n 200 :impl :foo} :value 2e-7}
+                              {:coord {:n 300 :impl :foo} :value 3e-7}]
+                        :bar [{:coord {:n 100 :impl :bar} :value 2e-7}
+                              {:coord {:n 200 :impl :bar} :value 4e-7}
+                              {:coord {:n 300 :impl :bar} :value 6e-7}]}}}
+            pprint-output (with-out-str
+                            (view/domain-comparison-chart* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/domain-comparison-chart* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "[foo]"))
+        (is (str/includes? pprint-output "[bar]"))))
 
     (testing "returns nil for nil comparison"
       (is (nil? (view/domain-comparison-chart* :pprint {} {:comparison nil}))))))

--- a/bases/criterium/test/criterium/viewer/print/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/core_test.clj
@@ -625,3 +625,202 @@
                                 {:my-kde kde-data :my-modes modes-data}))]
         (is (str/includes? output "n=25"))
         (is (str/includes? output "modes: 1"))))))
+
+;;; Sample Chart Tests
+
+(deftest samples-with-chart-test
+  ;; Tests samples* with show-chart option for ASCII scatter plot rendering.
+  ;; Covers: chart rendering, dimension formatting, proper scaling.
+  (testing "samples*"
+    (testing "renders ASCII chart when show-chart is true"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 110 105 120 115]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 5
+                       :eval-count 5
+                       :elapsed-time 550}
+                      :outliers
+                      {:type :criterium/outliers
+                       :metrics-defs metrics-defs
+                       :outliers {:elapsed-time {:outlier-counts
+                                                 (metrics-samples/outlier-count 0 0 0 0)
+                                                 :outliers {}}}
+                       :num-samples 5
+                       :source-id :samples
+                       :quantiles-id :quantiles
+                       :transform collect-plan/identity-transforms}}
+            output (with-out-str
+                     (view/samples* :print
+                                    {:show-chart true
+                                     :chart-width 60
+                                     :chart-height 10}
+                                    data-map))
+            lines (trimmed-lines output)]
+        ;; Should contain chart title
+        (is (some #(str/includes? % "samples") lines))
+        ;; Should contain axis markers
+        (is (some #(str/includes? % "|") lines))
+        ;; Should contain plot characters
+        (is (some #(or (str/includes? % "*") (str/includes? % ".")) lines))))
+
+    (testing "does not render chart when show-chart is false (default)"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 110 105]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 3
+                       :eval-count 3
+                       :elapsed-time 315}
+                      :outliers
+                      {:type :criterium/outliers
+                       :metrics-defs metrics-defs
+                       :outliers {:elapsed-time {:outlier-counts
+                                                 (metrics-samples/outlier-count 0 0 0 0)
+                                                 :outliers {}}}
+                       :num-samples 3
+                       :source-id :samples
+                       :quantiles-id :quantiles
+                       :transform collect-plan/identity-transforms}}
+            output (with-out-str
+                     (view/samples* :print {} data-map))
+            lines (trimmed-lines output)]
+        ;; Should not contain chart elements (no axis lines)
+        (is (not (some #(str/includes? % "samples\n") lines)))))))
+
+(deftest sample-percentiles-test
+  ;; Tests sample-percentiles* for ASCII percentile chart rendering.
+  ;; Covers: percentile computation, chart formatting, dimension scaling.
+  (testing "sample-percentiles*"
+    (testing "renders ASCII percentile chart"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 200 150 300 250]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 5
+                       :eval-count 5
+                       :elapsed-time 1000}}
+            output (with-out-str
+                     (view/sample-percentiles* :print
+                                               {:chart-width 60
+                                                :chart-height 10}
+                                               data-map))
+            lines (trimmed-lines output)]
+        ;; Should contain chart title with "percentiles"
+        (is (some #(str/includes? % "percentiles") lines))
+        ;; Should contain y-axis markers
+        (is (some #(str/includes? % "|") lines))
+        ;; Should contain plot characters
+        (is (some #(or (str/includes? % "*") (str/includes? % ".")) lines))))
+
+    (testing "handles single sample"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 1
+                       :eval-count 1
+                       :elapsed-time 100}}
+            output (with-out-str
+                     (view/sample-percentiles* :print
+                                               {:chart-width 40
+                                                :chart-height 8}
+                                               data-map))]
+        ;; Should render without error
+        (is (string? output))
+        (is (pos? (count output)))))))
+
+(deftest sample-diffs-test
+  ;; Tests sample-diffs* for ASCII sample differences chart rendering.
+  ;; Covers: diff computation from minimum, unique values, chart formatting.
+  (testing "sample-diffs*"
+    (testing "renders ASCII diffs chart"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 200 150 300 100]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 5
+                       :eval-count 5
+                       :elapsed-time 850}}
+            output (with-out-str
+                     (view/sample-diffs* :print
+                                         {:chart-width 60
+                                          :chart-height 10}
+                                         data-map))
+            lines (trimmed-lines output)]
+        ;; Should contain chart title with "differences"
+        (is (some #(str/includes? % "differences") lines))
+        ;; Should contain y-axis markers
+        (is (some #(str/includes? % "|") lines))
+        ;; Should contain plot characters
+        (is (some #(or (str/includes? % "*") (str/includes? % ".")) lines))))
+
+    (testing "handles all identical values"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [100 100 100]))}
+                       :transform collect-plan/identity-transforms
+                       :batch-size 1
+                       :num-samples 3
+                       :eval-count 3
+                       :elapsed-time 300}}
+            output (with-out-str
+                     (view/sample-diffs* :print
+                                         {:chart-width 40
+                                          :chart-height 8}
+                                         data-map))]
+        ;; Should render without error (all diffs are 0)
+        (is (string? output))
+        (is (pos? (count output)))))
+
+    (testing "applies transforms correctly"
+      (let [metrics-defs (select-keys (metrics/metrics) [:elapsed-time])
+            batch-size 10
+            data-map {:samples
+                      {:type :criterium/metrics-samples
+                       :metrics-defs metrics-defs
+                       :metric->values {[:elapsed-time]
+                                        (arr/->double-array
+                                         (double-array [1000 2000 1500]))}
+                       :transform (#'collect-plan/batch-transforms batch-size)
+                       :batch-size batch-size
+                       :num-samples 3
+                       :eval-count 30
+                       :elapsed-time 4500}}
+            output (with-out-str
+                     (view/sample-diffs* :print
+                                         {:chart-width 40
+                                          :chart-height 8}
+                                         data-map))]
+        ;; Should render (transforms divide by batch-size)
+        (is (string? output))
+        (is (pos? (count output)))))))

--- a/bases/criterium/test/criterium/viewer/print/domain_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/domain_test.clj
@@ -582,7 +582,8 @@
         (is (str/includes? output "Domain Comparison"))))))
 
 (deftest domain-comparison-chart-print-test
-  ;; Tests that print viewer returns nil for charts (text viewers don't render charts).
+  ;; Tests the print viewer ASCII chart rendering for domain-comparison.
+  ;; Charts are rendered for multi-point strategy; single-point returns nil.
   (testing "domain-comparison-chart*"
     (testing "returns nil for single-point strategy"
       (is (nil? (view/domain-comparison-chart*
@@ -597,20 +598,90 @@
                    {:foo [{:coord {:impl :foo} :value 1e-7}]
                     :bar [{:coord {:impl :bar} :value 2e-7}]}}}))))
 
-    (testing "returns nil for multi-point strategy"
-      (is (nil? (view/domain-comparison-chart*
-                 :print
-                 {}
-                 {:comparison
-                  {:type :criterium/domain-comparison
-                   :axis :impl
-                   :metric [:stats :elapsed-time :mean]
-                   :implementations [:foo :bar]
-                   :data
-                   {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
-                          {:coord {:n 200 :impl :foo} :value 2e-7}]
-                    :bar [{:coord {:n 100 :impl :bar} :value 2e-7}
-                          {:coord {:n 200 :impl :bar} :value 4e-7}]}}}))))
+    (testing "renders ASCII chart for multi-point strategy"
+      (let [output (with-out-str
+                     (view/domain-comparison-chart*
+                      :print
+                      {}
+                      {:comparison
+                       {:type :criterium/domain-comparison
+                        :axis :impl
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data
+                        {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
+                               {:coord {:n 200 :impl :foo} :value 2e-7}
+                               {:coord {:n 300 :impl :foo} :value 3e-7}]
+                         :bar [{:coord {:n 100 :impl :bar} :value 2e-7}
+                               {:coord {:n 200 :impl :bar} :value 4e-7}
+                               {:coord {:n 300 :impl :bar} :value 6e-7}]}}}))]
+        ;; Should have charts for both implementations
+        (is (str/includes? output "[foo]"))
+        (is (str/includes? output "[bar]"))
+        ;; Chart should contain point markers
+        (is (str/includes? output "*"))))
+
+    (testing "respects chart-width and chart-height options"
+      (let [output (with-out-str
+                     (view/domain-comparison-chart*
+                      :print
+                      {:chart-width 40 :chart-height 10}
+                      {:comparison
+                       {:type :criterium/domain-comparison
+                        :axis :impl
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo]
+                        :data
+                        {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
+                               {:coord {:n 200 :impl :foo} :value 2e-7}
+                               {:coord {:n 300 :impl :foo} :value 3e-7}]}}}))
+            lines (str/split-lines output)]
+        ;; With smaller dimensions, lines should be shorter
+        (is (every? #(<= (count %) 45) lines))))
+
+    (testing "uses custom comparison-id"
+      (let [output (with-out-str
+                     (view/domain-comparison-chart*
+                      :print
+                      {:comparison-id :my-comparison}
+                      {:my-comparison
+                       {:type :criterium/domain-comparison
+                        :axis :impl
+                        :metric [:stats :elapsed-time :mean]
+                        :implementations [:foo :bar]
+                        :data
+                        {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
+                               {:coord {:n 200 :impl :foo} :value 2e-7}
+                               {:coord {:n 300 :impl :foo} :value 3e-7}]
+                         :bar [{:coord {:n 100 :impl :bar} :value 2e-7}
+                               {:coord {:n 200 :impl :bar} :value 4e-7}
+                               {:coord {:n 300 :impl :bar} :value 6e-7}]}}}))]
+        (is (str/includes? output "[foo]"))))
 
     (testing "returns nil for nil comparison"
-      (is (nil? (view/domain-comparison-chart* :print {} {:comparison nil}))))))
+      (is (nil? (view/domain-comparison-chart* :print {} {:comparison nil}))))
+
+    (testing "renders chart with multi-metric comparison"
+      (let [output (with-out-str
+                     (view/domain-comparison-chart*
+                      :print
+                      {}
+                      {:comparison
+                       {:type :criterium/domain-comparison
+                        :axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data {:foo [{:coord {:n 100 :impl :foo} :value 1e-7}
+                                                {:coord {:n 200 :impl :foo} :value 2e-7}]
+                                          :bar [{:coord {:n 100 :impl :bar} :value 2e-7}
+                                                {:coord {:n 200 :impl :bar} :value 4e-7}]}}
+                                  :allocation
+                                  {:metric [:stats :thread-allocation :mean]
+                                   :data {:foo [{:coord {:n 100 :impl :foo} :value 1000}
+                                                {:coord {:n 200 :impl :foo} :value 2000}]
+                                          :bar [{:coord {:n 100 :impl :bar} :value 2000}
+                                                {:coord {:n 200 :impl :bar} :value 4000}]}}}}}))]
+        ;; Should have charts for both metrics
+        (is (str/includes? output "elapsed-time"))
+        (is (str/includes? output "allocation"))))))

--- a/bases/criterium/test/criterium/viewer/print/domain_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/domain_test.clj
@@ -391,7 +391,8 @@
         (is (str/includes? output "Domain Extract"))))))
 
 (deftest domain-extract-chart-print-test
-  ;; Tests that print viewer returns nil for charts (text viewers don't render charts).
+  ;; Tests the print viewer ASCII chart rendering for domain-extract.
+  ;; Charts are rendered for multi-point strategy; single-point returns nil.
   (testing "domain-extract-chart*"
     (testing "returns nil for single-point strategy"
       (is (nil? (view/domain-extract-chart*
@@ -406,23 +407,103 @@
                               :data [[{:n 100 :impl :foo} 1e-7]
                                      [{:n 100 :impl :bar} 2e-7]]}}}}))))
 
-    (testing "returns nil for multi-point strategy"
-      (is (nil? (view/domain-extract-chart*
-                 :print
-                 {}
-                 {:extract
-                  {:type :criterium/domain-extract
-                   :impl-axis :impl
-                   :implementations [:foo :bar]
-                   :metrics {:elapsed-time
-                             {:metric [:stats :elapsed-time :mean]
-                              :data [[{:n 100 :impl :foo} 1e-7]
-                                     [{:n 200 :impl :foo} 2e-7]
-                                     [{:n 100 :impl :bar} 2e-7]
-                                     [{:n 200 :impl :bar} 4e-7]]}}}}))))
+    (testing "renders ASCII chart for multi-point strategy with single impl"
+      (let [output (with-out-str
+                     (view/domain-extract-chart*
+                      :print
+                      {}
+                      {:extract
+                       {:type :criterium/domain-extract
+                        :impl-axis :impl
+                        :implementations [:foo]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data [[{:n 100 :impl :foo} 1e-7]
+                                          [{:n 200 :impl :foo} 2e-7]
+                                          [{:n 300 :impl :foo} 3e-7]]}}}}))]
+        (is (str/includes? output "elapsed-time"))
+        (is (str/includes? output "[foo]"))
+        ;; Chart should contain point markers
+        (is (str/includes? output "*"))))
+
+    (testing "renders separate ASCII charts for multi-point multi-impl"
+      (let [output (with-out-str
+                     (view/domain-extract-chart*
+                      :print
+                      {}
+                      {:extract
+                       {:type :criterium/domain-extract
+                        :impl-axis :impl
+                        :implementations [:foo :bar]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data [[{:n 100 :impl :foo} 1e-7]
+                                          [{:n 200 :impl :foo} 2e-7]
+                                          [{:n 100 :impl :bar} 2e-7]
+                                          [{:n 200 :impl :bar} 4e-7]]}}}}))]
+        ;; Should have charts for both implementations
+        (is (str/includes? output "[foo]"))
+        (is (str/includes? output "[bar]"))
+        ;; Chart should contain point markers
+        (is (str/includes? output "*"))))
+
+    (testing "respects chart-width and chart-height options"
+      (let [output (with-out-str
+                     (view/domain-extract-chart*
+                      :print
+                      {:chart-width 40 :chart-height 10}
+                      {:extract
+                       {:type :criterium/domain-extract
+                        :impl-axis :impl
+                        :implementations [:foo]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data [[{:n 100 :impl :foo} 1e-7]
+                                          [{:n 200 :impl :foo} 2e-7]
+                                          [{:n 300 :impl :foo} 3e-7]]}}}}))
+            lines (str/split-lines output)]
+        ;; With smaller dimensions, lines should be shorter
+        (is (every? #(<= (count %) 45) lines))))
+
+    (testing "uses custom extract-id"
+      (let [output (with-out-str
+                     (view/domain-extract-chart*
+                      :print
+                      {:extract-id :my-extract}
+                      {:my-extract
+                       {:type :criterium/domain-extract
+                        :impl-axis :impl
+                        :implementations [:foo]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data [[{:n 100 :impl :foo} 1e-7]
+                                          [{:n 200 :impl :foo} 2e-7]
+                                          [{:n 300 :impl :foo} 3e-7]]}}}}))]
+        (is (str/includes? output "elapsed-time"))))
 
     (testing "returns nil for nil extract"
-      (is (nil? (view/domain-extract-chart* :print {} {:extract nil}))))))
+      (is (nil? (view/domain-extract-chart* :print {} {:extract nil}))))
+
+    (testing "renders chart with multiple metrics"
+      (let [output (with-out-str
+                     (view/domain-extract-chart*
+                      :print
+                      {}
+                      {:extract
+                       {:type :criterium/domain-extract
+                        :impl-axis :impl
+                        :implementations [:foo]
+                        :metrics {:elapsed-time
+                                  {:metric [:stats :elapsed-time :mean]
+                                   :data [[{:n 100 :impl :foo} 1e-7]
+                                          [{:n 200 :impl :foo} 2e-7]]}
+                                  :allocation
+                                  {:metric [:stats :thread-allocation :mean]
+                                   :data [[{:n 100 :impl :foo} 1000]
+                                          [{:n 200 :impl :foo} 2000]]}}}}))]
+        ;; Should have charts for both metrics
+        (is (str/includes? output "elapsed-time"))
+        (is (str/includes? output "allocation"))))))
 
 ;;; Domain Comparison Table/Chart Tests
 


### PR DESCRIPTION
## Summary

Add ASCII-based chart rendering for line and scatter plots in the :print and :pprint viewers, providing useful text-based visualizations that work in any terminal.

## Chart Types Implemented

**Line plots (domain analysis):**
- `domain-extract-chart*` - metric values across a domain axis (e.g., input size vs execution time)
- `domain-comparison-chart*` - implementation comparisons across domain coordinates
- Multiple implementations rendered as separate plots (one per impl)

**Scatter plots (sample visualization):**
- `samples*` - sample index vs value (via :show-chart option)
- `sample-percentiles*` - sorted samples vs percentile rank
- `sample-diffs*` - sorted unique differences from minimum value

## Design

- Core ASCII chart infrastructure in `criterium.viewer.common.ascii-chart` namespace
- LTTB (Largest Triangle Three Buckets) downsampling for data points exceeding chart width
- Default 80-character width (most portable), configurable via view options
- SI unit axis labels via existing `criterium.util.format` infrastructure
- :pprint delegates to :print for chart rendering

## Commits

- Add LTTB downsampling and ASCII chart renderer
- Implement domain-extract-chart* for :print viewer
- Implement domain-comparison-chart* for :print viewer
- Implement sample chart renderers (samples*, sample-percentiles*, sample-diffs*)
- Add :pprint delegation to :print for domain and sample charts
- Add :show-chart delegation to :pprint samples*
- Eliminate boxed math warnings in ascii-chart
- Rename render-samples-chart to render-sample-chart