### PR TITLE
feat(viewer): implement missing view methods across all viewers

### DIFF
--- a/bases/criterium/src/criterium/viewer/common/core.clj
+++ b/bases/criterium/src/criterium/viewer/common/core.clj
@@ -537,3 +537,26 @@
       (if (and (seq uniform-axes) (pos? remaining-keys))
         (mapv #(apply dissoc % uniform-axes) coords)
         coords))))
+
+;;; Transform Extraction
+
+(defn simple-transforms
+  "Extract transforms from a data map, normalizing to vector format.
+
+  Many viewer data maps contain a :transform key with :sample-> and :->sample
+  functions. These may be single functions or vectors of functions.
+  This helper normalizes both formats to vectors for use with
+  criterium.util.helpers/transform-sample->.
+
+  Returns map {:sample-> [fns...] :->sample [fns...]} or nil if no transform."
+  [data-map]
+  (let [t (:transform data-map)]
+    (when t
+      (let [s-> (:sample-> t)
+            ->s (:->sample t)]
+        {:sample-> (cond (fn? s->) [s->]
+                         (sequential? s->) (vec s->)
+                         :else [identity])
+         :->sample (cond (fn? ->s) [->s]
+                         (sequential? ->s) (vec ->s)
+                         :else [identity])}))))

--- a/bases/criterium/src/criterium/viewer/common_charts/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts/autocorrelation.clj
@@ -1,11 +1,17 @@
 (ns criterium.viewer.common-charts.autocorrelation
-  "Vega-Lite chart specification for ACF (Autocorrelation Function) plots.
+  "Chart specifications for ACF (Autocorrelation Function) plots.
 
-  Provides point charts showing autocorrelation coefficients for all lags,
-  with points colored by severity and horizontal threshold lines for
-  lag-1 (blue) and other-lag (gray) thresholds."
+  Provides:
+  - Vega-Lite point charts for graphical viewers (:portal, :kindly)
+  - ASCII bar chart rendering for text viewers (:print, :pprint)
+
+  Both chart types show autocorrelation coefficients for all lags,
+  with severity-based coloring and threshold visualization."
   (:require
-   [criterium.stats.autocorrelation :as stats]))
+   [clojure.string :as str]
+   [criterium.stats.autocorrelation :as stats]
+   [criterium.viewer.common.autocorrelation :as acf-common]
+   [criterium.viewer.common.core :as core]))
 
 ;;; Severity Colors
 
@@ -251,3 +257,85 @@
          {:title title
           :layer (vec (remove nil? layers))}
          (select-keys chart-options [:width :height]))))))
+
+;;; ASCII ACF Plot
+
+(defn- format-threshold-legend
+  "Format threshold legend showing only crossed thresholds.
+  Returns vector of strings like [\"lag-1 [minor 0.10, moderate 0.20]\" \"other [minor 0.15]\"]."
+  [acf-map thresholds]
+  (let [lag-1-acf (Math/abs (double (get acf-map 1 0)))
+        other-max-acf (double (if (> (count acf-map) 1)
+                                (apply max 0 (map #(Math/abs (double %))
+                                                  (vals (dissoc acf-map 1))))
+                                0))
+        lag-1-thresholds (:lag-1 thresholds)
+        other-thresholds (:other thresholds)
+        lag-1-crossed (for [[level ^double threshold] (sort-by val lag-1-thresholds)
+                            :when (> lag-1-acf threshold)]
+                        (format "%s %.2f" (name level) threshold))
+        other-crossed (for [[level ^double threshold] (sort-by val other-thresholds)
+                            :when (> other-max-acf threshold)]
+                        (format "%s %.2f" (name level) threshold))]
+    (cond-> []
+      (seq lag-1-crossed)
+      (conj (str "lag-1 [" (str/join ", " lag-1-crossed) "]"))
+      (seq other-crossed)
+      (conj (str "other [" (str/join ", " other-crossed) "]")))))
+
+(defn render-ascii-acf-plot
+  "Render ASCII ACF plot for a single metric as a string.
+
+  Shows autocorrelation coefficients as bidirectional ASCII bar charts.
+  Returns nil if no lags meet the min-severity threshold.
+
+  Parameters:
+    acf-data     - map with :acf, :effective-sample-size, :lag-severities, :thresholds
+    metric-label - string label for the metric
+    opts         - options map:
+      :min-severity   - minimum severity to display (default :moderate)
+      :bar-width      - half-width of bar in characters (default 15)
+      :header-fn      - fn [metric-label n] -> header string
+      :indent         - string prefix for continuation lines"
+  [{:keys [acf effective-sample-size lag-severities thresholds]} metric-label opts]
+  (let [{:keys [min-severity bar-width header-fn indent]
+         :or {min-severity :moderate
+              bar-width 15
+              header-fn (fn [label n] (format "%s ACF Plot (n=%d):" label n))
+              indent ""}} opts
+        n (get effective-sample-size :n-original)
+        thresholds (or thresholds
+                       {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                        :other {:minor 0.15 :moderate 0.25 :severe 0.40}})]
+    (when (and acf n lag-severities
+               (has-severity-at-or-above? lag-severities min-severity))
+      (let [min-rank (get severity-rank min-severity 0)
+            qualifying-lags (for [[lag sev] lag-severities
+                                  :when (>= (long (get severity-rank sev 0))
+                                            (long min-rank))]
+                              lag)
+            max-abs-acf (apply max 0.01 (map #(Math/abs (double (get acf % 0)))
+                                             qualifying-lags))
+            sorted-lags (sort qualifying-lags)
+            max-lag-width (max 3 (count (str (apply max 1 sorted-lags))))
+            header-fmt (str "%s%" max-lag-width "s   %s")
+            row-fmt (str "%s%" max-lag-width "d  %6.2f  %s (%s)")
+            header-lines [(header-fn metric-label n)
+                          (format header-fmt indent "Lag" "ACF")]
+            data-lines (mapv (fn [lag]
+                               (let [acf-val (double (get acf lag))
+                                     severity (get lag-severities lag :none)
+                                     bar (core/ascii-bar-bidirectional
+                                          acf-val max-abs-acf bar-width)]
+                                 (format row-fmt
+                                         indent
+                                         lag
+                                         acf-val
+                                         bar
+                                         (acf-common/format-severity severity))))
+                             sorted-lags)
+            legend-parts (format-threshold-legend acf thresholds)
+            legend-lines (when (seq legend-parts)
+                           ["" (format "%sThresholds: %s"
+                                       indent (str/join ", " legend-parts))])]
+        (str/join "\n" (concat header-lines data-lines legend-lines))))))

--- a/bases/criterium/src/criterium/viewer/common_charts/distribution_ascii.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts/distribution_ascii.clj
@@ -1,0 +1,266 @@
+(ns criterium.viewer.common-charts.distribution-ascii
+  "ASCII chart rendering for distribution analysis visualization.
+
+  Provides ASCII chart functions for:
+  - PDF (probability density function) line charts
+  - CDF (cumulative distribution function) step charts
+  - Q-Q (quantile-quantile) scatter plots
+
+  These functions are used by :print and :pprint viewers for terminal-based
+  visualization of distribution fit results."
+  (:require
+   [clojure.string :as str]
+   [criterium.array :as arr]
+   [criterium.metric :as metric]
+   [criterium.primitive-fn :as prim]
+   [criterium.stats.probability :as prob]
+   [criterium.util.helpers :as util]
+   [criterium.viewer.common-charts.distribution :as dist]
+   [criterium.viewer.common.ascii-chart :as ascii-chart]))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+;;; PDF Chart
+
+(defn- make-pdf-fn
+  "Create a PDF function for the given distribution and parameters."
+  [dist params]
+  (case dist
+    :gamma (prob/gamma-pdf (:shape params) (:scale params))
+    :lognormal (prob/lognormal-pdf (:mu params) (:sigma params))
+    :inverse-gaussian (prob/inverse-gaussian-pdf (:mu params) (:lambda params))
+    :weibull (prob/weibull-pdf (:shape params) (:scale params))
+    nil))
+
+(defn- pdf-points-for-distribution
+  "Generate PDF points for a single fitted distribution.
+
+  Returns vector of [x density] pairs, or nil if distribution not fitted."
+  [dist fit-result grid]
+  (when (and (:params fit-result)
+             (not (:error fit-result))
+             (not (:skipped fit-result)))
+    (let [pdf-fn (make-pdf-fn dist (:params fit-result))]
+      (when pdf-fn
+        (->> grid
+             (mapv (fn [^double x]
+                     (let [p (prim/invoke-dd pdf-fn x)]
+                       (when (and (Double/isFinite p) (not (Double/isNaN p)))
+                         [x p]))))
+             (filterv some?))))))
+
+(defn render-ascii-pdf
+  "Render ASCII PDF chart for the best-fit distribution.
+
+  Parameters:
+    fit-data    - distribution fit data for a metric (from :distribution-fit)
+    transforms  - transforms to apply to x-values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [dist-label n] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no valid fit."
+  [fit-data transforms opts]
+  (let [{:keys [best-model distributions sample-range n]} fit-data
+        {:keys [width height header-fn indent]
+         :or {width 60
+              height 15
+              header-fn (fn [label n] (format "PDF: %s (n=%d)" label n))
+              indent ""}} opts
+        [sample-min sample-max] sample-range]
+    (when (and best-model sample-min sample-max
+               (> (double sample-max) (double sample-min)))
+      (let [fit-result (get distributions best-model)
+            label (get dist/distribution-labels best-model (name best-model))
+            ;; Generate grid spanning the sample range
+            range-val (- (double sample-max) (double sample-min))
+            grid-min (max 1e-10 (- (double sample-min) (* 0.05 range-val)))
+            grid-max (+ (double sample-max) (* 0.05 range-val))
+            step (/ (- grid-max grid-min) 100.0)
+            grid (vec (range grid-min grid-max step))
+            ;; Generate PDF points
+            points (pdf-points-for-distribution best-model fit-result grid)]
+        (when (seq points)
+          ;; Transform x-values for display
+          (let [display-points (mapv (fn [[x y]]
+                                       [(util/transform-sample-> x transforms) y])
+                                     points)
+                header (header-fn label n)
+                chart-lines (ascii-chart/render-chart
+                             display-points
+                             {:width (- (long width) (count indent))
+                              :height height
+                              :y-label "density"
+                              :point-char \*
+                              :line-char \.})]
+            (when (seq chart-lines)
+              (str header "\n"
+                   (->> chart-lines
+                        (map #(str indent %))
+                        (str/join "\n"))))))))))
+
+;;; CDF Chart
+
+(defn- ecdf-points
+  "Compute ECDF (empirical CDF) points from samples.
+
+  Returns vector of [x cumulative-probability] pairs."
+  [samples transforms]
+  (let [sorted-arr (arr/sorted samples)
+        n (arr/length sorted-arr)
+        nd (double n)]
+    (arr/indexed-dfold sorted-arr
+                       (fn [acc ^long i ^double x]
+                         (conj acc [(util/transform-sample-> x transforms)
+                                    (/ (double (inc i)) nd)]))
+                       [])))
+
+(defn render-ascii-cdf
+  "Render ASCII CDF chart showing ECDF as step function.
+
+  Parameters:
+    samples     - sample array for the metric
+    transforms  - transforms to apply to sample values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [n] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no samples."
+  [samples transforms opts]
+  (when (and samples (pos? (arr/length samples)))
+    (let [{:keys [width height header-fn indent]
+           :or {width 60
+                height 15
+                header-fn (fn [n] (format "CDF (n=%d)" n))
+                indent ""}} opts
+          n (arr/length samples)
+          ;; Compute ECDF points
+          ecdf (ecdf-points samples transforms)
+          header (header-fn n)
+          chart-lines (ascii-chart/render-chart
+                       ecdf
+                       {:width (- (long width) (count indent))
+                        :height height
+                        :y-label "cumulative"
+                        :point-char \*
+                        :line-char nil})] ; No lines, just points for step effect
+      (when (seq chart-lines)
+        (str header "\n"
+             (->> chart-lines
+                  (map #(str indent %))
+                  (str/join "\n")))))))
+
+;;; Q-Q Chart
+
+(defn render-ascii-qq
+  "Render ASCII Q-Q plot for the best-fit distribution.
+
+  Shows theoretical quantiles (x-axis) vs observed quantiles (y-axis).
+  Points near the diagonal indicate good fit.
+
+  Parameters:
+    samples     - sample array for the metric
+    fit-data    - distribution fit data for a metric
+    transforms  - transforms to apply to values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [dist-label n] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no valid fit."
+  [samples fit-data transforms opts]
+  (let [{:keys [best-model distributions]} fit-data
+        {:keys [width height header-fn indent]
+         :or {width 60
+              height 15
+              header-fn (fn [label n] (format "Q-Q Plot: %s (n=%d)" label n))
+              indent ""}} opts]
+    (when (and best-model samples (pos? (arr/length samples)))
+      (let [fit-result (get distributions best-model)
+            label (get dist/distribution-labels best-model (name best-model))
+            quantile-fn (dist/make-quantile-fn best-model (:params fit-result))
+            n (arr/length samples)]
+        (when quantile-fn
+          ;; Generate Q-Q points using Hazen plotting positions
+          (let [sorted-arr (arr/sorted samples)
+                nd (double n)
+                qq-points (arr/indexed-dfold
+                           sorted-arr
+                           (fn [acc ^long i ^double observed]
+                             (let [p (/ (- (double (inc i)) 0.5) nd)
+                                   theoretical (quantile-fn p)
+                                   t-obs (util/transform-sample-> observed transforms)
+                                   t-theo (util/transform-sample-> theoretical transforms)]
+                               (if (and (Double/isFinite t-theo)
+                                        (not (Double/isNaN t-theo)))
+                                 (conj acc [t-theo t-obs])
+                                 acc)))
+                           [])]
+            (when (seq qq-points)
+              (let [header (header-fn label n)
+                    chart-lines (ascii-chart/render-chart
+                                 qq-points
+                                 {:width (- (long width) (count indent))
+                                  :height height
+                                  :x-label "theoretical"
+                                  :y-label "observed"
+                                  :point-char \*
+                                  :line-char nil})] ; Scatter plot, no lines
+                (when (seq chart-lines)
+                  (str header "\n"
+                       (->> chart-lines
+                            (map #(str indent %))
+                            (str/join "\n"))))))))))))
+
+;;; Data Extraction Helpers
+
+(defn- simple-transforms
+  "Get transforms from samples-map, wrapping in vectors for transform-sample->.
+
+  Handles both simple {:sample-> fn :->sample fn} and
+  list/vector formats {:sample-> (fn...) :->sample [fn...]}."
+  [samples-map]
+  (let [t (:transform samples-map)]
+    (when t
+      (let [s-> (:sample-> t)
+            ->s (:->sample t)]
+        {:sample-> (cond (fn? s->) [s->]
+                         (sequential? s->) (vec s->)
+                         :else [identity])
+         :->sample (cond (fn? ->s) [->s]
+                         (sequential? ->s) (vec ->s)
+                         :else [identity])}))))
+
+(defn with-distribution-metrics
+  "Iterate over metrics with distribution fit data, calling f for each.
+
+  Parameters:
+    view     - view options with :distribution-fit-id, :samples-id
+    data-map - analysis data map
+    f        - fn [fit-data samples transforms metric-config] -> any"
+  [view data-map f]
+  (let [distribution-fit-id (or (:distribution-fit-id view) :distribution-fit)
+        samples-id (or (:samples-id view) :samples)
+        distribution-fit-map (get data-map distribution-fit-id)
+        samples-map (get data-map samples-id)]
+    (when (and distribution-fit-map samples-map)
+      (let [fits (:fits distribution-fit-map)
+            metrics-defs (:metrics-defs samples-map)
+            metric-configs (when metrics-defs
+                             (metric/all-metric-configs
+                              (metric/filter-metrics
+                               metrics-defs
+                               (metric/type-pred :quantitative))))
+            metric->values (:metric->values samples-map)
+            transforms (simple-transforms samples-map)]
+        (doseq [mc metric-configs]
+          (let [path (:path mc)
+                fit-data (get fits path)
+                samples (get metric->values path)]
+            (when (and fit-data samples)
+              (f fit-data samples transforms mc))))))))

--- a/bases/criterium/src/criterium/viewer/common_charts/distribution_ascii.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts/distribution_ascii.clj
@@ -16,7 +16,8 @@
    [criterium.stats.probability :as prob]
    [criterium.util.helpers :as util]
    [criterium.viewer.common-charts.distribution :as dist]
-   [criterium.viewer.common.ascii-chart :as ascii-chart]))
+   [criterium.viewer.common.ascii-chart :as ascii-chart]
+   [criterium.viewer.common.core :as common]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -219,23 +220,6 @@
 
 ;;; Data Extraction Helpers
 
-(defn- simple-transforms
-  "Get transforms from samples-map, wrapping in vectors for transform-sample->.
-
-  Handles both simple {:sample-> fn :->sample fn} and
-  list/vector formats {:sample-> (fn...) :->sample [fn...]}."
-  [samples-map]
-  (let [t (:transform samples-map)]
-    (when t
-      (let [s-> (:sample-> t)
-            ->s (:->sample t)]
-        {:sample-> (cond (fn? s->) [s->]
-                         (sequential? s->) (vec s->)
-                         :else [identity])
-         :->sample (cond (fn? ->s) [->s]
-                         (sequential? ->s) (vec ->s)
-                         :else [identity])}))))
-
 (defn with-distribution-metrics
   "Iterate over metrics with distribution fit data, calling f for each.
 
@@ -257,7 +241,7 @@
                                metrics-defs
                                (metric/type-pred :quantitative))))
             metric->values (:metric->values samples-map)
-            transforms (simple-transforms samples-map)]
+            transforms (common/simple-transforms samples-map)]
         (doseq [mc metric-configs]
           (let [path (:path mc)
                 fit-data (get fits path)

--- a/bases/criterium/src/criterium/viewer/common_charts/tail_ascii.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts/tail_ascii.clj
@@ -17,7 +17,8 @@
    [criterium.metric :as metric]
    [criterium.stats.tail :as stats]
    [criterium.util.helpers :as util]
-   [criterium.viewer.common.ascii-chart :as ascii-chart]))
+   [criterium.viewer.common.ascii-chart :as ascii-chart]
+   [criterium.viewer.common.core :as common]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -344,23 +345,6 @@
 
 ;;; Data Extraction Helper
 
-(defn- simple-transforms
-  "Get transforms from tail-analysis-map, wrapping in sequences for transform-sample->.
-
-  Handles both simple {:sample-> fn :->sample fn} and
-  list/vector formats {:sample-> (fn...) :->sample [fn...]}."
-  [tail-analysis-map]
-  (let [t (:transform tail-analysis-map)]
-    (when t
-      (let [s-> (:sample-> t)
-            ->s (:->sample t)]
-        {:sample-> (cond (fn? s->) [s->]
-                         (sequential? s->) (vec s->)
-                         :else [identity])
-         :->sample (cond (fn? ->s) [->s]
-                         (sequential? ->s) (vec ->s)
-                         :else [identity])}))))
-
 (defn with-tail-metrics
   "Iterate over metrics with tail analysis data, calling f for each.
 
@@ -384,7 +368,7 @@
                                metrics-defs
                                (metric/type-pred :quantitative))))
             metric->values (when samples-map (util/metric->values samples-map))
-            transforms (simple-transforms tail-analysis-map)]
+            transforms (common/simple-transforms tail-analysis-map)]
         (doseq [mc metric-configs]
           (let [path (:path mc)
                 tail-data (get tail-results path)

--- a/bases/criterium/src/criterium/viewer/common_charts/tail_ascii.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts/tail_ascii.clj
@@ -1,0 +1,393 @@
+(ns criterium.viewer.common-charts.tail-ascii
+  "ASCII chart rendering for tail analysis visualization.
+
+  Provides ASCII chart functions for:
+  - Tail ratios bar chart
+  - Hill plot (tail index estimates vs k)
+  - MRL plot (mean residual life vs threshold)
+  - Zipf plot (complementary CDF on log-log scale)
+  - Exponential Q-Q plot
+  - GPD Q-Q plot
+
+  These functions are used by :print and :pprint viewers for terminal-based
+  visualization of tail analysis results."
+  (:require
+   [clojure.string :as str]
+   [criterium.array :as arr]
+   [criterium.metric :as metric]
+   [criterium.stats.tail :as stats]
+   [criterium.util.helpers :as util]
+   [criterium.viewer.common.ascii-chart :as ascii-chart]))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+;;; Tail Ratios Chart
+
+(defn render-ascii-tail-ratios
+  "Render ASCII horizontal bar chart for tail ratios.
+
+  Parameters:
+    tail-data   - tail analysis data for a metric
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :header-fn  - fn [] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no ratios."
+  [tail-data opts]
+  (let [{:keys [tail-ratios empirical-quantiles]} tail-data
+        {:keys [width header-fn indent]
+         :or {width 60
+              header-fn (fn [] "Tail Ratios")
+              indent ""}} opts
+        {:keys [p99-p95 p999-p99 p999-p95]} tail-ratios
+        {:keys [p95 p99 p999]} empirical-quantiles]
+    (when (and tail-ratios (or p99-p95 p999-p99 p999-p95))
+      (let [ratios (cond-> []
+                     p99-p95 (conj {:label "p99/p95" :value p99-p95
+                                    :detail (format "p99=%.3g p95=%.3g"
+                                                    (double p99) (double p95))})
+                     p999-p99 (conj {:label "p999/p99" :value p999-p99
+                                     :detail (format "p999=%.3g p99=%.3g"
+                                                     (double p999) (double p99))})
+                     p999-p95 (conj {:label "p999/p95" :value p999-p95
+                                     :detail (format "p999=%.3g p95=%.3g"
+                                                     (double p999) (double p95))}))]
+        (when (seq ratios)
+          (let [max-val (double (apply max (map :value ratios)))
+                bar-width (- (long width) (count indent) 25) ; label + value + spacing
+                header (header-fn)
+                lines (for [{:keys [label value detail]} ratios]
+                        (let [bar-len (long (* (/ (double value) max-val)
+                                               (double bar-width)))
+                              bar (apply str (repeat bar-len \#))]
+                          (format "%s%9s |%s %.3f  %s"
+                                  indent label bar value detail)))]
+            (str header "\n" (str/join "\n" lines))))))))
+
+;;; Hill Plot
+
+(defn render-ascii-hill-plot
+  "Render ASCII Hill plot showing tail index estimates vs k.
+
+  Parameters:
+    tail-data   - tail analysis data for a metric
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no Hill data."
+  [tail-data opts]
+  (let [{:keys [hill]} tail-data
+        {:keys [k-range estimates stable-estimate]} hill
+        {:keys [width height header-fn indent]
+         :or {width 60
+              height 15
+              header-fn (fn [] "Hill Plot (H_k vs k)")
+              indent ""}} opts]
+    (when (and (seq k-range) (seq estimates))
+      (let [points (mapv vector k-range estimates)
+            header (header-fn)
+            chart-lines (ascii-chart/render-chart
+                         points
+                         {:width (- (long width) (count indent))
+                          :height height
+                          :x-label "k"
+                          :y-label "H_k"
+                          :point-char \*
+                          :line-char \.})]
+        (when (seq chart-lines)
+          (let [stable-line (when stable-estimate
+                              (format "%sStable estimate: %.4f" indent stable-estimate))]
+            (str header "\n"
+                 (->> chart-lines
+                      (map #(str indent %))
+                      (str/join "\n"))
+                 (when stable-line (str "\n" stable-line)))))))))
+
+;;; MRL Plot
+
+(defn render-ascii-mrl-plot
+  "Render ASCII mean residual life plot.
+
+  Shows e(u) = E[X - u | X > u] vs threshold u. For GPD data, MRL is linear.
+
+  Parameters:
+    tail-data   - tail analysis data for a metric
+    transforms  - transforms to apply to values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no MRL data."
+  [tail-data transforms opts]
+  (let [{:keys [mrl threshold]} tail-data
+        {:keys [thresholds values]} mrl
+        {:keys [width height header-fn indent]
+         :or {width 60
+              height 15
+              header-fn (fn [] "Mean Residual Life Plot")
+              indent ""}} opts]
+    (when (and (seq thresholds) (seq values))
+      (let [points (mapv (fn [u mrl-val]
+                           [(util/transform-sample-> u transforms)
+                            (util/transform-sample-> mrl-val transforms)])
+                         thresholds values)
+            threshold-transformed (util/transform-sample-> threshold transforms)
+            header (header-fn)
+            chart-lines (ascii-chart/render-chart
+                         points
+                         {:width (- (long width) (count indent))
+                          :height height
+                          :x-label "threshold"
+                          :y-label "MRL"
+                          :point-char \*
+                          :line-char \.})]
+        (when (seq chart-lines)
+          (str header "\n"
+               (->> chart-lines
+                    (map #(str indent %))
+                    (str/join "\n"))
+               (format "\n%sSelected threshold: %.4g" indent threshold-transformed)))))))
+
+;;; Zipf Plot
+
+(defn render-ascii-zipf-plot
+  "Render ASCII Zipf plot (complementary CDF on log-log scale).
+
+  For Pareto-like tails, this appears as a straight line with slope -α.
+
+  Parameters:
+    samples     - sample array for the metric
+    transforms  - transforms to apply to sample values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [n] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if no samples."
+  [samples transforms opts]
+  (when (and samples (pos? (arr/length samples)))
+    (let [{:keys [width height header-fn indent]
+           :or {width 60
+                height 15
+                header-fn (fn [n] (format "Zipf Plot (log-log CCDF, n=%d)" n))
+                indent ""}} opts
+          sorted-arr (arr/sorted samples)
+          n (arr/length sorted-arr)
+          ;; Compute log10(x) vs log10(1-F(x)) points
+          points (arr/indexed-dfold
+                  sorted-arr
+                  (fn [acc ^long i ^double x]
+                    (let [ccdf (/ (double (- n i)) (double n))
+                          tx (util/transform-sample-> x transforms)]
+                      (if (and (pos? tx) (pos? ccdf))
+                        (conj acc [(Math/log10 tx) (Math/log10 ccdf)])
+                        acc)))
+                  [])
+          header (header-fn n)]
+      (when (seq points)
+        (let [chart-lines (ascii-chart/render-chart
+                           points
+                           {:width (- (long width) (count indent))
+                            :height height
+                            :x-label "log₁₀(x)"
+                            :y-label "log₁₀(CCDF)"
+                            :point-char \*
+                            :line-char nil})] ; Scatter, no lines
+          (when (seq chart-lines)
+            (str header "\n"
+                 (->> chart-lines
+                      (map #(str indent %))
+                      (str/join "\n")))))))))
+
+;;; Exponential Q-Q Plot
+
+(defn- exponential-quantile
+  "Quantile function for standard exponential distribution.
+  Q(p) = -ln(1-p)"
+  ^double [^double p]
+  (cond
+    (<= p 0.0) 0.0
+    (>= p 1.0) Double/POSITIVE_INFINITY
+    :else (- (Math/log (- 1.0 p)))))
+
+(defn render-ascii-exponential-qq
+  "Render ASCII exponential Q-Q plot for tail exceedances.
+
+  Compares exceedances (values above threshold) to exponential distribution.
+  Points near diagonal indicate exponential tail (GPD with ξ=0).
+
+  Parameters:
+    samples     - sample array for the metric
+    threshold   - threshold value for exceedances
+    transforms  - transforms to apply to values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [n-exceed] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if insufficient exceedances."
+  [samples ^double threshold transforms opts]
+  (when (and samples (pos? (arr/length samples)))
+    (let [{:keys [width height header-fn indent]
+           :or {width 60
+                height 15
+                header-fn (fn [n] (format "Exponential Q-Q Plot (n=%d exceedances)" n))
+                indent ""}} opts
+          exceedances (stats/exceedances-over-threshold samples threshold)
+          n-exceed (arr/length exceedances)]
+      (when (> n-exceed 2)
+        (let [;; Compute mean for scaling
+              mean-exceed (/ (arr/fold-double exceedances
+                                              (fn ^double [^double acc ^double y]
+                                                (+ acc y))
+                                              0.0)
+                             n-exceed)
+              sorted-exceed (arr/sorted exceedances)
+              ;; Generate Q-Q points
+              points (arr/indexed-dfold
+                      sorted-exceed
+                      (fn [acc ^long i ^double y]
+                        (let [p (/ (- (double (inc i)) 0.5) (double n-exceed))
+                              theoretical (* mean-exceed (exponential-quantile p))
+                              t-theo (util/transform-sample-> theoretical transforms)
+                              t-obs (util/transform-sample-> y transforms)]
+                          (if (and (Double/isFinite t-theo) (Double/isFinite t-obs))
+                            (conj acc [t-theo t-obs])
+                            acc)))
+                      [])
+              header (header-fn n-exceed)]
+          (when (seq points)
+            (let [chart-lines (ascii-chart/render-chart
+                               points
+                               {:width (- (long width) (count indent))
+                                :height height
+                                :x-label "theoretical"
+                                :y-label "observed"
+                                :point-char \*
+                                :line-char nil})] ; Scatter, no lines
+              (when (seq chart-lines)
+                (str header "\n"
+                     (->> chart-lines
+                          (map #(str indent %))
+                          (str/join "\n")))))))))))
+
+;;; GPD Q-Q Plot
+
+(defn render-ascii-gpd-qq
+  "Render ASCII GPD Q-Q plot for tail exceedances.
+
+  Compares exceedances to fitted Generalized Pareto Distribution.
+  Points near diagonal indicate good GPD fit.
+
+  Parameters:
+    samples     - sample array for the metric
+    threshold   - threshold value for exceedances
+    gpd-fit     - GPD fit map {:xi :sigma}
+    transforms  - transforms to apply to values
+    opts        - options map:
+      :width      - chart width in characters (default 60)
+      :height     - chart height in lines (default 15)
+      :header-fn  - fn [n-exceed] -> header string
+      :indent     - string prefix for each line
+
+  Returns string of ASCII chart, or nil if insufficient data."
+  [samples threshold gpd-fit transforms opts]
+  (when (and samples (pos? (arr/length samples)) gpd-fit)
+    (let [{:keys [xi sigma]} gpd-fit
+          threshold (double threshold)]
+      (when (and xi sigma (pos? (double sigma)))
+        (let [{:keys [width height header-fn indent]
+               :or {width 60
+                    height 15
+                    header-fn (fn [n] (format "GPD Q-Q Plot (n=%d exceedances)" n))
+                    indent ""}} opts
+              exceedances (stats/exceedances-over-threshold samples threshold)
+              n-exceed (arr/length exceedances)]
+          (when (> n-exceed 2)
+            (let [gpd-quantile-fn (stats/gpd-quantile (double xi) (double sigma))
+                  sorted-exceed (arr/sorted exceedances)
+                  ;; Generate Q-Q points
+                  points (arr/indexed-dfold
+                          sorted-exceed
+                          (fn [acc ^long i ^double y]
+                            (let [p (/ (- (double (inc i)) 0.5) (double n-exceed))
+                                  theoretical (gpd-quantile-fn p)
+                                  t-theo (util/transform-sample-> theoretical transforms)
+                                  t-obs (util/transform-sample-> y transforms)]
+                              (if (and (Double/isFinite t-theo) (Double/isFinite t-obs))
+                                (conj acc [t-theo t-obs])
+                                acc)))
+                          [])
+                  header (header-fn n-exceed)]
+              (when (seq points)
+                (let [chart-lines (ascii-chart/render-chart
+                                   points
+                                   {:width (- (long width) (count indent))
+                                    :height height
+                                    :x-label "GPD theoretical"
+                                    :y-label "observed"
+                                    :point-char \*
+                                    :line-char nil})] ; Scatter, no lines
+                  (when (seq chart-lines)
+                    (str header "\n"
+                         (->> chart-lines
+                              (map #(str indent %))
+                              (str/join "\n")))))))))))))
+
+;;; Data Extraction Helper
+
+(defn- simple-transforms
+  "Get transforms from tail-analysis-map, wrapping in sequences for transform-sample->.
+
+  Handles both simple {:sample-> fn :->sample fn} and
+  list/vector formats {:sample-> (fn...) :->sample [fn...]}."
+  [tail-analysis-map]
+  (let [t (:transform tail-analysis-map)]
+    (when t
+      (let [s-> (:sample-> t)
+            ->s (:->sample t)]
+        {:sample-> (cond (fn? s->) [s->]
+                         (sequential? s->) (vec s->)
+                         :else [identity])
+         :->sample (cond (fn? ->s) [->s]
+                         (sequential? ->s) (vec ->s)
+                         :else [identity])}))))
+
+(defn with-tail-metrics
+  "Iterate over metrics with tail analysis data, calling f for each.
+
+  Parameters:
+    view     - view options with :tail-analysis-id, :samples-id
+    data-map - analysis data map
+    f        - fn [tail-data samples transforms metric-config] -> any
+
+  Samples may be nil if :samples-id data is not available."
+  [view data-map f]
+  (let [tail-analysis-id (or (:tail-analysis-id view) :tail-analysis)
+        samples-id (or (:samples-id view) :samples)
+        tail-analysis-map (get data-map tail-analysis-id)
+        samples-map (get data-map samples-id)]
+    (when tail-analysis-map
+      (let [tail-results (:tail-analysis tail-analysis-map)
+            metrics-defs (:metrics-defs tail-analysis-map)
+            metric-configs (when metrics-defs
+                             (metric/all-metric-configs
+                              (metric/filter-metrics
+                               metrics-defs
+                               (metric/type-pred :quantitative))))
+            metric->values (when samples-map (util/metric->values samples-map))
+            transforms (simple-transforms tail-analysis-map)]
+        (doseq [mc metric-configs]
+          (let [path (:path mc)
+                tail-data (get tail-results path)
+                samples (when metric->values (get metric->values path))]
+            (when tail-data
+              (f tail-data samples transforms mc))))))))

--- a/bases/criterium/src/criterium/viewer/common_charts/tail_ascii.clj
+++ b/bases/criterium/src/criterium/viewer/common_charts/tail_ascii.clj
@@ -31,7 +31,7 @@
     tail-data   - tail analysis data for a metric
     opts        - options map:
       :width      - chart width in characters (default 60)
-      :header-fn  - fn [] -> header string
+      :header-fn  - fn [n] -> header string, where n is number of ratios
       :indent     - string prefix for each line
 
   Returns string of ASCII chart, or nil if no ratios."
@@ -39,7 +39,7 @@
   (let [{:keys [tail-ratios empirical-quantiles]} tail-data
         {:keys [width header-fn indent]
          :or {width 60
-              header-fn (fn [] "Tail Ratios")
+              header-fn (fn [n] (format "Tail Ratios (n=%d)" n))
               indent ""}} opts
         {:keys [p99-p95 p999-p99 p999-p95]} tail-ratios
         {:keys [p95 p99 p999]} empirical-quantiles]
@@ -55,9 +55,10 @@
                                      :detail (format "p999=%.3g p95=%.3g"
                                                      (double p999) (double p95))}))]
         (when (seq ratios)
-          (let [max-val (double (apply max (map :value ratios)))
+          (let [n (count ratios)
+                max-val (double (apply max (map :value ratios)))
                 bar-width (- (long width) (count indent) 25) ; label + value + spacing
-                header (header-fn)
+                header (header-fn n)
                 lines (for [{:keys [label value detail]} ratios]
                         (let [bar-len (long (* (/ (double value) max-val)
                                                (double bar-width)))
@@ -76,7 +77,7 @@
     opts        - options map:
       :width      - chart width in characters (default 60)
       :height     - chart height in lines (default 15)
-      :header-fn  - fn [] -> header string
+      :header-fn  - fn [n] -> header string, where n is number of k values
       :indent     - string prefix for each line
 
   Returns string of ASCII chart, or nil if no Hill data."
@@ -86,11 +87,12 @@
         {:keys [width height header-fn indent]
          :or {width 60
               height 15
-              header-fn (fn [] "Hill Plot (H_k vs k)")
+              header-fn (fn [n] (format "Hill Plot (H_k vs k, n=%d)" n))
               indent ""}} opts]
     (when (and (seq k-range) (seq estimates))
-      (let [points (mapv vector k-range estimates)
-            header (header-fn)
+      (let [n (count estimates)
+            points (mapv vector k-range estimates)
+            header (header-fn n)
             chart-lines (ascii-chart/render-chart
                          points
                          {:width (- (long width) (count indent))
@@ -121,7 +123,7 @@
     opts        - options map:
       :width      - chart width in characters (default 60)
       :height     - chart height in lines (default 15)
-      :header-fn  - fn [] -> header string
+      :header-fn  - fn [n] -> header string, where n is number of threshold points
       :indent     - string prefix for each line
 
   Returns string of ASCII chart, or nil if no MRL data."
@@ -131,15 +133,16 @@
         {:keys [width height header-fn indent]
          :or {width 60
               height 15
-              header-fn (fn [] "Mean Residual Life Plot")
+              header-fn (fn [n] (format "Mean Residual Life Plot (n=%d)" n))
               indent ""}} opts]
     (when (and (seq thresholds) (seq values))
-      (let [points (mapv (fn [u mrl-val]
+      (let [n (count thresholds)
+            points (mapv (fn [u mrl-val]
                            [(util/transform-sample-> u transforms)
                             (util/transform-sample-> mrl-val transforms)])
                          thresholds values)
             threshold-transformed (util/transform-sample-> threshold transforms)
-            header (header-fn)
+            header (header-fn n)
             chart-lines (ascii-chart/render-chart
                          points
                          {:width (- (long width) (count indent))

--- a/bases/criterium/src/criterium/viewer/kindly/core.clj
+++ b/bases/criterium/src/criterium/viewer/kindly/core.clj
@@ -18,7 +18,11 @@
   appropriate `:kindly/kind` metadata."
   (:refer-clojure :exclude [flush])
   (:require
+   [clojure.string :as str]
+   [criterium.array :as arr]
+   [criterium.jvm :as jvm]
    [criterium.metric :as metric]
+   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
@@ -26,6 +30,8 @@
    [criterium.viewer.common-charts.samples :as charts.samples]
    [criterium.viewer.common.bootstrap :as bootstrap]
    [criterium.viewer.common.core :as core]))
+
+(set! *unchecked-math* false)
 
 ;;; Accumulator
 
@@ -331,8 +337,61 @@
                            :mean :mean-ci-lower :mean-ci-upper
                            :p10 :p90]}))))))
 
-;;; Noop Implementations
+;;; Final GC Warnings
 
-(defmethod view/final-gc-warnings* :kindly [_ _ _])
-(defmethod view/os* :kindly [_ _ _])
-(defmethod view/runtime* :kindly [_ _ _])
+(defmethod view/final-gc-warnings* :kindly
+  [_ {:keys [final-gc-id samples-id warn-threshold]} data-map]
+  {:pre [(number? warn-threshold)]}
+  (let [final-gc-id (or final-gc-id :final-gc)
+        samples-id (or samples-id :samples)
+        metrics-samples (data-map samples-id)
+        metrics-deps (:metrics-deps metrics-samples)
+        gc-metric-configs (metric/all-metric-configs
+                           (select-keys
+                            metrics-deps
+                            [:elapsed-time :garbage-collector]))
+        metric (first gc-metric-configs)
+        gc-time-metrics (->> (next gc-metric-configs)
+                             (filterv #(= :time (:dimension %))))
+        metric->values (util/metric->values metrics-samples)
+        total (* (:scale metric)
+                 (arr/sum (metric->values [:elapsed-time])))
+        gc-samples (-> data-map final-gc-id util/metric->values)
+        total-gc (reduce
+                  +
+                  (mapv
+                   (fn [m]
+                     (* (:scale m) (arr/sum (gc-samples (:path m)))))
+                   gc-time-metrics))
+        frac (/ total-gc total)]
+    (when (and total-gc (> frac warn-threshold))
+      (kindly-heading "Final GC Warning")
+      (kindly-table
+       [{:warning (format "Final GC ran for %s, %.1f%% of total sampling time (%s)"
+                          (format/format-value :time total-gc)
+                          (* frac 100)
+                          (format/format-value :time total))}]))))
+
+;;; OS Info
+
+(defmethod view/os* :kindly
+  [_ _ _sampled]
+  (let [os (jvm/os-details)]
+    (kindly-heading "Operating System")
+    (kindly-table
+     [{:property "Name" :value (:name os)}
+      {:property "Version" :value (:version os)}
+      {:property "Architecture" :value (:arch os)}
+      {:property "Processors" :value (:available-processors os)}])))
+
+;;; Runtime Info
+
+(defmethod view/runtime* :kindly
+  [_ _ _sampled]
+  (let [runtime (jvm/runtime-details)]
+    (kindly-heading "Runtime")
+    (kindly-table
+     [{:property "VM Name" :value (:vm-name runtime)}
+      {:property "VM Version" :value (:vm-version runtime)}
+      {:property "VM Vendor" :value (:vm-vendor runtime)}
+      {:property "Arguments" :value (str/join " " (:input-arguments runtime))}])))

--- a/bases/criterium/src/criterium/viewer/portal/core.clj
+++ b/bases/criterium/src/criterium/viewer/portal/core.clj
@@ -11,7 +11,11 @@
   - histograms, KDE, quantiles"
   (:refer-clojure :exclude [flush])
   (:require
+   [clojure.string :as str]
+   [criterium.array :as arr]
+   [criterium.jvm :as jvm]
    [criterium.metric :as metric]
+   [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
@@ -19,6 +23,8 @@
    [criterium.viewer.common-charts.samples :as charts.samples]
    [criterium.viewer.common.bootstrap :as bootstrap]
    [criterium.viewer.common.core :as core]))
+
+(set! *unchecked-math* false)
 
 ;;; Tap Infrastructure
 
@@ -286,10 +292,61 @@
               :when stat]
           (bootstrap/bootstrap-stat-row m stat transforms)))))))
 
-;;; No-op Views
+;;; Final GC Warnings
 
-(defmethod view/final-gc-warnings* :portal [_ _ _])
+(defmethod view/final-gc-warnings* :portal
+  [_ {:keys [final-gc-id samples-id warn-threshold]} data-map]
+  {:pre [(number? warn-threshold)]}
+  (let [final-gc-id (or final-gc-id :final-gc)
+        samples-id (or samples-id :samples)
+        metrics-samples (data-map samples-id)
+        metrics-deps (:metrics-deps metrics-samples)
+        gc-metric-configs (metric/all-metric-configs
+                           (select-keys
+                            metrics-deps
+                            [:elapsed-time :garbage-collector]))
+        metric (first gc-metric-configs)
+        gc-time-metrics (->> (next gc-metric-configs)
+                             (filterv #(= :time (:dimension %))))
+        metric->values (util/metric->values metrics-samples)
+        total (* (:scale metric)
+                 (arr/sum (metric->values [:elapsed-time])))
+        gc-samples (-> data-map final-gc-id util/metric->values)
+        total-gc (reduce
+                  +
+                  (mapv
+                   (fn [m]
+                     (* (:scale m) (arr/sum (gc-samples (:path m)))))
+                   gc-time-metrics))
+        frac (/ total-gc total)]
+    (when (and total-gc (> frac warn-threshold))
+      (heading "Final GC Warning")
+      (portal-table
+       [{:warning (format "Final GC ran for %s, %.1f%% of total sampling time (%s)"
+                          (format/format-value :time total-gc)
+                          (* frac 100)
+                          (format/format-value :time total))}]))))
 
-(defmethod view/os* :portal [_ _ _])
+;;; OS Info
 
-(defmethod view/runtime* :portal [_ _ _])
+(defmethod view/os* :portal
+  [_ _ _sampled]
+  (let [os (jvm/os-details)]
+    (heading "Operating System")
+    (portal-table
+     [{:property "Name" :value (:name os)}
+      {:property "Version" :value (:version os)}
+      {:property "Architecture" :value (:arch os)}
+      {:property "Processors" :value (:available-processors os)}])))
+
+;;; Runtime Info
+
+(defmethod view/runtime* :portal
+  [_ _ _sampled]
+  (let [runtime (jvm/runtime-details)]
+    (heading "Runtime")
+    (portal-table
+     [{:property "VM Name" :value (:vm-name runtime)}
+      {:property "VM Version" :value (:vm-version runtime)}
+      {:property "VM Vendor" :value (:vm-vendor runtime)}
+      {:property "Arguments" :value (str/join " " (:input-arguments runtime))}])))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -717,17 +717,42 @@
   [viewer view-opts data-map]
   ((get-method view/most-called* :print) viewer view-opts data-map))
 
-;;; Chart no-ops (charts cannot render in pprint text output)
+;;; Chart delegations to :print (ASCII chart rendering)
 
 ;; Distribution charts
-(defmethod view/distribution-pdf* :pprint [_ _ _])
-(defmethod view/distribution-cdf* :pprint [_ _ _])
-(defmethod view/distribution-qq* :pprint [_ _ _])
+(defmethod view/distribution-pdf* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/distribution-pdf* :print) viewer view-opts data-map))
+
+(defmethod view/distribution-cdf* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/distribution-cdf* :print) viewer view-opts data-map))
+
+(defmethod view/distribution-qq* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/distribution-qq* :print) viewer view-opts data-map))
 
 ;; Tail analysis charts
-(defmethod view/tail-ratios-chart* :pprint [_ _ _])
-(defmethod view/hill-plot* :pprint [_ _ _])
-(defmethod view/mrl-plot* :pprint [_ _ _])
-(defmethod view/zipf-plot* :pprint [_ _ _])
-(defmethod view/exponential-qq-plot* :pprint [_ _ _])
-(defmethod view/gpd-qq-plot* :pprint [_ _ _])
+(defmethod view/tail-ratios-chart* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/tail-ratios-chart* :print) viewer view-opts data-map))
+
+(defmethod view/hill-plot* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/hill-plot* :print) viewer view-opts data-map))
+
+(defmethod view/mrl-plot* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/mrl-plot* :print) viewer view-opts data-map))
+
+(defmethod view/zipf-plot* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/zipf-plot* :print) viewer view-opts data-map))
+
+(defmethod view/exponential-qq-plot* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/exponential-qq-plot* :print) viewer view-opts data-map))
+
+(defmethod view/gpd-qq-plot* :pprint
+  [viewer view-opts data-map]
+  ((get-method view/gpd-qq-plot* :print) viewer view-opts data-map))

--- a/bases/criterium/src/criterium/viewer/pprint.clj
+++ b/bases/criterium/src/criterium/viewer/pprint.clj
@@ -7,6 +7,7 @@
    [criterium.util.helpers :as util]
    [criterium.util.invariant :refer [have]]
    [criterium.view :as view]
+   [criterium.viewer.common-charts.autocorrelation :as acf-charts]
    [criterium.viewer.common.allocation :as allocation]
    [criterium.viewer.common.autocorrelation :as acf-common]
    [criterium.viewer.common.bootstrap :as bootstrap]
@@ -563,8 +564,13 @@
        [:metric :value]
        (autocorrelation-summary-table acf-data (:label mc))))))
 
-;; ACF plot is a no-op for pprint viewer (charts not supported)
-(defmethod view/acf-plot* :pprint [_ _ _])
+;; ACF plot uses common ASCII chart rendering
+(defmethod view/acf-plot* :pprint
+  [_ view data-map]
+  (acf-common/with-autocorrelation-metrics view data-map
+    (fn [acf-data mc]
+      (when-let [output (acf-charts/render-ascii-acf-plot acf-data (:label mc) view)]
+        (println output)))))
 
 (defn- classification-table-rows
   "Build classification table rows for pprint."

--- a/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
+++ b/bases/criterium/src/criterium/viewer/print/autocorrelation.clj
@@ -8,7 +8,6 @@
    [criterium.view :as view]
    [criterium.viewer.common-charts.autocorrelation :as acf-charts]
    [criterium.viewer.common.autocorrelation :as acf-common]
-   [criterium.viewer.common.core :as core]
    [criterium.viewer.print.core :as print-core]))
 
 (set! *unchecked-math* false)
@@ -80,86 +79,20 @@
 
 ;;; ACF Plot
 
-(defn- format-threshold-legend
-  "Format threshold legend showing only crossed thresholds.
-  Returns string like 'lag-1 [minor 0.10, moderate 0.20], other [minor 0.15]'."
-  [acf-map thresholds]
-  (let [lag-1-acf (Math/abs (double (get acf-map 1 0)))
-        other-max-acf (if (> (count acf-map) 1)
-                        (apply max 0 (map #(Math/abs (double %))
-                                          (vals (dissoc acf-map 1))))
-                        0)
-        lag-1-thresholds (:lag-1 thresholds)
-        other-thresholds (:other thresholds)
-        ;; Find crossed thresholds for lag-1
-        lag-1-crossed (for [[level ^double threshold] (sort-by val lag-1-thresholds)
-                            :when (> lag-1-acf threshold)]
-                        (format "%s %.2f" (name level) threshold))
-        ;; Find crossed thresholds for other lags
-        other-crossed (for [[level ^double threshold] (sort-by val other-thresholds)
-                            :when (> other-max-acf threshold)]
-                        (format "%s %.2f" (name level) threshold))]
-    (cond-> []
-      (seq lag-1-crossed)
-      (conj (str "lag-1 [" (str/join ", " lag-1-crossed) "]"))
-      (seq other-crossed)
-      (conj (str "other [" (str/join ", " other-crossed) "]")))))
-
 (defn print-acf-plot
   "Print ASCII ACF plot for a single metric.
 
-  Shows autocorrelation coefficients as bidirectional ASCII bar charts.
-  Only renders if at least one lag meets the min-severity threshold.
-
-  Options:
-    :min-severity - minimum severity to display (default :moderate)
-    :bar-width    - half-width of bar in characters (default 15)"
-  [{:keys [acf effective-sample-size lag-severities thresholds]} metric-label opts]
-  (let [{:keys [min-severity bar-width]
-         :or {min-severity :moderate bar-width 15}} opts
-        n (get effective-sample-size :n-original)
-        ;; Default thresholds if not provided
-        thresholds (or thresholds
-                       {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
-                        :other {:minor 0.15 :moderate 0.25 :severe 0.40}})]
-    (when (and acf n lag-severities
-               (acf-charts/has-severity-at-or-above? lag-severities min-severity))
-      ;; Filter lags by severity
-      (let [min-rank (get acf-charts/severity-rank min-severity 0)
-            qualifying-lags (for [[lag sev] lag-severities
-                                  :when (>= (long (get acf-charts/severity-rank sev 0))
-                                            (long min-rank))]
-                              lag)
-            ;; Calculate max |acf| for scaling
-            max-abs-acf (apply max 0.01 (map #(Math/abs (double (get acf % 0)))
-                                             qualifying-lags))
-            ;; Sort lags numerically
-            sorted-lags (sort qualifying-lags)
-            ;; Calculate column widths
-            max-lag-width (max 3 (count (str (apply max 1 sorted-lags))))
-            ;; Use sublabel-indent-str for lines following format-sublabel header
-            indent (print-core/sublabel-indent-str)
-            ;; Build format strings with dynamic width
-            header-fmt (str "%s%" max-lag-width "s   %s")
-            row-fmt (str "%s%" max-lag-width "d  %6.2f  %s (%s)")]
-        (println (format "%s ACF Plot (n=%d):" (print-core/format-sublabel metric-label) n))
-        (println (format header-fmt indent "Lag" "ACF"))
-        ;; Print each lag
-        (doseq [lag sorted-lags]
-          (let [acf-val (double (get acf lag))
-                severity (get lag-severities lag :none)
-                bar (core/ascii-bar-bidirectional acf-val max-abs-acf bar-width)]
-            (println (format row-fmt
-                             indent
-                             lag
-                             acf-val
-                             bar
-                             (acf-common/format-severity severity)))))
-        ;; Print threshold legend
-        (let [legend-parts (format-threshold-legend acf thresholds)]
-          (when (seq legend-parts)
-            (println)
-            (println (format "%sThresholds: %s" indent (str/join ", " legend-parts)))))))))
+  Uses the common render-ascii-acf-plot function with print-viewer formatting."
+  [acf-data metric-label opts]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [label n]
+                    (format "%s ACF Plot (n=%d):"
+                            (print-core/format-sublabel label) n))
+        render-opts (assoc opts
+                           :header-fn header-fn
+                           :indent indent)]
+    (when-let [output (acf-charts/render-ascii-acf-plot acf-data metric-label render-opts)]
+      (println output))))
 
 (defn print-acf-plots
   "Print ACF plots for all metrics."

--- a/bases/criterium/src/criterium/viewer/print/distribution.clj
+++ b/bases/criterium/src/criterium/viewer/print/distribution.clj
@@ -4,10 +4,11 @@
   Contains views for:
   - Distribution model comparison (AIC, BIC, goodness-of-fit tests)
   - Parameter confidence intervals for best-fit models
-  - No-op chart views (PDF, CDF, Q-Q plots not supported in print)"
+  - ASCII chart views (PDF, CDF, Q-Q plots)"
   (:require
    [criterium.metric :as metric]
    [criterium.view :as view]
+   [criterium.viewer.common-charts.distribution-ascii :as dist-ascii]
    [criterium.viewer.common.distribution :as common.distribution]
    [criterium.viewer.print.core :as print-core :refer [for-each-metric-keyed]]))
 
@@ -141,7 +142,77 @@
   [_ view data-map]
   (print-distribution-parameter-cis view data-map))
 
-;; Chart views are no-ops for print viewer
-(defmethod view/distribution-pdf* :print [_ _ _])
-(defmethod view/distribution-cdf* :print [_ _ _])
-(defmethod view/distribution-qq* :print [_ _ _])
+;;; PDF Chart View
+
+(defn print-distribution-pdf
+  "Print ASCII PDF chart for all metrics with distribution fits."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [label n]
+                    (format "%s PDF: %s (n=%d)"
+                            (print-core/format-sublabel "Distribution")
+                            label n))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (dist-ascii/with-distribution-metrics view data-map
+      (fn [fit-data _samples transforms _mc]
+        (when-let [output (dist-ascii/render-ascii-pdf fit-data transforms opts)]
+          (println output)
+          (println))))))
+
+(defmethod view/distribution-pdf* :print
+  [_ view data-map]
+  (print-distribution-pdf view data-map))
+
+;;; CDF Chart View
+
+(defn print-distribution-cdf
+  "Print ASCII CDF chart for all metrics with samples."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [n]
+                    (format "%s CDF (n=%d)"
+                            (print-core/format-sublabel "Distribution")
+                            n))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (dist-ascii/with-distribution-metrics view data-map
+      (fn [_fit-data samples transforms _mc]
+        (when-let [output (dist-ascii/render-ascii-cdf samples transforms opts)]
+          (println output)
+          (println))))))
+
+(defmethod view/distribution-cdf* :print
+  [_ view data-map]
+  (print-distribution-cdf view data-map))
+
+;;; Q-Q Plot View
+
+(defn print-distribution-qq
+  "Print ASCII Q-Q plot for all metrics with distribution fits."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [label n]
+                    (format "%s Q-Q Plot: %s (n=%d)"
+                            (print-core/format-sublabel "Distribution")
+                            label n))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (dist-ascii/with-distribution-metrics view data-map
+      (fn [fit-data samples transforms _mc]
+        (when-let [output (dist-ascii/render-ascii-qq samples fit-data transforms opts)]
+          (println output)
+          (println))))))
+
+(defmethod view/distribution-qq* :print
+  [_ view data-map]
+  (print-distribution-qq view data-map))

--- a/bases/criterium/src/criterium/viewer/print/tail.clj
+++ b/bases/criterium/src/criterium/viewer/print/tail.clj
@@ -5,13 +5,13 @@
   - Tail summary (GPD/Hill parameters)
   - Tail ratios (p99/p95, p999/p99, p999/p95)
   - High quantile estimates (GPD extrapolation)
-  - No-op chart views (tail ratio charts, Hill/MRL/Zipf plots,
-    Q-Q plots not supported in print)"
+  - ASCII chart views (tail ratio charts, Hill/MRL/Zipf plots, Q-Q plots)"
   (:require
    [criterium.metric :as metric]
    [criterium.util.format :as format]
    [criterium.util.helpers :as util]
    [criterium.view :as view]
+   [criterium.viewer.common-charts.tail-ascii :as tail-ascii]
    [criterium.viewer.common.core :as core]
    [criterium.viewer.print.core
     :as print-core
@@ -125,10 +125,151 @@
   [_ view data-map]
   (print-tail-high-quantiles view data-map))
 
-;;; Chart views are no-ops for print viewer
-(defmethod view/tail-ratios-chart* :print [_ _ _])
-(defmethod view/hill-plot* :print [_ _ _])
-(defmethod view/mrl-plot* :print [_ _ _])
-(defmethod view/zipf-plot* :print [_ _ _])
-(defmethod view/exponential-qq-plot* :print [_ _ _])
-(defmethod view/gpd-qq-plot* :print [_ _ _])
+;;; Tail Ratios Chart View
+
+(defn print-tail-ratios-chart
+  "Print ASCII tail ratios bar chart for all metrics."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn []
+                    (format "%s Tail Ratios"
+                            (print-core/format-sublabel "Chart")))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70)]
+    (tail-ascii/with-tail-metrics view data-map
+      (fn [tail-data _samples _transforms _mc]
+        (when-let [output (tail-ascii/render-ascii-tail-ratios tail-data opts)]
+          (println output)
+          (println))))))
+
+(defmethod view/tail-ratios-chart* :print
+  [_ view data-map]
+  (print-tail-ratios-chart view data-map))
+
+;;; Hill Plot View
+
+(defn print-hill-plot
+  "Print ASCII Hill plot for all metrics."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn []
+                    (format "%s Hill Plot (H_k vs k)"
+                            (print-core/format-sublabel "Chart")))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (tail-ascii/with-tail-metrics view data-map
+      (fn [tail-data _samples _transforms _mc]
+        (when-let [output (tail-ascii/render-ascii-hill-plot tail-data opts)]
+          (println output)
+          (println))))))
+
+(defmethod view/hill-plot* :print
+  [_ view data-map]
+  (print-hill-plot view data-map))
+
+;;; MRL Plot View
+
+(defn print-mrl-plot
+  "Print ASCII mean residual life plot for all metrics."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn []
+                    (format "%s Mean Residual Life Plot"
+                            (print-core/format-sublabel "Chart")))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (tail-ascii/with-tail-metrics view data-map
+      (fn [tail-data _samples transforms _mc]
+        (when-let [output (tail-ascii/render-ascii-mrl-plot tail-data transforms opts)]
+          (println output)
+          (println))))))
+
+(defmethod view/mrl-plot* :print
+  [_ view data-map]
+  (print-mrl-plot view data-map))
+
+;;; Zipf Plot View
+
+(defn print-zipf-plot
+  "Print ASCII Zipf plot (log-log CCDF) for all metrics."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [n]
+                    (format "%s Zipf Plot (log-log CCDF, n=%d)"
+                            (print-core/format-sublabel "Chart") n))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (tail-ascii/with-tail-metrics view data-map
+      (fn [_tail-data samples transforms _mc]
+        (when samples
+          (when-let [output (tail-ascii/render-ascii-zipf-plot samples transforms opts)]
+            (println output)
+            (println)))))))
+
+(defmethod view/zipf-plot* :print
+  [_ view data-map]
+  (print-zipf-plot view data-map))
+
+;;; Exponential Q-Q Plot View
+
+(defn print-exponential-qq-plot
+  "Print ASCII exponential Q-Q plot for all metrics."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [n]
+                    (format "%s Exponential Q-Q Plot (n=%d exceedances)"
+                            (print-core/format-sublabel "Chart") n))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (tail-ascii/with-tail-metrics view data-map
+      (fn [tail-data samples transforms _mc]
+        (when (and samples (:threshold tail-data))
+          (when-let [output (tail-ascii/render-ascii-exponential-qq
+                             samples (:threshold tail-data) transforms opts)]
+            (println output)
+            (println)))))))
+
+(defmethod view/exponential-qq-plot* :print
+  [_ view data-map]
+  (print-exponential-qq-plot view data-map))
+
+;;; GPD Q-Q Plot View
+
+(defn print-gpd-qq-plot
+  "Print ASCII GPD Q-Q plot for all metrics."
+  [view data-map]
+  (let [indent (print-core/sublabel-indent-str)
+        header-fn (fn [n]
+                    (format "%s GPD Q-Q Plot (n=%d exceedances)"
+                            (print-core/format-sublabel "Chart") n))
+        opts (assoc view
+                    :header-fn header-fn
+                    :indent indent
+                    :width 70
+                    :height 12)]
+    (tail-ascii/with-tail-metrics view data-map
+      (fn [tail-data samples transforms _mc]
+        (when (and samples (:threshold tail-data) (:gpd tail-data))
+          (when-let [output (tail-ascii/render-ascii-gpd-qq
+                             samples (:threshold tail-data) (:gpd tail-data)
+                             transforms opts)]
+            (println output)
+            (println)))))))
+
+(defmethod view/gpd-qq-plot* :print
+  [_ view data-map]
+  (print-gpd-qq-plot view data-map))

--- a/bases/criterium/src/criterium/viewer/print/tail.clj
+++ b/bases/criterium/src/criterium/viewer/print/tail.clj
@@ -131,9 +131,9 @@
   "Print ASCII tail ratios bar chart for all metrics."
   [view data-map]
   (let [indent (print-core/sublabel-indent-str)
-        header-fn (fn []
-                    (format "%s Tail Ratios"
-                            (print-core/format-sublabel "Chart")))
+        header-fn (fn [n]
+                    (format "%s Tail Ratios (n=%d)"
+                            (print-core/format-sublabel "Chart") n))
         opts (assoc view
                     :header-fn header-fn
                     :indent indent
@@ -154,9 +154,9 @@
   "Print ASCII Hill plot for all metrics."
   [view data-map]
   (let [indent (print-core/sublabel-indent-str)
-        header-fn (fn []
-                    (format "%s Hill Plot (H_k vs k)"
-                            (print-core/format-sublabel "Chart")))
+        header-fn (fn [n]
+                    (format "%s Hill Plot (H_k vs k, n=%d)"
+                            (print-core/format-sublabel "Chart") n))
         opts (assoc view
                     :header-fn header-fn
                     :indent indent
@@ -178,9 +178,9 @@
   "Print ASCII mean residual life plot for all metrics."
   [view data-map]
   (let [indent (print-core/sublabel-indent-str)
-        header-fn (fn []
-                    (format "%s Mean Residual Life Plot"
-                            (print-core/format-sublabel "Chart")))
+        header-fn (fn [n]
+                    (format "%s Mean Residual Life Plot (n=%d)"
+                            (print-core/format-sublabel "Chart") n))
         opts (assoc view
                     :header-fn header-fn
                     :indent indent

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -538,7 +538,10 @@
 (defn final-gc-warning-map
   "Create a data-map for testing final-gc-warnings views.
   Contains samples with elapsed time and final-gc with GC time data
-  structured to trigger a warning (GC time = 1% of total)."
+  structured to trigger a warning (GC time = 1% of total).
+
+  Returns the data-map directly (not wrapped in {:data ...})
+  to match other chart test data factories."
   []
   (let [metrics-defs (->
                       (select-keys
@@ -556,25 +559,24 @@
                          :scale 1e-3
                          :type :event
                          :dimension :time}]))]
-    {:data
-     {:samples
-      {:type :criterium/collected-metrics-samples
-       :metric->values
-       {[:elapsed-time] (arr/->long-array (long-array [99999999]))}
-       :metrics-deps metrics-defs
-       :batch-size 1
-       :eval-count 1
-       :elapsed-time 1}
-      :final-gc
-      {:type :criterium/collected-metrics-samples
-       :metric->values
-       {[:compilation :time-ms] (arr/->long-array (long-array [3]))
-        [:garbage-collector :total :time-ms] (arr/->long-array (long-array [1]))
-        [:elapsed-time] (arr/->long-array (long-array [1]))}
-       :metrics-deps metrics-defs
-       :batch-size 1
-       :eval-count 1
-       :elapsed-time 1}}}))
+    {:samples
+     {:type :criterium/collected-metrics-samples
+      :metric->values
+      {[:elapsed-time] (arr/->long-array (long-array [99999999]))}
+      :metrics-deps metrics-defs
+      :batch-size 1
+      :eval-count 1
+      :elapsed-time 1}
+     :final-gc
+     {:type :criterium/collected-metrics-samples
+      :metric->values
+      {[:compilation :time-ms] (arr/->long-array (long-array [3]))
+       [:garbage-collector :total :time-ms] (arr/->long-array (long-array [1]))
+       [:elapsed-time] (arr/->long-array (long-array [1]))}
+      :metrics-deps metrics-defs
+      :batch-size 1
+      :eval-count 1
+      :elapsed-time 1}}))
 
 (defn tail-analysis-data-map
   "Create a data-map with samples and tail-analysis data for testing tail charts.

--- a/bases/criterium/test/criterium/test_data.clj
+++ b/bases/criterium/test/criterium/test_data.clj
@@ -535,6 +535,47 @@
                          :ks-test {:statistic 0.11 :p-value 0.85}
                          :cvm-test {:statistic 0.055 :p-value 0.8}}}}}}}))
 
+(defn final-gc-warning-map
+  "Create a data-map for testing final-gc-warnings views.
+  Contains samples with elapsed time and final-gc with GC time data
+  structured to trigger a warning (GC time = 1% of total)."
+  []
+  (let [metrics-defs (->
+                      (select-keys
+                       (metrics/metrics)
+                       [:elapsed-time :class-loader :compilation])
+                      (assoc-in
+                       [:garbage-collector :values]
+                       [{:path [:garbage-collector :total :count]
+                         :label "GC total count"
+                         :scale 1
+                         :type :event
+                         :dimension :count}
+                        {:path [:garbage-collector :total :time-ms]
+                         :label "GC total time"
+                         :scale 1e-3
+                         :type :event
+                         :dimension :time}]))]
+    {:data
+     {:samples
+      {:type :criterium/collected-metrics-samples
+       :metric->values
+       {[:elapsed-time] (arr/->long-array (long-array [99999999]))}
+       :metrics-deps metrics-defs
+       :batch-size 1
+       :eval-count 1
+       :elapsed-time 1}
+      :final-gc
+      {:type :criterium/collected-metrics-samples
+       :metric->values
+       {[:compilation :time-ms] (arr/->long-array (long-array [3]))
+        [:garbage-collector :total :time-ms] (arr/->long-array (long-array [1]))
+        [:elapsed-time] (arr/->long-array (long-array [1]))}
+       :metrics-deps metrics-defs
+       :batch-size 1
+       :eval-count 1
+       :elapsed-time 1}}}))
+
 (defn tail-analysis-data-map
   "Create a data-map with samples and tail-analysis data for testing tail charts.
   Includes sample data and tail analysis results (Hill, GPD, MRL, tail ratios)."

--- a/bases/criterium/test/criterium/viewer/common_charts/tail_ascii_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts/tail_ascii_test.clj
@@ -56,8 +56,8 @@
     (testing "uses custom header function"
       (let [output (tail-ascii/render-ascii-tail-ratios
                     sample-tail-ratios
-                    {:header-fn (fn [] "Custom Header")})]
-        (is (str/includes? output "Custom Header"))))
+                    {:header-fn (fn [n] (str "Custom Header n=" n))})]
+        (is (str/includes? output "Custom Header n=3"))))
 
     (testing "applies indent"
       (let [output (tail-ascii/render-ascii-tail-ratios
@@ -98,8 +98,8 @@
     (testing "uses custom header function"
       (let [output (tail-ascii/render-ascii-hill-plot
                     sample-hill-data
-                    {:header-fn (fn [] "Custom Hill")})]
-        (is (str/includes? output "Custom Hill"))))
+                    {:header-fn (fn [n] (str "Custom Hill n=" n))})]
+        (is (str/includes? output "Custom Hill n=6"))))
 
     (testing "returns nil with empty data"
       (is (nil? (tail-ascii/render-ascii-hill-plot

--- a/bases/criterium/test/criterium/viewer/common_charts/tail_ascii_test.clj
+++ b/bases/criterium/test/criterium/viewer/common_charts/tail_ascii_test.clj
@@ -1,0 +1,224 @@
+(ns criterium.viewer.common-charts.tail-ascii-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [criterium.array :as arr]
+   [criterium.viewer.common-charts.tail-ascii :as tail-ascii]))
+
+;; Tests ASCII chart rendering for tail analysis visualization.
+;; Verifies chart structure, content, and edge case handling.
+
+;;; Test Data Fixtures
+
+(def identity-transforms
+  "Identity transforms for testing."
+  {:sample-> [identity]
+   :->sample [identity]})
+
+(def sample-tail-ratios
+  "Sample tail ratios data for testing."
+  {:tail-ratios {:p99-p95 1.5 :p999-p99 1.8 :p999-p95 2.7}
+   :empirical-quantiles {:p95 10.0 :p99 15.0 :p999 27.0}})
+
+(def sample-hill-data
+  "Sample Hill estimator data for testing."
+  {:hill {:k-range [3 4 5 6 7 8]
+          :estimates [0.8 0.85 0.82 0.81 0.83 0.84]
+          :stable-estimate 0.82}})
+
+(def sample-mrl-data
+  "Sample MRL data for testing."
+  {:threshold 5.0
+   :mrl {:thresholds [2.0 3.0 4.0 5.0 6.0 7.0]
+         :values [4.5 5.2 6.0 7.0 8.5 10.0]}})
+
+(def sample-gpd-fit
+  "Sample GPD fit parameters."
+  {:xi 0.3 :sigma 2.5})
+
+;;; Tail Ratios Chart Tests
+
+(deftest render-ascii-tail-ratios-test
+  ;; Tests ASCII bar chart rendering for tail ratios.
+  ;; Verifies chart structure and ratio display.
+  (testing "render-ascii-tail-ratios"
+    (testing "renders bar chart with all ratios"
+      (let [output (tail-ascii/render-ascii-tail-ratios
+                    sample-tail-ratios
+                    {:width 60})]
+        (is (string? output))
+        (is (str/includes? output "p99/p95"))
+        (is (str/includes? output "p999/p99"))
+        (is (str/includes? output "p999/p95"))
+        (is (str/includes? output "#"))  ; Bar characters
+        (is (str/includes? output "1.5")))) ; Ratio value
+
+    (testing "uses custom header function"
+      (let [output (tail-ascii/render-ascii-tail-ratios
+                    sample-tail-ratios
+                    {:header-fn (fn [] "Custom Header")})]
+        (is (str/includes? output "Custom Header"))))
+
+    (testing "applies indent"
+      (let [output (tail-ascii/render-ascii-tail-ratios
+                    sample-tail-ratios
+                    {:indent "  "})]
+        (is (str/includes? output "  p99/p95"))))
+
+    (testing "returns nil when no ratios"
+      (is (nil? (tail-ascii/render-ascii-tail-ratios
+                 {:tail-ratios {} :empirical-quantiles {}}
+                 {}))))
+
+    (testing "handles partial ratios"
+      (let [output (tail-ascii/render-ascii-tail-ratios
+                    {:tail-ratios {:p99-p95 1.5}
+                     :empirical-quantiles {:p95 10.0 :p99 15.0}}
+                    {})]
+        (is (string? output))
+        (is (str/includes? output "p99/p95"))
+        (is (not (str/includes? output "p999")))))))
+
+;;; Hill Plot Tests
+
+(deftest render-ascii-hill-plot-test
+  ;; Tests ASCII Hill plot rendering.
+  ;; Verifies line chart structure and stable estimate display.
+  (testing "render-ascii-hill-plot"
+    (testing "renders line chart with Hill estimates"
+      (let [output (tail-ascii/render-ascii-hill-plot
+                    sample-hill-data
+                    {:width 60 :height 12})]
+        (is (string? output))
+        (is (str/includes? output "|"))  ; Axis
+        (is (or (str/includes? output "*")
+                (str/includes? output ".")))  ; Chart chars
+        (is (str/includes? output "Stable estimate"))))
+
+    (testing "uses custom header function"
+      (let [output (tail-ascii/render-ascii-hill-plot
+                    sample-hill-data
+                    {:header-fn (fn [] "Custom Hill")})]
+        (is (str/includes? output "Custom Hill"))))
+
+    (testing "returns nil with empty data"
+      (is (nil? (tail-ascii/render-ascii-hill-plot
+                 {:hill {:k-range [] :estimates []}}
+                 {}))))
+
+    (testing "works without stable estimate"
+      (let [output (tail-ascii/render-ascii-hill-plot
+                    {:hill {:k-range [3 4 5]
+                            :estimates [0.8 0.85 0.82]}}
+                    {:width 60})]
+        (is (string? output))
+        (is (not (str/includes? output "Stable estimate")))))))
+
+;;; MRL Plot Tests
+
+(deftest render-ascii-mrl-plot-test
+  ;; Tests ASCII MRL plot rendering.
+  ;; Verifies line chart structure and threshold display.
+  (testing "render-ascii-mrl-plot"
+    (testing "renders line chart with MRL curve"
+      (let [output (tail-ascii/render-ascii-mrl-plot
+                    sample-mrl-data
+                    identity-transforms
+                    {:width 60 :height 12})]
+        (is (string? output))
+        (is (str/includes? output "|"))  ; Axis
+        (is (or (str/includes? output "*")
+                (str/includes? output ".")))  ; Chart chars
+        (is (str/includes? output "threshold"))))
+
+    (testing "returns nil with empty thresholds"
+      (is (nil? (tail-ascii/render-ascii-mrl-plot
+                 {:threshold 5.0 :mrl {:thresholds [] :values []}}
+                 identity-transforms
+                 {}))))))
+
+;;; Zipf Plot Tests
+
+(deftest render-ascii-zipf-plot-test
+  ;; Tests ASCII Zipf plot (log-log CCDF) rendering.
+  ;; Verifies scatter plot structure.
+  (testing "render-ascii-zipf-plot"
+    (testing "renders scatter plot with log-transformed axes"
+      (let [samples (arr/->double-array (double-array [1.0 2.0 3.0 4.0 5.0]))
+            output (tail-ascii/render-ascii-zipf-plot
+                    samples
+                    identity-transforms
+                    {:width 60 :height 12})]
+        (is (string? output))
+        (is (str/includes? output "|"))  ; Axis
+        (is (str/includes? output "*"))))  ; Points
+
+    (testing "returns nil for empty samples"
+      (is (nil? (tail-ascii/render-ascii-zipf-plot
+                 (arr/->double-array (double-array []))
+                 identity-transforms
+                 {}))))
+
+    (testing "returns nil for nil samples"
+      (is (nil? (tail-ascii/render-ascii-zipf-plot
+                 nil
+                 identity-transforms
+                 {}))))))
+
+;;; Exponential Q-Q Plot Tests
+
+(deftest render-ascii-exponential-qq-test
+  ;; Tests ASCII exponential Q-Q plot rendering.
+  ;; Verifies scatter plot structure.
+  (testing "render-ascii-exponential-qq"
+    (testing "renders scatter plot for exceedances"
+      (let [samples (arr/->double-array
+                     (double-array [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 10.0 15.0]))
+            threshold 5.0
+            output (tail-ascii/render-ascii-exponential-qq
+                    samples threshold
+                    identity-transforms
+                    {:width 60 :height 12})]
+        (is (string? output))
+        (is (str/includes? output "|"))  ; Axis
+        (is (str/includes? output "*")))) ; Points
+
+    (testing "returns nil when too few exceedances"
+      (let [samples (arr/->double-array (double-array [1.0 2.0 3.0 6.0]))
+            threshold 5.0]  ; Only 1 exceedance
+        (is (nil? (tail-ascii/render-ascii-exponential-qq
+                   samples threshold
+                   identity-transforms
+                   {})))))))
+
+;;; GPD Q-Q Plot Tests
+
+(deftest render-ascii-gpd-qq-test
+  ;; Tests ASCII GPD Q-Q plot rendering.
+  ;; Verifies scatter plot structure.
+  (testing "render-ascii-gpd-qq"
+    (testing "renders scatter plot for exceedances vs GPD quantiles"
+      (let [samples (arr/->double-array
+                     (double-array [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 10.0 15.0]))
+            threshold 5.0
+            output (tail-ascii/render-ascii-gpd-qq
+                    samples threshold sample-gpd-fit
+                    identity-transforms
+                    {:width 60 :height 12})]
+        (is (string? output))
+        (is (str/includes? output "|"))  ; Axis
+        (is (str/includes? output "*")))) ; Points
+
+    (testing "returns nil when gpd-fit is nil"
+      (let [samples (arr/->double-array (double-array [1.0 2.0 6.0 7.0 8.0]))]
+        (is (nil? (tail-ascii/render-ascii-gpd-qq
+                   samples 5.0 nil
+                   identity-transforms
+                   {})))))
+
+    (testing "returns nil when sigma is zero"
+      (let [samples (arr/->double-array (double-array [1.0 2.0 6.0 7.0 8.0]))]
+        (is (nil? (tail-ascii/render-ascii-gpd-qq
+                   samples 5.0 {:xi 0.3 :sigma 0.0}
+                   identity-transforms
+                   {})))))))

--- a/bases/criterium/test/criterium/viewer/kindly/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly/core_test.clj
@@ -289,7 +289,7 @@
       (view/final-gc-warnings*
        :kindly
        {:warn-threshold 0.01}
-       (:data (test-data/final-gc-warning-map)))
+       (test-data/final-gc-warning-map))
       (let [result (core/flush)]
         (is (= :kind/fragment (:kindly/kind (meta result))))
         (is (= 2 (count result)) "Expected heading and table")
@@ -305,5 +305,5 @@
       (view/final-gc-warnings*
        :kindly
        {:warn-threshold 0.99}
-       (:data (test-data/final-gc-warning-map)))
+       (test-data/final-gc-warning-map))
       (is (empty? @core/accumulated)))))

--- a/bases/criterium/test/criterium/viewer/kindly/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly/core_test.clj
@@ -3,6 +3,7 @@
   ;; and basic view implementations (stats, extremes, quantiles, outliers,
   ;; samples, histogram, KDE, bootstrap stats).
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [criterium.analyse :as analyse]
    [criterium.test-data :as test-data]
@@ -237,19 +238,72 @@
           (is (= :kind/md (:kindly/kind (meta heading))))
           (is (= ["**Metrics**"] heading)))))))
 
-(deftest noop-views-test
-  (testing "noop views"
-    (testing "final-gc-warnings* produces no output"
-      (reset! core/accumulated [])
-      (view/final-gc-warnings* :kindly {} {})
-      (is (empty? @core/accumulated)))
+;;; OS Info Tests
 
-    (testing "os* produces no output"
+(deftest os-view-test
+  ;; Tests the kindly viewer output for OS information.
+  ;; Verifies table with name, version, architecture, and processor count.
+  (testing "view/os* :kindly"
+    (testing "displays OS info table"
       (reset! core/accumulated [])
       (view/os* :kindly {} {})
-      (is (empty? @core/accumulated)))
+      (let [result (core/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result)) "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Operating System**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 4 (count table)) "Expected 4 rows")
+          (is (= "Name" (:property (nth table 0))))
+          (is (= "Processors" (:property (nth table 3)))))))))
 
-    (testing "runtime* produces no output"
+;;; Runtime Info Tests
+
+(deftest runtime-view-test
+  ;; Tests the kindly viewer output for runtime information.
+  ;; Verifies table with VM name, version, vendor, and arguments.
+  (testing "view/runtime* :kindly"
+    (testing "displays runtime info table"
       (reset! core/accumulated [])
       (view/runtime* :kindly {} {})
+      (let [result (core/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result)) "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Runtime**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 4 (count table)) "Expected 4 rows")
+          (is (= "VM Name" (:property (nth table 0))))
+          (is (= "Arguments" (:property (nth table 3)))))))))
+
+;;; Final GC Warnings Tests
+
+(deftest final-gc-warnings-view-test
+  ;; Tests the kindly viewer output for final GC warnings.
+  ;; Verifies warning displays when GC time exceeds threshold.
+  (testing "view/final-gc-warnings* :kindly"
+    (testing "displays warning when GC exceeds threshold"
+      (reset! core/accumulated [])
+      (view/final-gc-warnings*
+       :kindly
+       {:warn-threshold 0.01}
+       (:data (test-data/final-gc-warning-map)))
+      (let [result (core/flush)]
+        (is (= :kind/fragment (:kindly/kind (meta result))))
+        (is (= 2 (count result)) "Expected heading and table")
+        (let [[heading table] result]
+          (is (= :kind/md (:kindly/kind (meta heading))))
+          (is (= ["**Final GC Warning**"] heading))
+          (is (= :kind/table (:kindly/kind (meta table))))
+          (is (= 1 (count table)))
+          (is (str/includes? (:warning (first table)) "Final GC ran for")))))
+
+    (testing "outputs nothing when GC below threshold"
+      (reset! core/accumulated [])
+      (view/final-gc-warnings*
+       :kindly
+       {:warn-threshold 0.99}
+       (:data (test-data/final-gc-warning-map)))
       (is (empty? @core/accumulated)))))

--- a/bases/criterium/test/criterium/viewer/kindly_basic_views_test.clj
+++ b/bases/criterium/test/criterium/viewer/kindly_basic_views_test.clj
@@ -417,25 +417,10 @@
             (is (= 350 (-> chart :vconcat first :height))
                 "Expected notebook-friendly height")))))))
 
-(deftest noop-views-test
-  ;; Tests that noop multimethods do not add anything to the accumulator.
-  (testing "noop views"
-    (testing "bootstrap-stats* produces no output"
+(deftest bootstrap-stats-no-data-test
+  ;; Tests that bootstrap-stats* does not add anything when data is missing.
+  (testing "bootstrap-stats* without data"
+    (testing "produces no output when data-map is empty"
       (reset! kindly/accumulated [])
       (view/bootstrap-stats* :kindly {} {})
-      (is (empty? @kindly/accumulated)))
-
-    (testing "final-gc-warnings* produces no output"
-      (reset! kindly/accumulated [])
-      (view/final-gc-warnings* :kindly {} {})
-      (is (empty? @kindly/accumulated)))
-
-    (testing "os* produces no output"
-      (reset! kindly/accumulated [])
-      (view/os* :kindly {} {})
-      (is (empty? @kindly/accumulated)))
-
-    (testing "runtime* produces no output"
-      (reset! kindly/accumulated [])
-      (view/runtime* :kindly {} {})
       (is (empty? @kindly/accumulated)))))

--- a/bases/criterium/test/criterium/viewer/portal/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal/core_test.clj
@@ -400,3 +400,70 @@
           (is (contains? row :mean-ci-upper))
           (is (contains? row :p10))
           (is (contains? row :p90)))))))
+
+;;; OS Info Tests
+
+(deftest portal-os-test
+  ;; Tests the portal viewer output for OS information.
+  ;; Verifies table with name, version, architecture, and processor count.
+  (testing "view/os*"
+    (testing "displays OS info table"
+      (let [[title table] (with-tap-out
+                            (view/os* :portal {} {}))]
+        (is (= [:b "Operating System"] title))
+        (is (= 4 (count table)) "Expected 4 rows")
+        (is (= "Name" (:property (nth table 0))))
+        (is (= "Version" (:property (nth table 1))))
+        (is (= "Architecture" (:property (nth table 2))))
+        (is (= "Processors" (:property (nth table 3))))
+        (is (string? (:value (nth table 0))))
+        (is (number? (:value (nth table 3))))))))
+
+;;; Runtime Info Tests
+
+(deftest portal-runtime-test
+  ;; Tests the portal viewer output for runtime information.
+  ;; Verifies table with VM name, version, vendor, and arguments.
+  (testing "view/runtime*"
+    (testing "displays runtime info table"
+      (let [[title table] (with-tap-out
+                            (view/runtime* :portal {} {}))]
+        (is (= [:b "Runtime"] title))
+        (is (= 4 (count table)) "Expected 4 rows")
+        (is (= "VM Name" (:property (nth table 0))))
+        (is (= "VM Version" (:property (nth table 1))))
+        (is (= "VM Vendor" (:property (nth table 2))))
+        (is (= "Arguments" (:property (nth table 3))))
+        (is (string? (:value (nth table 0))))
+        (is (string? (:value (nth table 3))))))))
+
+;;; Final GC Warnings Tests
+
+(deftest portal-final-gc-warnings-test
+  ;; Tests the portal viewer output for final GC warnings.
+  ;; Verifies warning displays when GC time exceeds threshold.
+  (testing "view/final-gc-warnings*"
+    (testing "displays warning when GC exceeds threshold"
+      (let [data-map (:data (test-data/final-gc-warning-map))
+            [title table] (with-tap-out
+                            (view/final-gc-warnings*
+                             :portal
+                             {:warn-threshold 0.01}
+                             data-map))]
+        (is (= [:b "Final GC Warning"] title))
+        (is (= 1 (count table)))
+        (is (str/includes? (:warning (first table)) "Final GC ran for"))))
+
+    (testing "outputs nothing when GC below threshold"
+      (let [v (volatile! [])
+            f (fn [x] (when-not (= :criterium.viewer.portal/_ x) (vswap! v conj x)))]
+        (try
+          (add-tap f)
+          (view/final-gc-warnings*
+           :portal
+           {:warn-threshold 0.99}
+           (:data (test-data/final-gc-warning-map)))
+          (portal-core/flush)
+          (is (empty? @v))
+          (finally
+            (remove-tap f)))))))

--- a/bases/criterium/test/criterium/viewer/portal/core_test.clj
+++ b/bases/criterium/test/criterium/viewer/portal/core_test.clj
@@ -444,7 +444,7 @@
   ;; Verifies warning displays when GC time exceeds threshold.
   (testing "view/final-gc-warnings*"
     (testing "displays warning when GC exceeds threshold"
-      (let [data-map (:data (test-data/final-gc-warning-map))
+      (let [data-map (test-data/final-gc-warning-map)
             [title table] (with-tap-out
                             (view/final-gc-warnings*
                              :portal
@@ -462,7 +462,7 @@
           (view/final-gc-warnings*
            :portal
            {:warn-threshold 0.99}
-           (:data (test-data/final-gc-warning-map)))
+           (test-data/final-gc-warning-map))
           (portal-core/flush)
           (is (empty? @v))
           (finally

--- a/bases/criterium/test/criterium/viewer/pprint_test.clj
+++ b/bases/criterium/test/criterium/viewer/pprint_test.clj
@@ -939,3 +939,226 @@
             ":pprint should produce same output as :print when :show-chart true")
         (is (str/includes? pprint-output "Samples"))
         (is (str/includes? pprint-output "|"))))))
+
+;;; Chart Delegation Tests
+;; These tests verify that :pprint viewer delegates chart methods to :print
+;; and produces identical output.
+
+;;; Distribution Chart Delegation Tests
+
+(def ^:private sample-metric-defs
+  (select-keys (criterium.collector.metrics/metrics) [:elapsed-time]))
+
+(def ^:private gamma-best-fit-with-params
+  "Distribution fit results with full params for chart rendering."
+  {:fits
+   {[:elapsed-time]
+    {:n 50
+     :best-model :gamma
+     :sample-range [1000000.0 5000000.0]
+     :distributions
+     {:gamma {:aic 150.0 :delta-aic 0.0 :bic 155.0
+              :params {:shape 2.5 :scale 1000000.0}}}
+     :parameter-cis
+     {:gamma {:shape {:point-estimate 2.5 :ci-lower 2.0 :ci-upper 3.0}
+              :scale {:point-estimate 1000000.0 :ci-lower 800000.0 :ci-upper 1200000.0}}}}}})
+
+(defn- make-sample-values
+  "Create sample values array for testing."
+  [n ^double mean ^double stddev]
+  (let [rng (java.util.Random. 42)]
+    (arr/->double-array
+     (double-array
+      (repeatedly n #(+ mean (* stddev (.nextGaussian rng))))))))
+
+(defn- data-map-with-fit-and-samples
+  "Create data map with distribution fit, sample metadata, and sample values."
+  [fit-data]
+  {:distribution-fit fit-data
+   :samples {:type :criterium/metrics-samples
+             :metrics-defs sample-metric-defs
+             :metric->values {[:elapsed-time] (make-sample-values 50 2500000.0 500000.0)}
+             :transform collect-plan/identity-transforms
+             :batch-size 1
+             :eval-count 50
+             :num-samples 50}})
+
+(deftest distribution-pdf-pprint-delegation-test
+  ;; Tests that pprint viewer delegates distribution-pdf* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "distribution-pdf*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (data-map-with-fit-and-samples gamma-best-fit-with-params)
+            pprint-output (with-out-str
+                            (view/distribution-pdf* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/distribution-pdf* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "PDF")
+            "Should show PDF in header")
+        (is (str/includes? pprint-output "Gamma")
+            "Should show distribution name")))))
+
+(deftest distribution-cdf-pprint-delegation-test
+  ;; Tests that pprint viewer delegates distribution-cdf* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "distribution-cdf*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (data-map-with-fit-and-samples gamma-best-fit-with-params)
+            pprint-output (with-out-str
+                            (view/distribution-cdf* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/distribution-cdf* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "CDF")
+            "Should show CDF in header")))))
+
+(deftest distribution-qq-pprint-delegation-test
+  ;; Tests that pprint viewer delegates distribution-qq* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "distribution-qq*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (data-map-with-fit-and-samples gamma-best-fit-with-params)
+            pprint-output (with-out-str
+                            (view/distribution-qq* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/distribution-qq* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "Q-Q")
+            "Should show Q-Q in header")))))
+
+;;; Tail Analysis Chart Delegation Tests
+
+(deftest tail-ratios-chart-pprint-delegation-test
+  ;; Tests that pprint viewer delegates tail-ratios-chart* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "tail-ratios-chart*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (test-data/tail-analysis-data-map)
+            pprint-output (with-out-str
+                            (view/tail-ratios-chart* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/tail-ratios-chart* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "Tail Ratios")
+            "Should have header")
+        (is (str/includes? pprint-output "p99/p95")
+            "Should show ratio names")))))
+
+(deftest hill-plot-pprint-delegation-test
+  ;; Tests that pprint viewer delegates hill-plot* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "hill-plot*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (test-data/tail-analysis-data-map)
+            pprint-output (with-out-str
+                            (view/hill-plot* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/hill-plot* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "Hill Plot")
+            "Should have header")))))
+
+(deftest mrl-plot-pprint-delegation-test
+  ;; Tests that pprint viewer delegates mrl-plot* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "mrl-plot*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (test-data/tail-analysis-data-map)
+            pprint-output (with-out-str
+                            (view/mrl-plot* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/mrl-plot* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "Mean Residual Life")
+            "Should have header")))))
+
+(deftest zipf-plot-pprint-delegation-test
+  ;; Tests that pprint viewer delegates zipf-plot* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "zipf-plot*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (test-data/tail-analysis-data-map)
+            pprint-output (with-out-str
+                            (view/zipf-plot* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/zipf-plot* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "Zipf Plot")
+            "Should have header")))))
+
+(deftest exponential-qq-plot-pprint-delegation-test
+  ;; Tests that pprint viewer delegates exponential-qq-plot* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "exponential-qq-plot*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (test-data/tail-analysis-data-map)
+            pprint-output (with-out-str
+                            (view/exponential-qq-plot* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/exponential-qq-plot* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "Exponential Q-Q")
+            "Should have header")))))
+
+(deftest gpd-qq-plot-pprint-delegation-test
+  ;; Tests that pprint viewer delegates gpd-qq-plot* to :print.
+  ;; Verifies identical output between :pprint and :print viewers.
+  (testing "gpd-qq-plot*"
+    (testing "delegates to :print and produces identical output"
+      (let [data-map (test-data/tail-analysis-data-map)
+            pprint-output (with-out-str
+                            (view/gpd-qq-plot* :pprint {} data-map))
+            print-output (with-out-str
+                           (view/gpd-qq-plot* :print {} data-map))]
+        (is (= print-output pprint-output)
+            ":pprint should produce same output as :print")
+        (is (str/includes? pprint-output "GPD Q-Q")
+            "Should have header")))))
+
+;;; ACF Plot Delegation Test
+
+(deftest acf-plot-pprint-delegation-test
+  ;; Tests that pprint viewer delegates acf-plot* rendering (via common chart).
+  ;; Verifies both viewers produce output with expected content.
+  (testing "acf-plot*"
+    (testing "produces ASCII ACF chart output"
+      (let [metrics-defs (select-keys (criterium.collector.metrics/metrics)
+                                      [:elapsed-time])
+            data-map {:autocorrelation
+                      {:type :criterium/autocorrelation
+                       :metrics-defs metrics-defs
+                       :source-id :samples
+                       :autocorrelation
+                       {[:elapsed-time]
+                        {:acf {1 0.25 2 0.18 3 0.05}
+                         :lag-1 {:value 0.25 :severity :moderate}
+                         :effective-sample-size {:n-original 200
+                                                 :n-effective 157
+                                                 :ratio 0.785}
+                         :ci-inflation-factor 1.13
+                         :lag-severities {1 :moderate 2 :minor 3 :none}
+                         :thresholds {:lag-1 {:minor 0.10 :moderate 0.20 :severe 0.35}
+                                      :other {:minor 0.15 :moderate 0.25 :severe 0.40}}
+                         :ljung-box {:q-statistic 15.0 :df 10 :p-value 0.5}
+                         :pattern :clean
+                         :classification :acceptable
+                         :detected-period nil}}}}
+            ;; pprint uses common chart rendering with different options
+            ;; so output may differ slightly, but both should produce output
+            pprint-output (with-out-str
+                            (view/acf-plot* :pprint {:min-severity :minor} data-map))]
+        (is (str/includes? pprint-output "ACF Plot")
+            "Should have header")
+        (is (str/includes? pprint-output "n=200")
+            "Should show sample count")
+        (is (str/includes? pprint-output "█")
+            "Should have bar characters")))))

--- a/bases/criterium/test/criterium/viewer/print/distribution_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/distribution_test.clj
@@ -1,6 +1,9 @@
 (ns criterium.viewer.print.distribution-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [criterium.array :as arr]
+   [criterium.collect-plan :as collect-plan]
    [criterium.collector.metrics :as metrics]
    [criterium.test-utils :refer [trimmed-lines]]
    [criterium.view :as view]
@@ -31,6 +34,20 @@
      {:gamma {:shape {:point-estimate 2.5 :ci-lower 2.0 :ci-upper 3.0}
               :scale {:point-estimate 0.01 :ci-lower 0.008 :ci-upper 0.012}}}}}})
 
+(def gamma-best-fit-with-params
+  "Distribution fit results with full params for chart rendering."
+  {:fits
+   {[:elapsed-time]
+    {:n 50
+     :best-model :gamma
+     :sample-range [1000000.0 5000000.0]  ; 1-5ms in nanoseconds
+     :distributions
+     {:gamma {:aic 150.0 :delta-aic 0.0 :bic 155.0
+              :params {:shape 2.5 :scale 1000000.0}}}
+     :parameter-cis
+     {:gamma {:shape {:point-estimate 2.5 :ci-lower 2.0 :ci-upper 3.0}
+              :scale {:point-estimate 1000000.0 :ci-lower 800000.0 :ci-upper 1200000.0}}}}}})
+
 (def small-sample-fit
   "Distribution fit with small sample warning."
   {:fits
@@ -59,6 +76,26 @@
   [fit-data]
   {:distribution-fit fit-data
    :samples {:metrics-defs sample-metric-defs}})
+
+(defn- make-sample-values
+  "Create sample values array for testing."
+  [n ^double mean ^double stddev]
+  (let [rng (java.util.Random. 42)]
+    (arr/->double-array
+     (double-array
+      (repeatedly n #(+ mean (* stddev (.nextGaussian rng))))))))
+
+(defn data-map-with-fit-and-samples
+  "Create data map with distribution fit, sample metadata, and sample values."
+  [fit-data]
+  {:distribution-fit fit-data
+   :samples {:type :criterium/metrics-samples
+             :metrics-defs sample-metric-defs
+             :metric->values {[:elapsed-time] (make-sample-values 50 2500000.0 500000.0)}
+             :transform collect-plan/identity-transforms
+             :batch-size 1
+             :eval-count 50
+             :num-samples 50}})
 
 ;;; Distribution Models Tests
 
@@ -150,19 +187,77 @@
                       (data-map-with-fit gamma-best-fit))))]
         (is (some #(.contains ^String % "Parameter CIs") lines))))))
 
-;;; No-op Chart Views Tests
+;;; Chart Views Tests
 
-(deftest chart-views-noop-test
-  (testing "chart views are no-ops for print viewer"
-    (testing "distribution-pdf* produces no output"
+(deftest distribution-pdf-test
+  ;; Tests ASCII PDF chart rendering for distribution fits.
+  ;; Verifies chart structure and content.
+  (testing "distribution-pdf*"
+    (testing "renders ASCII PDF chart with fitted distribution"
+      (let [data-map (data-map-with-fit-and-samples gamma-best-fit-with-params)
+            output (with-out-str
+                     (view/distribution-pdf* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "PDF") lines)
+            "Should show PDF in header")
+        (is (some #(str/includes? % "Gamma") lines)
+            "Should show distribution name")
+        (is (some #(str/includes? % "n=50") lines)
+            "Should show sample count")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(or (str/includes? % "*") (str/includes? % ".")) lines)
+            "Should have chart characters")))
+
+    (testing "produces no output when no distribution fit data"
       (is (= ""
              (with-out-str
-               (view/distribution-pdf* :print {} {})))))
-    (testing "distribution-cdf* produces no output"
+               (view/distribution-pdf* :print {} {})))))))
+
+(deftest distribution-cdf-test
+  ;; Tests ASCII CDF chart rendering showing ECDF.
+  ;; Verifies chart structure and sample count display.
+  (testing "distribution-cdf*"
+    (testing "renders ASCII CDF chart with ECDF"
+      (let [data-map (data-map-with-fit-and-samples gamma-best-fit-with-params)
+            output (with-out-str
+                     (view/distribution-cdf* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "CDF") lines)
+            "Should show CDF in header")
+        (is (some #(str/includes? % "n=50") lines)
+            "Should show sample count")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(str/includes? % "*") lines)
+            "Should have point characters")))
+
+    (testing "produces no output when no samples"
       (is (= ""
              (with-out-str
-               (view/distribution-cdf* :print {} {})))))
-    (testing "distribution-qq* produces no output"
+               (view/distribution-cdf* :print {} {})))))))
+
+(deftest distribution-qq-test
+  ;; Tests ASCII Q-Q plot rendering for distribution fits.
+  ;; Verifies chart structure showing theoretical vs observed quantiles.
+  (testing "distribution-qq*"
+    (testing "renders ASCII Q-Q plot for best-fit distribution"
+      (let [data-map (data-map-with-fit-and-samples gamma-best-fit-with-params)
+            output (with-out-str
+                     (view/distribution-qq* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Q-Q") lines)
+            "Should show Q-Q in header")
+        (is (some #(str/includes? % "Gamma") lines)
+            "Should show distribution name")
+        (is (some #(str/includes? % "n=50") lines)
+            "Should show sample count")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(str/includes? % "*") lines)
+            "Should have point characters")))
+
+    (testing "produces no output when no distribution fit data"
       (is (= ""
              (with-out-str
                (view/distribution-qq* :print {} {})))))))

--- a/bases/criterium/test/criterium/viewer/print/tail_test.clj
+++ b/bases/criterium/test/criterium/viewer/print/tail_test.clj
@@ -68,13 +68,127 @@
       (let [output (with-out-str (view/tail-high-quantiles* :print {} {}))]
         (is (str/blank? output))))))
 
-(deftest tail-chart-views-print-test
-  ;; Tests that chart views are no-ops for print viewer.
-  (testing "chart views are no-ops for print"
-    (let [data-map (test-data/tail-analysis-data-map)]
-      (is (nil? (view/tail-ratios-chart* :print {} data-map)))
-      (is (nil? (view/hill-plot* :print {} data-map)))
-      (is (nil? (view/mrl-plot* :print {} data-map)))
-      (is (nil? (view/zipf-plot* :print {} data-map)))
-      (is (nil? (view/exponential-qq-plot* :print {} data-map)))
-      (is (nil? (view/gpd-qq-plot* :print {} data-map))))))
+;;; Chart View Tests
+
+(deftest tail-ratios-chart-print-test
+  ;; Tests ASCII tail ratios bar chart rendering.
+  ;; Verifies chart structure and ratio display.
+  (testing "tail-ratios-chart*"
+    (testing "renders ASCII bar chart with tail ratios"
+      (let [data-map (test-data/tail-analysis-data-map)
+            output (with-out-str (view/tail-ratios-chart* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Tail Ratios") lines)
+            "Should have header")
+        (is (some #(str/includes? % "p99/p95") lines)
+            "Should show p99/p95 ratio")
+        (is (some #(str/includes? % "#") lines)
+            "Should have bar characters")))
+
+    (testing "produces no output when no data"
+      (is (= "" (with-out-str (view/tail-ratios-chart* :print {} {})))))))
+
+(deftest hill-plot-print-test
+  ;; Tests ASCII Hill plot rendering.
+  ;; Verifies chart structure and axis labels.
+  (testing "hill-plot*"
+    (testing "renders ASCII Hill plot"
+      (let [data-map (test-data/tail-analysis-data-map)
+            output (with-out-str (view/hill-plot* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Hill Plot") lines)
+            "Should have header")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(or (str/includes? % "*") (str/includes? % ".")) lines)
+            "Should have chart characters")
+        (is (some #(str/includes? % "Stable estimate") lines)
+            "Should show stable estimate")))
+
+    (testing "produces no output when no data"
+      (is (= "" (with-out-str (view/hill-plot* :print {} {})))))))
+
+(deftest mrl-plot-print-test
+  ;; Tests ASCII mean residual life plot rendering.
+  ;; Verifies chart structure and threshold display.
+  (testing "mrl-plot*"
+    (testing "renders ASCII MRL plot"
+      (let [data-map (test-data/tail-analysis-data-map)
+            output (with-out-str (view/mrl-plot* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Mean Residual Life") lines)
+            "Should have header")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(or (str/includes? % "*") (str/includes? % ".")) lines)
+            "Should have chart characters")
+        (is (some #(str/includes? % "threshold") lines)
+            "Should show selected threshold")))
+
+    (testing "produces no output when no data"
+      (is (= "" (with-out-str (view/mrl-plot* :print {} {})))))))
+
+(deftest zipf-plot-print-test
+  ;; Tests ASCII Zipf plot (log-log CCDF) rendering.
+  ;; Verifies scatter plot structure.
+  (testing "zipf-plot*"
+    (testing "renders ASCII Zipf plot"
+      (let [data-map (test-data/tail-analysis-data-map)
+            output (with-out-str (view/zipf-plot* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Zipf Plot") lines)
+            "Should have header")
+        (is (some #(str/includes? % "log") lines)
+            "Should mention log scale")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(str/includes? % "*") lines)
+            "Should have point characters")))
+
+    (testing "produces no output when no samples"
+      (let [data-map (test-data/tail-analysis-data-map)
+            no-samples (assoc data-map :samples nil)]
+        (is (= "" (with-out-str (view/zipf-plot* :print {} no-samples))))))))
+
+(deftest exponential-qq-plot-print-test
+  ;; Tests ASCII exponential Q-Q plot rendering.
+  ;; Verifies scatter plot structure.
+  (testing "exponential-qq-plot*"
+    (testing "renders ASCII exponential Q-Q plot"
+      (let [data-map (test-data/tail-analysis-data-map)
+            output (with-out-str (view/exponential-qq-plot* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "Exponential Q-Q") lines)
+            "Should have header")
+        (is (some #(str/includes? % "exceedances") lines)
+            "Should show exceedance count")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(str/includes? % "*") lines)
+            "Should have point characters")))
+
+    (testing "produces no output when no data"
+      (is (= "" (with-out-str (view/exponential-qq-plot* :print {} {})))))))
+
+(deftest gpd-qq-plot-print-test
+  ;; Tests ASCII GPD Q-Q plot rendering.
+  ;; Verifies scatter plot structure.
+  (testing "gpd-qq-plot*"
+    (testing "renders ASCII GPD Q-Q plot"
+      (let [data-map (test-data/tail-analysis-data-map)
+            output (with-out-str (view/gpd-qq-plot* :print {} data-map))
+            lines (trimmed-lines output)]
+        (is (some #(str/includes? % "GPD Q-Q") lines)
+            "Should have header")
+        (is (some #(str/includes? % "exceedances") lines)
+            "Should show exceedance count")
+        (is (some #(str/includes? % "|") lines)
+            "Should have axis markers")
+        (is (some #(str/includes? % "*") lines)
+            "Should have point characters")))
+
+    (testing "produces no output when no GPD fit"
+      (let [data-map (test-data/tail-analysis-data-map)
+            no-gpd (update-in data-map [:tail-analysis :tail-analysis [:elapsed-time]]
+                              dissoc :gpd)]
+        (is (= "" (with-out-str (view/gpd-qq-plot* :print {} no-gpd))))))))


### PR DESCRIPTION
## Summary

Audit and implement all missing/no-op view implementations across the 4 viewers (:print, :pprint, :portal, :kindly).

**25 no-op implementations addressed:**
- 9 ASCII chart implementations for :print viewer (distribution PDF/CDF/QQ, 6 tail analysis charts)
- 10 :pprint chart delegations to :print implementations
- 6 text info views for :portal and :kindly viewers (final-gc-warnings, os, runtime)

## Changes

- Extract ASCII ACF plot rendering to `criterium.viewer.common-charts.autocorrelation`
- Add `criterium.viewer.common-charts.distribution-ascii` with PDF, CDF, QQ chart rendering
- Add `criterium.viewer.common-charts.tail-ascii` with 6 tail analysis chart renderers
- Implement `final-gc-warnings*`, `os*`, `runtime*` for :portal and :kindly viewers
- Delegate all :pprint chart views to :print implementations
- Extract `simple-transforms` helper to common.core
- Standardize header-fn signatures in tail-ascii charts

## Test plan

- [x] All existing tests pass
- [x] New tests for :pprint chart delegation methods
- [x] Tests for final-gc-warning-map test data factory