### PR TITLE
feat(notebooks): restore allocation analysis notebooks

### DIFF
--- a/bases/notebooks/src/_quarto.yml
+++ b/bases/notebooks/src/_quarto.yml
@@ -23,3 +23,7 @@ website:
         contents:
           - domain_complexity_analysis.qmd
           - domain_comparison_analysis.qmd
+      - section: "Allocation Analysis"
+        contents:
+          - allocation_tracking.qmd
+          - allocation_bench.qmd

--- a/bases/notebooks/src/allocation_bench.clj
+++ b/bases/notebooks/src/allocation_bench.clj
@@ -1,0 +1,226 @@
+(ns
+ ^{:kindly/options {:kinds-that-hide-code #{:kind/hidden}}}
+ allocation-bench
+  "Benchmarking with integrated allocation analysis."
+  (:require
+   [clojure.string :as str]
+   [criterium.agent :as agent]
+   [criterium.bench :as bench]
+   [notebook.helpers :refer [bench-display]]
+   [scicloj.kindly.v4.kind :as kind]))
+
+(kind/hidden
+ (bench/set-default-viewer! :kindly))
+
+;; # Allocation Analysis with bench
+;;
+;; The `:with-allocation-trace` option integrates allocation tracking directly
+;; into the bench macro. This provides automatic collection, analysis, and
+;; display of allocation data alongside timing metrics.
+
+;; ## Agent Requirements
+;;
+;; Allocation tracing requires the native JVMTI agent. Check availability:
+
+{:agent-attached? (agent/attached?)
+ :agent-loaded?   (agent/loaded?)}
+
+;; If the agent is not attached, add the JVM argument from `agent/jvm-opts`
+;; when starting your REPL. See the
+;; [Allocation Tracking notebook](./allocation_tracking.html)
+;; for detailed setup instructions.
+
+;; ## Basic Usage
+;;
+;; Add `:with-allocation-trace true` to any bench call:
+
+(bench/bench (vec (range 100)) :with-allocation-trace true)
+
+;; The output now includes three additional sections:
+;; - **Allocation Summary** - Aggregate allocation statistics
+;; - **Allocation Hotspots** - Top allocation sites by bytes/count
+;; - **Allocations by Type** - Breakdown by object type
+
+;; ## Understanding Allocation Summary
+;;
+;; The allocation summary provides aggregate statistics:
+
+^:kindly/hide-code
+(kind/table
+ {:column-names ["Metric" "Description"]
+  :row-vectors  [["Total Allocated" "Total bytes allocated during trace"]
+                 ["Total Freed" "Bytes from objects garbage collected"]
+                 ["Num Allocations" "Total object allocations"]
+                 ["Num Freed" "Objects that were garbage collected"]]})
+
+;; A high "freed" count indicates short-lived temporary objects, which may
+;; signal optimization opportunities.
+
+;; ## Interpreting Hotspots
+;;
+;; The hotspots section identifies where allocations originate:
+
+(bench/bench (mapv str (range 50)) :with-allocation-trace true)
+
+;; Each hotspot entry shows:
+;; - **Call Site** - The file, class, method, and line triggering allocation
+;; - **Count** - Number of allocations from this site
+;; - **Bytes** - Total bytes allocated
+;; - **Freed Count/Bytes** - How many were garbage collected
+
+;; Hotspots are sorted by bytes allocated, making it easy to identify the
+;; most memory-intensive code paths.
+
+;; ## Analyzing by Type
+;;
+;; The by-type breakdown shows which object types are being created:
+
+(bench/bench (into {} (map (fn [i] [(keyword (str i)) i]) (range 20)))
+             :with-allocation-trace true)
+
+;; This reveals:
+;; - Primitive array allocations (e.g., `[J` for long arrays)
+;; - Collection overhead (persistent data structure nodes)
+;; - String allocations from conversions
+
+;; ## Comparing Code Variants
+;;
+;; Allocation tracing is valuable for comparing implementation approaches.
+
+;; ### String Building Comparison
+
+;; **Using str with apply:**
+
+(let [words ["the" "quick" "brown" "fox" "jumps"]]
+  (bench/bench (apply str (interpose " " words))
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; **Using clojure.string/join:**
+
+(let [words ["the" "quick" "brown" "fox" "jumps"]]
+  (bench/bench (str/join " " words)
+               :with-allocation-trace true
+               :collect-plan :one-shot))
+
+;; The `:one-shot` collect plan is useful for quick allocation comparisons
+;; since allocation patterns are typically consistent across runs.
+
+;; ### Collection Creation Comparison
+
+;; **Using vec on range:**
+
+(bench/bench (vec (range 100))
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; **Using into []:**
+
+(bench/bench (into [] (range 100))
+             :with-allocation-trace true
+             :collect-plan :one-shot)
+
+;; ## Graceful Degradation
+;;
+;; When the agent is not attached, `:with-allocation-trace` has no effect:
+;; - The benchmark runs normally
+;; - Timing and other metrics are collected as usual
+;; - Allocation sections are simply omitted from output
+;; - No errors are thrown
+
+;; This means code using `:with-allocation-trace` works on any system,
+;; with allocation data appearing only when the agent is available.
+
+;; Same code works with or without agent
+
+(bench/bench (vec (range 100)) :with-allocation-trace true)
+
+;; Without agent: shows timing only
+;; With agent: shows timing + allocation analysis)
+
+;; ## Using Different Viewers
+;;
+;; Allocation analysis works with all bench viewers.
+
+;; ### :pprint Viewer
+;;
+;; Shows the raw data structures:
+
+(bench-display
+ (bench/bench (vec (range 50))
+              :with-allocation-trace true
+              :viewer :pprint
+              :collect-plan :one-shot
+              :return-value [:nil]))
+
+;; ### :kindly Viewer
+;;
+;; Returns Kindly-annotated tables for Clay rendering:
+
+(bench/bench (vec (range 50))
+             :with-allocation-trace true
+             :viewer :kindly
+             :collect-plan :one-shot)
+
+;; ### :portal Viewer
+;;
+;; Sends allocation tables to Portal for interactive exploration.
+;; Ensure Portal is connected before using:
+
+(require '[portal.api :as p])
+(require 'criterium.viewer.portal)
+(def p (p/open))
+(def submit (criterium.viewer.portal/submit #'portal.api/submit))
+(add-tap #'submit)
+
+(bench/bench (vec (range 100))
+             :with-allocation-trace true
+             :viewer :portal
+             :return-value [:nil])
+
+;; ## Accessing Results Programmatically
+;;
+;; The allocation data is available in `last-bench` results:
+
+(do
+  (bench/bench (mapv inc (range 100))
+               :with-allocation-trace true
+               :viewer :none)
+  (let [data (:data (bench/last-bench))]
+    {:has-trace?    (contains? data :allocation-trace)
+     :has-summary?  (contains? data :allocation-summary)
+     :has-hotspots? (contains? data :allocation-hotspots)
+     :has-by-type?  (contains? data :allocation-by-type)}))
+
+;; Access specific analysis results:
+
+(do
+  (bench/bench (vec (range 100))
+               :with-allocation-trace true
+               :viewer :none)
+  (when-let [summary (get-in (bench/last-bench) [:data :allocation-summary])]
+    {:total-allocated (:total-allocated summary)
+     :num-allocations (:num-allocations summary)}))
+
+(kind/hidden
+ (bench/set-default-viewer! :print))
+
+;; ## Best Practices
+;;
+;; 1. **Use :one-shot for allocation comparisons**
+;;    Allocation patterns are consistent, so a single run suffices for comparing
+;;    implementations.
+;;
+;; 2. **Focus on hotspots first**
+;;    The top allocation sites usually reveal the most impactful optimization
+;;    opportunities.
+;;
+;; 3. **Watch the freed ratio**
+;;    High freed counts indicate temporary objects that add GC pressure.
+;;
+;; 4. **Compare similar workloads**
+;;    When comparing implementations, use identical input sizes for meaningful
+;;    comparisons.
+;;
+;; 5. **Consider memory vs time tradeoffs**
+;;    Lower allocations often correlate with better performance, but not always.

--- a/bases/notebooks/src/allocation_tracking.clj
+++ b/bases/notebooks/src/allocation_tracking.clj
@@ -1,0 +1,211 @@
+(ns allocation-tracking
+  "Memory allocation analysis with criterium's native agent."
+  (:require
+   [clojure.string :as str]
+   [criterium.agent :as agent]
+   [criterium.jvm :as jvm]
+   [scicloj.kindly.v4.kind :as kind]))
+
+;; # Allocation Tracking
+;;
+;; Criterium's optional native agent captures detailed allocation information
+;; with minimal overhead.
+
+;; ## When to Use Allocation Tracking
+;;
+;; Use allocation tracking when you want to:
+;; - Measure memory pressure from code execution
+;; - Identify allocation hotspots
+;; - Compare allocation costs of different implementations
+;; - Verify zero-allocation code paths
+
+;; ## Agent Requirements
+;;
+;; Allocation tracking uses a native JVMTI agent.
+;;
+;; Load the agent at JVM startup with -agentpath.  Use `jvm-opts` to get the
+;; correct JVM arguments:
+
+(agent/jvm-opts)
+
+;; Add the returned argument when starting your JVM:
+
+(kind/code "clojure -J-agentpath:/path/to/libcriterium.dylib -M:dev")
+
+;; Check if the agent is currently available:
+
+{:attached? (agent/attached?)
+ :loaded?   (agent/loaded?)}
+
+;; ## Basic Usage
+;;
+;; The `with-allocation-tracing` macro captures all JVM allocations
+;; during execution of its body. It returns a vector of
+;; `[allocation-records result]`:
+
+(let [[allocations result] (agent/with-allocation-tracing
+                             (str "hello" " " "world"))]
+  {:result           result
+   :allocation-count (when allocations (count allocations))
+   :agent-available? (some? allocations)})
+
+;; When the agent is unavailable, the macro gracefully degrades:
+;; - The body still executes normally
+;; - `allocations` is nil instead of a vector
+;; - No error is thrown
+
+;; ## Understanding Allocation Records
+;;
+;; Each allocation record is a map containing:
+
+^:kindly/hide-code
+(kind/table
+ {:column-names ["Key" "Description"]
+  :row-vectors  [[":object-type" "Class of allocated object"]
+                 [":object_size" "Size in bytes"]
+                 [":thread" "Thread ID where allocation occurred"]
+                 [":freed" "Whether object was garbage collected"]
+                 [":call-class" "Class that triggered allocation"]
+                 [":call-method" "Method that triggered allocation"]
+                 [":call-file" "Source file of allocation site"]
+                 [":call-line" "Line number of allocation site"]
+                 [":alloc-class" "Class doing the actual allocation"]
+                 [":alloc-method" "Method doing the allocation"]]})
+
+;; An example
+(let [[allocations _] (agent/with-allocation-tracing
+                        (vec (range 10)))]
+  (when allocations
+    {:total-allocations (count allocations)
+     :sample-record     (first allocations)
+     :object-types      (->> allocations
+                             (map :object-type)
+                             frequencies)}))
+
+;; ## Filtering by Thread
+;;
+;; Allocation tracking captures allocations from ALL JVM threads,
+;; not just the current one. Background tasks, GC finalization,
+;; and other threads contribute allocations.
+;;
+;; Use `allocation-on-thread?` to filter to a specific thread:
+
+(let [current-thread  (jvm/current-thread-id)
+      [allocations _] (agent/with-allocation-tracing
+                        (mapv inc (range 100)))]
+  (when allocations
+    (let [all-count     (count allocations)
+          thread-allocs (filter (agent/allocation-on-thread?) allocations)
+          thread-count  (count thread-allocs)]
+      {:current-thread     current-thread
+       :all-allocations    all-count
+       :thread-allocations thread-count
+       :other-threads      (- all-count thread-count)})))
+
+;; The predicate can also filter for a specific thread ID:
+
+(defn filter-specific-thread
+  "Filter allocations for a specific thread."
+  [thread-id allocations]
+  (filter (agent/allocation-on-thread? thread-id) allocations))
+
+;; ## Checking Freed Objects
+;;
+;; The `:freed` field indicates whether an object was garbage collected
+;; during the tracking session. Use `allocation-freed?` to check:
+
+(let [[allocations _] (agent/with-allocation-tracing
+                        (dotimes [_ 100]
+                          (str "temp-" (rand-int 1000))))]
+  (when allocations
+    (let [thread-allocs (filter (agent/allocation-on-thread?) allocations)
+          freed         (filter agent/allocation-freed? thread-allocs)
+          retained      (remove agent/allocation-freed? thread-allocs)]
+      {:total-tracked  (count thread-allocs)
+       :freed-count    (count freed)
+       :retained-count (count retained)})))
+
+;; ## Summarizing Allocations
+;;
+;; The `allocations-summary` function provides aggregate statistics:
+
+(let [[allocations _] (agent/with-allocation-tracing
+                        (vec (repeatedly 50 #(str "item-" (rand-int 100)))))]
+  (when allocations
+    (let [thread-allocs (filter (agent/allocation-on-thread?) allocations)]
+      (agent/allocations-summary thread-allocs))))
+
+;; The summary includes:
+;; - `:num-allocated` - Total objects allocated
+;; - `:num-freed` - Objects that were garbage collected
+;; - `:allocated-bytes` - Total bytes allocated
+;; - `:freed-bytes` - Bytes from freed objects
+
+;; ## Comparing Implementations
+;;
+;; Allocation tracking helps compare memory costs of different approaches.
+
+;; ### String concatenation
+
+(let [words ["the" "quick" "brown" "fox"]
+
+      ;; Approach 1: str with apply
+      [allocs1 _] (agent/with-allocation-tracing
+                    (apply str (interpose " " words)))
+      summary1    (when allocs1
+                    (agent/allocations-summary
+                     (filter (agent/allocation-on-thread?) allocs1)))
+
+      ;; Approach 2: clojure.string/join
+      [allocs2 _] (agent/with-allocation-tracing
+                    (str/join " " words))
+      summary2    (when allocs2
+                    (agent/allocations-summary
+                     (filter (agent/allocation-on-thread?) allocs2)))]
+
+  {:apply-str-approach   summary1
+   :string-join-approach summary2})
+
+;; ### Collection creation
+
+(let [;; vec from range
+      [allocs1 _] (agent/with-allocation-tracing
+                    (vec (range 100)))
+      summary1    (when allocs1
+                    (agent/allocations-summary
+                     (filter (agent/allocation-on-thread?) allocs1)))
+
+      ;; mapv
+      [allocs2 _] (agent/with-allocation-tracing
+                    (mapv identity (range 100)))
+      summary2    (when allocs2
+                    (agent/allocations-summary
+                     (filter (agent/allocation-on-thread?) allocs2)))]
+
+  {:vec-range     summary1
+   :mapv-identity summary2})
+
+;; ## Analyzing Allocation Patterns
+;;
+;; Group allocations by type to understand allocation patterns:
+
+(let [[allocations _] (agent/with-allocation-tracing
+                        (let [data (vec (range 1000))]
+                          (reduce + data)))]
+  (when allocations
+    (let [thread-allocs (filter (agent/allocation-on-thread?) allocations)]
+      (->> thread-allocs
+           (group-by :object-type)
+           (map (fn [[type allocs]]
+                  {:type  type
+                   :count (count allocs)
+                   :bytes (reduce + (map :object_size allocs))}))
+           (sort-by :bytes >)
+           (take 10)
+           vec))))
+
+;; ## Graceful Degradation
+;;
+;; When the agent cannot be loaded (unsupported platform, permission
+;; issues, etc.), `with-allocation-tracing` returns nil for allocations
+;; but still executes the body:

--- a/bases/notebooks/src/notebook/render.clj
+++ b/bases/notebooks/src/notebook/render.clj
@@ -16,7 +16,9 @@
    "bases/notebooks/src/analysis_and_view_options.clj"
    "bases/notebooks/src/in_situ.clj"
    "bases/notebooks/src/domain_complexity_analysis.clj"
-   "bases/notebooks/src/domain_comparison_analysis.clj"])
+   "bases/notebooks/src/domain_comparison_analysis.clj"
+   "bases/notebooks/src/allocation_tracking.clj"
+   "bases/notebooks/src/allocation_bench.clj"])
 
 (def quarto-config-source
   "Source path for Quarto configuration."


### PR DESCRIPTION
## What

Recovers the two allocation notebooks that were dropped during the Quarto restructuring (`946631e`, *"feat(notebooks): add Quarto documentation structure"*) and never re-added:

- **`allocation_tracking.clj`** — *Memory allocation analysis with criterium's native agent* (recovered verbatim from `946631e~1`, only the `ns` adapted).
- **`allocation_bench.clj`** — *Benchmarking with integrated allocation analysis* (`bench :with-allocation-trace`).

## Changes

- Restore both notebook sources, adapted to the current **flat** layout:
  - `ns` updated to drop the `criterium.` prefix and `_notebook` suffix (matches `warmup`, `tail-analysis`, etc.).
  - `criterium.notebook.helpers` require -> `notebook.helpers`.
  - Cross-link in the bench notebook fixed to `./allocation_tracking.html`.
- Register both in `notebook.render`'s `notebook-sources`.
- Add an **"Allocation Analysis"** section to the `_quarto.yml` sidebar.

## Verification

- Both files parse cleanly; all referenced APIs still exist (`criterium.agent` allocation fns, `criterium.jvm/current-thread-id`, `criterium.bench` bench/last-bench/set-default-viewer!, `notebook.helpers/bench-display`).
- Rendered both **with the native agent attached** (built locally, arm64): live allocation data appears — `{:attached? true, :loaded? true}`, populated Allocation Summary / Hotspots / By-Type tables, no exceptions.

## Notes

- Rendered `docs/*.qmd` outputs are local build artifacts (never committed, no CI publishes them), so they are intentionally excluded from this PR.