### PR TITLE
fix(build): use :name param directly for lib symbol in deploy

### DIFF
--- a/build/src/build/tasks/deploy.clj
+++ b/build/src/build/tasks/deploy.clj
@@ -1,29 +1,19 @@
 (ns build.tasks.deploy
   (:require
-   [babashka.fs :as fs]
-   [build.common :as common]
    [build.verbose :as verbose]
    [clojure.tools.build.api :as b]
-   [clojure.tools.deps.util.dir :refer [with-dir]]
    [deps-deploy.deps-deploy :as dd]
    [taoensso.truss :refer [have]]))
 
 (defn deploy
-  [{:keys [jar-file pom-file project] :as params}]
-  (let [project-root (common/ensure-project-root "jar" project)
-        _ (with-dir
-            (fs/file project-root)
-            (common/get-project-aliases))
-        group-id (:group-id params)
-        artifact-id (:name params)
-        lib (symbol (name group-id) (name artifact-id))
+  [{:keys [jar-file pom-file name] :as params}]
+  (let [lib (symbol name)
         basis (b/create-basis)
         opts (merge
               params
               {:basis basis
                :lib lib
                :classifier nil
-
                :installer :remote
                :artifact jar-file
                :pom-file (str (have pom-file))})]


### PR DESCRIPTION
## Summary
- Fix NullPointerException during Clojars deploy (release workflow run 24366013771)
- Commit 193bc8c8 accidentally reverted the earlier fix from 82322191: project coordinates supply `:name` as the full maven coord (`criterium/criterium`) but no `:group-id`, so `(name nil)` threw at `deploy.clj:19`
- Restore `(symbol name)`, matching the pattern in `pom.clj`

## Test plan
- [ ] Re-run the Release workflow and confirm Clojars deploy succeeds for both `:criterium` and `:arg-gen`