### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,26 @@
 {
-"permissions": {
+  "permissions": {
     "allow": [
       "Bash(./build/test/criterium_tests:*)"
     ]
   },
-"enabledMcpjsonServers": [
+  "enabledMcpjsonServers": [
     "clojure-mcp",
     "mcp-tasks",
     "clj-kondo"
   ],
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing permissions and MCP config.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing permissions allow list and MCP server config are preserved unchanged.

Closes #147

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
