### PR TITLE
fix(viewer): guard against nil significance in print/pprint/kindly viewers

### DIFF
--- a/bases/criterium/src/criterium/viewer/kindly/core.clj
+++ b/bases/criterium/src/criterium/viewer/kindly/core.clj
@@ -276,12 +276,15 @@
         outlier-sig-map (data-map outlier-sig-id)
         outlier-sig (util/outlier-significance outlier-sig-map)
         metrics-defs (:metrics-defs outlier-sig-map)
-        metric-configs (metric/all-metric-configs metrics-defs)]
-    (kindly-heading "Outlier Significance")
-    (kindly-table
-     (vec
-      (for [m metric-configs]
-        (get-in outlier-sig (:path m)))))))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        significances (vec
+                       (for [m metric-configs
+                             :let [data (get-in outlier-sig (:path m))]
+                             :when (:significance data)]
+                         data))]
+    (when (seq significances)
+      (kindly-heading "Outlier Significance")
+      (kindly-table significances))))
 
 ;;; Sample Diffs
 

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -112,10 +112,13 @@
         outlier-sig-map (data-map outlier-sig-id)
         outlier-sig (util/outlier-significance outlier-sig-map)
         metrics-defs (:metrics-defs outlier-sig-map)
-        metric-configs (metric/all-metric-configs metrics-defs)]
-    (pprint/print-table
-     (for [m metric-configs]
-       (get-in outlier-sig (:path m))))))
+        metric-configs (metric/all-metric-configs metrics-defs)
+        significances (for [m metric-configs
+                            :let [data (get-in outlier-sig (:path m))]
+                            :when (:significance data)]
+                        data)]
+    (when (seq significances)
+      (pprint/print-table significances))))
 
 (defmethod view/outlier-significance* :pprint
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -515,12 +515,14 @@
   (when-let [{:keys [analysis-map metric-configs]}
              (get-analysis-context :outlier-significance-id :outlier-significance
                                    view data-map (metric/type-pred :quantitative))]
-    (let [outlier-sig (util/outlier-significance analysis-map)]
-      (for-each-metric
-       metric-configs outlier-sig
-       (fn [m data]
-         (when (:significance data)
-           (print-outlier-significance m (have seq data {:metric m}))))))))
+    (let [outlier-sig (util/outlier-significance analysis-map)
+          filtered-metrics (for [m metric-configs
+                                 :let [data (get-in outlier-sig (:path m))]
+                                 :when (:significance data)]
+                             [m data])]
+      (when (seq filtered-metrics)
+        (doseq [[m data] filtered-metrics]
+          (print-outlier-significance m (have seq data {:metric m})))))))
 
 (defmethod view/outlier-significance* :print
   [_ view data-map]

--- a/bases/criterium/src/criterium/viewer/print/core.clj
+++ b/bases/criterium/src/criterium/viewer/print/core.clj
@@ -519,7 +519,8 @@
       (for-each-metric
        metric-configs outlier-sig
        (fn [m data]
-         (print-outlier-significance m (have seq data {:metric m})))))))
+         (when (:significance data)
+           (print-outlier-significance m (have seq data {:metric m}))))))))
 
 (defmethod view/outlier-significance* :print
   [_ view data-map]

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -140,6 +140,25 @@
        :outliers-id          :outliers
        :transform            collect-plan/identity-transforms}}}))
 
+(defn outlier-significance-nil-map
+  "Creates an outlier-significance map with nil significance.
+  This occurs when there are no positive outlier counts."
+  []
+  (let [metrics-defs (-> (metrics/metrics)
+                         (metric/select-metrics [:elapsed-time])
+                         (metric/filter-metrics
+                          (metric/type-pred :quantitative)))]
+    {:data
+     {:outlier-significance
+      {:type                 :criterium/outlier-significance
+       :outlier-significance {:elapsed-time
+                              {:effect       nil
+                               :significance nil}}
+       :metrics-defs         metrics-defs
+       :source-id            :samples
+       :outliers-id          :outliers
+       :transform            collect-plan/identity-transforms}}}))
+
 (defn samples-with-non-numeric-value-map
   "Creates a samples map with a non-numeric metric value for testing viewer
   error handling."

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -142,22 +142,25 @@
 
 (defn outlier-significance-nil-map
   "Creates an outlier-significance map with nil significance.
-  This occurs when there are no positive outlier counts."
-  []
-  (let [metrics-defs (-> (metrics/metrics)
-                         (metric/select-metrics [:elapsed-time])
-                         (metric/filter-metrics
-                          (metric/type-pred :quantitative)))]
-    {:data
-     {:outlier-significance
-      {:type                 :criterium/outlier-significance
-       :outlier-significance {:elapsed-time
-                              {:effect       nil
-                               :significance nil}}
-       :metrics-defs         metrics-defs
-       :source-id            :samples
-       :outliers-id          :outliers
-       :transform            collect-plan/identity-transforms}}}))
+  This occurs when there are no positive outlier counts.
+  Optionally specify which metrics to include (defaults to [:elapsed-time])."
+  ([]
+   (outlier-significance-nil-map [:elapsed-time]))
+  ([metrics]
+   (let [metrics-defs (-> (metrics/metrics)
+                          (metric/select-metrics metrics)
+                          (metric/filter-metrics
+                           (metric/type-pred :quantitative)))]
+     {:data
+      {:outlier-significance
+       {:type                 :criterium/outlier-significance
+        :outlier-significance (zipmap metrics
+                                      (repeat {:effect       nil
+                                               :significance nil}))
+        :metrics-defs         metrics-defs
+        :source-id            :samples
+        :outliers-id          :outliers
+        :transform            collect-plan/identity-transforms}}})))
 
 (defn samples-with-non-numeric-value-map
   "Creates a samples map with a non-numeric metric value for testing viewer

--- a/bases/criterium/test/criterium/viewer/kindly_basic_views_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_basic_views_test.clj
@@ -355,7 +355,8 @@
 
 (deftest outlier-significance-view-test
   ;; Tests the view/outlier-significance* multimethod for :kindly viewer.
-  ;; Verifies that outlier significance data is rendered as heading and table.
+  ;; Verifies that outlier significance data is rendered as heading and table,
+  ;; and that nil significance entries are filtered out.
   (testing "view/outlier-significance* :kindly"
     (testing "renders outlier significance as heading and table"
       (reset! kindly/accumulated [])
@@ -377,7 +378,15 @@
             (is (= :moderate (:effect row))
                 "Expected moderate effect")
             (is (= 0.25 (:significance row))
-                "Expected 0.25 significance")))))))
+                "Expected 0.25 significance")))))
+
+    (testing "outputs nothing when significance is nil"
+      (reset! kindly/accumulated [])
+      (view/outlier-significance*
+       :kindly
+       {}
+       (:data (test-data/outlier-significance-nil-map)))
+      (is (nil? (kindly/flush))))))
 
 (deftest sample-diffs-view-test
   ;; Tests the view/sample-diffs* multimethod for :kindly viewer.

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -98,6 +98,8 @@
               (:data (test-data/outlier-count-map))))))))))
 
 (deftest print-outlier-significance-test
+  ;; Tests print-outlier-significances function for variance contribution display.
+  ;; Covers: effect classification, significance value, and nil handling.
   (testing "print-outlier-significance"
     (testing "prints via view"
       (is (= [""
@@ -108,7 +110,14 @@
               (with-out-str
                 ((view/outlier-significance)
                  :pprint
-                 (:data (test-data/outlier-significance-map))))))))))
+                 (:data (test-data/outlier-significance-map))))))))
+    (testing "with nil significance produces no output"
+      (is (= [""]
+             (trimmed-lines
+              (with-out-str
+                ((view/outlier-significance)
+                 :pprint
+                 (:data (test-data/outlier-significance-nil-map))))))))))
 
 (def ^:private expected-event-stats
   [""

--- a/bases/criterium/test/criterium/viewer/print/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/core_test.clj
@@ -432,7 +432,7 @@
 
 (deftest print-outlier-significance-test
   ;; Tests print-outlier-significance function and view/outlier-significance*.
-  ;; Covers: variance contribution and effect classification.
+  ;; Covers: variance contribution, effect classification, and nil handling.
   (testing "print-outlier-significance"
     (testing "prints via view"
       (is (= [(str "Elapsed Time Variance contribution from outliers : 25.0 %"
@@ -441,7 +441,14 @@
               (with-out-str
                 ((view/outlier-significance)
                  :print
-                 (:data (test-data/outlier-significance-map))))))))))
+                 (:data (test-data/outlier-significance-map))))))))
+    (testing "with nil significance produces no output"
+      (is (= [""]
+             (trimmed-lines
+              (with-out-str
+                ((view/outlier-significance)
+                 :print
+                 (:data (test-data/outlier-significance-nil-map))))))))))
 
 ;;; Event Stats Tests
 


### PR DESCRIPTION
## Summary

Fix NullPointerException in `:print` viewer when displaying outlier significance for benchmarks with no detected outliers. The `:pprint` and `:kindly` viewers were also updated for consistency.

**Root cause:** In `samples-outlier-significance` (analyse.clj:646), `:significance` is set to `nil` when no positive outlier counts exist. The print viewer then attempted `(* (:significance outlier-significance) 100.0)` which failed on nil.

**Fix:** All three viewers now filter out metrics where `:significance` is nil before rendering:
- `:print` viewer - filters in `print-outlier-significances` before calling `print-outlier-significance`
- `:pprint` viewer - filters entries before passing to `pprint/print-table`
- `:kindly` viewer - uses `:when (:significance data)` in the for comprehension

## Changes

- `bases/criterium/src/criterium/viewer/print/core.clj` - Add nil guard in `print-outlier-significances`
- `bases/criterium/src/criterium/viewer/pprint.clj` - Add nil filtering before print-table
- `bases/criterium/src/criterium/viewer/kindly/core.clj` - Add nil guard in `view/outlier-significance*`
- `bases/criterium/test/criterium/test_data.clj` - Add `outlier-significance-nil-map` test helper

## Test plan

- [x] Added tests for nil significance scenario in all three viewer test files
- [x] All existing tests pass