### PR TITLE
Persistent native-agent extraction + non-silent error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ version.edn
 agent-cpp/build/
 node_modules/
 # Native agent binaries (downloaded from CI before JAR builds)
-bases/agent/resources/native/**/*.so
-bases/agent/resources/native/**/*.dylib
-bases/agent/resources/native/**/*.sha256
+bases/criterium/resources/criterium/agent/**/*.so
+bases/criterium/resources/criterium/agent/**/*.dylib
+bases/criterium/resources/criterium/agent/**/*.sha256
 /bases/criterium/.clj-kondo/imports/

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ version.edn
 *.dylib
 *.log
 *.dSYM
-.clj-kondo/.cache/
+**/.clj-kondo/.cache/
 .clj-kondo/imports/
 .aider*
 agent-cpp/build/

--- a/bases/agent/src/clj/criterium/agent.clj
+++ b/bases/agent/src/clj/criterium/agent.clj
@@ -57,12 +57,53 @@
   []
   (runtime/loaded?))
 
+(defn extract-agent!
+  "Explicitly extract the bundled native agent to a persistent temp file, with
+  full error handling.
+
+  Use this when you want extraction to either succeed or fail *loudly* - for
+  example tooling that wires `-agentpath` for a separately-launched JVM and must
+  not silently continue without an agent. This is the explicit counterpart to
+  `jvm-opts` and the auto-loading helpers, which degrade gracefully.
+
+  Returns:
+  - the absolute path to the extracted binary on success;
+  - nil only when the current platform is unsupported (a legitimate outcome).
+
+  Throws:
+  - clojure.lang.ExceptionInfo on any extraction failure. The ex-data carries
+    `:criterium.agent/extraction-failure`, a `:stage` keyword identifying the
+    failing step (e.g. :read-hash, :resolve-binary, :copy, :verify-hash,
+    :atomic-move, :verify-permissions), and context (`:platform`,
+    `:resource-path`, `:target-path`, `:tmpdir`). See
+    `criterium.agent.runtime/extract-agent!` for the full stage list.
+
+  Options (map, optional):
+  - :cleanup-on-exit? (default false) - delete the extracted file on JVM exit.
+    Only for ephemeral in-process use; do NOT use when passing the path to a
+    separately-launched JVM, as the file would be removed when this JVM exits.
+
+  The extracted file is persistent by default (not deleted on JVM exit), so the
+  returned path is safe to pass to another JVM via -agentpath.
+
+  Example:
+  ```clojure
+  (criterium.agent/extract-agent!)
+  ;=> \"/tmp/criterium-agent-macos-arm64-<hash>.dylib\"
+  ```"
+  ([] (runtime/extract-agent!))
+  ([opts] (runtime/extract-agent! opts)))
+
 (defn jvm-opts
   "Returns a vector of JVM arguments for loading the native agent.
 
   Returns a vector like [\"-agentpath:/tmp/criterium-agent-...\"] that can be
   used when spawning subprocesses or configuring REPL JVM options. Returns an
   empty vector if the agent is unavailable or the platform is unsupported.
+
+  The referenced binary is extracted persistently (not deleted on JVM exit), so
+  the path is safe to pass to a separately-launched JVM, including restarting
+  this JVM with the returned -agentpath option.
 
   Useful for configuring JVM processes to use the bundled agent without manual
   -agentpath specification."

--- a/bases/agent/src/clj/criterium/agent/loader.clj
+++ b/bases/agent/src/clj/criterium/agent/loader.clj
@@ -12,8 +12,14 @@
   4. If not, locks and extracts atomically
   5. Sets appropriate file permissions (executable on Unix)
   6. Verifies file permissions
-  7. Registers cleanup hook on first extraction
-  8. Returns absolute path to extracted agent
+  7. Returns absolute path to extracted agent
+
+  Extraction is persistent by default: the extracted binary is NOT deleted
+  when the JVM exits. The temp filename is content-addressed (includes the
+  SHA256 hash), so the file is reused across runs and JAR versions, and a path
+  produced in one JVM remains valid for a separately-launched JVM (for example
+  the `-agentpath` returned by `criterium.agent/jvm-opts`). Deletion on JVM exit
+  is available as an explicit opt-in for ephemeral in-process use.
 
   Thread-safe and safe for concurrent JVM processes."
   (:require
@@ -23,29 +29,84 @@
   (:import
    [java.nio.channels FileChannel]
    [java.nio.file Files Path StandardCopyOption StandardOpenOption]
-   [java.nio.file.attribute FileAttribute PosixFilePermission]))
+   [java.nio.file.attribute FileAttribute PosixFilePermission]
+   [java.security MessageDigest]))
+
+(defn- warn
+  "Emit a single diagnostic line to stderr. Never silent, never on stdout."
+  [& parts]
+  (binding [*out* *err*]
+    (apply println "criterium:" parts)))
+
+(defn- extraction-error
+  "Throw a structured agent-extraction failure.
+
+  Carries the failing :stage and contextual data so callers can diagnose the
+  cause instead of seeing a bare nil/false. The original throwable, when
+  present, is attached as the exception cause. This is never used for the
+  legitimate \"unsupported platform\" case (which returns nil)."
+  ([stage msg data] (extraction-error stage msg data nil))
+  ([stage msg data ^Throwable cause]
+   (throw (ex-info (str "criterium agent extraction failed [" (name stage) "]: " msg)
+                   (merge {:criterium.agent/extraction-failure true
+                           :stage stage}
+                          data)
+                   cause))))
+
+(defn- compute-sha256
+  "Compute the lowercase hex SHA-256 of the file at the given path."
+  [^Path path]
+  (let [digest (MessageDigest/getInstance "SHA-256")
+        bytes (Files/readAllBytes path)]
+    (apply str (map #(format "%02x" %) (.digest digest bytes)))))
+
+(defn- verify-hash!
+  "Verify the extracted file's SHA-256 matches the expected bundled hash.
+
+  Promotes the hash from naming-only to an integrity check: a corrupt or
+  truncated bundled binary is detected here rather than failing later at load
+  time. Throws a structured :verify-hash error on mismatch. No-op when no
+  expected hash is available."
+  [^Path path expected-hash ctx]
+  (when (and expected-hash (not (str/blank? expected-hash)))
+    (let [actual (compute-sha256 path)]
+      (when-not (= (str/lower-case actual) (str/lower-case expected-hash))
+        (extraction-error
+         :verify-hash
+         (str "SHA-256 mismatch for extracted agent (corrupt or truncated binary)."
+              " expected=" expected-hash " actual=" actual)
+         (assoc ctx :expected-hash expected-hash :actual-hash actual))))))
 
 (defn- read-hash
   "Read SHA256 hash from bundled .sha256 file.
 
   Returns the hash string if found.
 
-  Throws RuntimeException if the platform is supported but the hash file is missing,
-  which indicates incomplete JAR packaging."
+  Throws a structured :read-hash error if the platform is supported but the
+  hash file is missing or unreadable, which indicates incomplete JAR packaging."
   [platform]
   (when-let [resource-path (platform/resource-path platform)]
     (let [hash-path (str resource-path ".sha256")
           resource (io/resource hash-path)]
       (if resource
-        (-> resource
-            slurp
-            str/trim
-            (str/split #"\s+")
-            first)
-        (throw (RuntimeException.
-                (str "SHA256 hash file not found in JAR resources: " hash-path "\n"
-                     "This indicates the agent binary was not properly packaged.\n"
-                     "See docs/contributor/building-agent.md for bundling instructions.")))))))
+        (try
+          (-> resource
+              slurp
+              str/trim
+              (str/split #"\s+")
+              first)
+          (catch Exception e
+            (extraction-error
+             :read-hash
+             (str "SHA256 hash file could not be read: " hash-path)
+             {:platform platform :resource-path hash-path}
+             e)))
+        (extraction-error
+         :read-hash
+         (str "SHA256 hash file not found in JAR resources: " hash-path "\n"
+              "This indicates the agent binary was not properly packaged.\n"
+              "See docs/contributor/building-agent.md for bundling instructions.")
+         {:platform platform :resource-path hash-path})))))
 
 (defn- temp-path
   "Build path to extracted agent in temp directory.
@@ -73,7 +134,11 @@
 (defn- register-cleanup-hook!
   "Register shutdown hook to delete extracted agents.
 
-  Only registers once per JVM lifetime."
+  Only registers once per JVM lifetime.
+
+  Opt-in only: used when an extraction explicitly requests deletion on JVM exit.
+  The default extraction path leaves the binary in place so it can outlive the
+  producing JVM."
   []
   (when (compare-and-set! cleanup-registered? false true)
     (.addShutdownHook
@@ -121,86 +186,159 @@
             (str "Extracted agent is not executable: " path
                  ". This may indicate a permission issue.")))))
 
+(defn- step
+  "Run a side-effecting extraction step, tagging any failure with its stage.
+
+  Already-structured extraction failures propagate unchanged; any other
+  throwable is wrapped in a structured error naming the failing stage so no
+  failure is ever silently swallowed."
+  [stage ctx msg thunk]
+  (try
+    (thunk)
+    (catch clojure.lang.ExceptionInfo e
+      (if (:criterium.agent/extraction-failure (ex-data e))
+        (throw e)
+        (extraction-error stage (str msg ": " (ex-message e)) ctx e)))
+    (catch Exception e
+      (extraction-error stage (str msg ": " (.getMessage e)) ctx e))))
+
 (defn- extract-with-lock
   "Extract agent binary to target path using file locking.
 
-  Uses lock file to coordinate between concurrent processes.
-  Sets executable permissions and verifies file is readable/executable.
-  Returns true if extraction succeeded, false otherwise."
-  [resource-path target-path]
+  Uses a lock file to coordinate between concurrent processes, verifies the
+  extracted bytes against the expected SHA-256, sets executable permissions and
+  verifies the file is readable/executable.
+
+  Returns true on success. Throws a structured per-stage extraction error on any
+  failure (never returns false / swallows the cause). On failure, partial
+  artifacts are cleaned up."
+  [resource-path target-path platform expected-hash]
   (let [lock-file (io/file (lock-path target-path))
-        target-file (io/file target-path)]
+        target-file (io/file target-path)
+        ctx {:platform platform
+             :resource-path resource-path
+             :target-path target-path
+             :tmpdir (System/getProperty "java.io.tmpdir")}]
     (try
       ;; Create lock file parent directory if needed
-      (.mkdirs (.getParentFile lock-file))
+      (step :lock-dir-create ctx "could not create lock directory"
+            #(.mkdirs (.getParentFile lock-file)))
 
       ;; Acquire exclusive lock
-      (with-open [lock-channel (FileChannel/open
-                                (.toPath lock-file)
-                                (into-array [StandardOpenOption/CREATE
-                                             StandardOpenOption/WRITE]))]
-        (with-open [_lock (.lock lock-channel)]
+      (with-open [^FileChannel lock-channel
+                  (step :open-lock ctx
+                        (str "could not open lock file " lock-file
+                             " (filesystem may not support file locking)")
+                        #(FileChannel/open
+                          (.toPath lock-file)
+                          (into-array [StandardOpenOption/CREATE
+                                       StandardOpenOption/WRITE])))]
+        (with-open [^java.nio.channels.FileLock _lock
+                    (step :acquire-lock ctx "could not acquire extraction lock"
+                          #(.lock lock-channel))]
           ;; Double-check: another process may have extracted while we waited
           (when-not (.exists target-file)
-            (let [temp-file (Files/createTempFile
-                             "criterium-agent-"
-                             (str "." (platform/extension
-                                       (second (re-find #"criterium-agent-([^-]+)-" target-path))))
-                             (into-array FileAttribute []))]
-              ;; Copy resource to temp file
-              (with-open [in (io/input-stream (io/resource resource-path))]
-                (Files/copy ^java.io.InputStream in
-                            ^Path temp-file
-                            ^"[Ljava.nio.file.CopyOption;" (into-array [StandardCopyOption/REPLACE_EXISTING])))
+            (let [^Path temp-file (step :create-temp ctx
+                                        "could not create temp file for extraction"
+                                        #(Files/createTempFile
+                                          "criterium-agent-"
+                                          (str "." (platform/extension platform))
+                                          (into-array FileAttribute [])))]
+              (try
+                ;; Copy resource to temp file
+                (step :copy ctx "failed copying agent resource to temp file (disk full?)"
+                      (fn []
+                        (with-open [in (io/input-stream (io/resource resource-path))]
+                          (Files/copy ^java.io.InputStream in
+                                      ^Path temp-file
+                                      ^"[Ljava.nio.file.CopyOption;"
+                                      (into-array [StandardCopyOption/REPLACE_EXISTING])))))
 
-              ;; Atomic move to target
-              (Files/move temp-file
-                          (.toPath target-file)
-                          (into-array [StandardCopyOption/ATOMIC_MOVE
-                                       StandardCopyOption/REPLACE_EXISTING]))
+                ;; Verify integrity before publishing the file into place
+                (verify-hash! temp-file expected-hash ctx)
+
+                ;; Atomic move to target
+                (step :atomic-move ctx
+                      (str "atomic move failed (temp dir and target may be on "
+                           "different filesystems)")
+                      #(Files/move temp-file
+                                   (.toPath target-file)
+                                   (into-array [StandardCopyOption/ATOMIC_MOVE
+                                                StandardCopyOption/REPLACE_EXISTING])))
+                (catch clojure.lang.ExceptionInfo e
+                  ;; Clean up the un-published temp file before propagating
+                  (try (Files/deleteIfExists temp-file) (catch Exception _))
+                  (throw e)))
 
               ;; Set executable permissions on Unix platforms
-              (set-executable! (.toPath target-file))
+              (step :set-executable ctx "could not set executable permissions"
+                    #(set-executable! (.toPath target-file)))
 
               ;; Verify file has appropriate permissions
-              (verify-permissions! (.toPath target-file))))))
-      ;; Clean up lock file
-      (.delete lock-file)
+              (step :verify-permissions ctx
+                    (str "extracted agent failed permission verification "
+                         "(the temp directory may be mounted noexec)")
+                    #(verify-permissions! (.toPath target-file)))))))
+      ;; Clean up lock file (best effort)
+      (try (.delete lock-file) (catch Exception _))
       true
-      (catch Exception _e
-        false))))
+      (catch clojure.lang.ExceptionInfo e
+        ;; Structured failure: remove any partially-published target and rethrow
+        (try (.delete target-file) (catch Exception _))
+        (try (.delete lock-file) (catch Exception _))
+        (throw e)))))
 
 (defn extract-agent
   "Extract bundled agent binary to temp directory.
 
-  Returns absolute path to extracted agent or nil if:
-  - Platform is not supported
-  - Hash file is not found in resources
-  - Agent binary is not found in resources
-  - Extraction fails
+  Returns the absolute path to the extracted agent, or nil only when the
+  platform is unsupported (a legitimate, non-error outcome).
 
-  The extracted file is registered for cleanup on JVM shutdown.
+  Throws a structured extraction error (carrying :stage and context) for any
+  genuine failure - missing hash file, missing binary resource, copy/lock/move
+  failures, hash mismatch, or permission problems. Failures are never silently
+  swallowed.
+
+  By default the extracted file is persistent: it is NOT deleted on JVM
+  shutdown, so the returned path remains valid for a separately-launched JVM
+  (such as one started with the `-agentpath` produced by
+  `criterium.agent/jvm-opts`). The temp filename is content-addressed, so the
+  file is safely reused across runs.
+
+  Options:
+  - :cleanup-on-exit? (default false) - when true, registers a JVM shutdown
+    hook to delete the extracted file on exit. Only appropriate for ephemeral,
+    in-process use where no other JVM will load the path.
 
   Safe to call concurrently from multiple threads or processes."
-  []
-  (when-let [platform (platform/detect)]
-    (when-let [hash (read-hash platform)]
-      (let [target-path (temp-path platform hash)
-            target-file (io/file target-path)]
-        (cond
-          ;; File already exists, use it
-          (.exists target-file)
-          (do
-            (register-cleanup-hook!)
-            (swap! extracted-agents conj target-path)
-            target-path)
+  ([] (extract-agent {}))
+  ([{:keys [cleanup-on-exit?] :or {cleanup-on-exit? false}}]
+   (when-let [platform (platform/detect)]
+     (when-let [hash (read-hash platform)]
+       (let [target-path (temp-path platform hash)
+             target-file (io/file target-path)
+             register! (fn []
+                         (when cleanup-on-exit?
+                           (register-cleanup-hook!)
+                           (swap! extracted-agents conj target-path)))]
+         (cond
+           ;; File already exists, use it
+           (.exists target-file)
+           (do
+             (register!)
+             target-path)
 
-          ;; File doesn't exist, attempt extraction
-          :else
-          (when-let [resource-path (platform/resource-path platform)]
-            (when (io/resource resource-path)
-              (when (extract-with-lock resource-path target-path)
-                ;; Extraction succeeded, register and return path
-                (register-cleanup-hook!)
-                (swap! extracted-agents conj target-path)
-                target-path))))))))
+           ;; File doesn't exist, attempt extraction
+           :else
+           (let [resource-path (platform/resource-path platform)]
+             (when-not (io/resource resource-path)
+               (extraction-error
+                :resolve-binary
+                (str "agent binary not found in JAR resources: " resource-path "\n"
+                     "This indicates the agent binary was not properly packaged.\n"
+                     "See docs/contributor/building-agent.md for bundling instructions.")
+                {:platform platform :resource-path resource-path}))
+             (extract-with-lock resource-path target-path platform hash)
+             ;; Extraction succeeded; register cleanup only if requested
+             (register!)
+             target-path)))))))

--- a/bases/agent/src/clj/criterium/agent/loader.clj
+++ b/bases/agent/src/clj/criterium/agent/loader.clj
@@ -280,7 +280,9 @@
                          "(the temp directory may be mounted noexec)")
                     #(verify-permissions! (.toPath target-file)))))))
       ;; Clean up lock file (best effort)
-      (try (.delete lock-file) (catch Exception _))
+      (try (.delete lock-file)
+           (catch Exception e
+             (warn "could not delete lock file" (str lock-file) "-" (.getMessage e))))
       true
       (catch clojure.lang.ExceptionInfo e
         ;; Structured failure: remove any partially-published target and rethrow

--- a/bases/agent/src/clj/criterium/agent/platform.clj
+++ b/bases/agent/src/clj/criterium/agent/platform.clj
@@ -53,6 +53,27 @@
     (when (and canonical-os canonical-arch)
       (str canonical-os "-" canonical-arch))))
 
+(defn describe
+  "Return a diagnostic map of raw and canonical platform values.
+
+  Useful for explaining *why* a platform was (un)supported instead of leaving
+  a bare nil from `detect`. Includes the raw `os.name`/`os.arch` system
+  properties, their canonical mappings, the resulting platform id, and whether
+  it is supported."
+  []
+  (let [os-name (System/getProperty "os.name")
+        os-arch (System/getProperty "os.arch")
+        canonical-os (get os-name-mapping os-name)
+        canonical-arch (get os-arch-mapping os-arch)
+        platform (when (and canonical-os canonical-arch)
+                   (str canonical-os "-" canonical-arch))]
+    {:os-name os-name
+     :os-arch os-arch
+     :canonical-os canonical-os
+     :canonical-arch canonical-arch
+     :platform platform
+     :supported? (some? platform)}))
+
 (defn extension
   "Return the native library file extension for the given platform.
 

--- a/bases/agent/src/clj/criterium/agent/runtime.clj
+++ b/bases/agent/src/clj/criterium/agent/runtime.clj
@@ -22,7 +22,8 @@
   The agent can also be loaded via -agentpath JVM argument, in which case
   load-agent! will detect it's already loaded and skip loading."
   (:require
-   [criterium.agent.loader :as loader])
+   [criterium.agent.loader :as loader]
+   [criterium.agent.platform :as platform])
   (:import
    [com.sun.tools.attach VirtualMachine]
    [java.lang.management ManagementFactory]))
@@ -41,7 +42,17 @@
   "Returns the absolute path to the extracted native agent, or nil if unavailable.
 
   Extracts the bundled agent binary to a temporary directory on first call.
-  Returns nil for unsupported platforms with a logged warning.
+
+  Returns nil only when the platform is unsupported - a legitimate outcome,
+  logged once to stderr with the detected os.name/os.arch so the reason is
+  never silent. Genuine extraction failures are caught and logged to stderr
+  with their failing stage and context (rather than throwing, to preserve
+  graceful degradation of higher-level allocation tracking) and also return
+  nil; they are never silently swallowed.
+
+  The extracted file is persistent (not deleted on JVM exit), so the returned
+  path stays valid for a separately-launched JVM, e.g. one started with the
+  `-agentpath` from `criterium.agent/jvm-opts`.
 
   The path points to a platform-specific shared library (.so or .dylib) that
   can be loaded via -agentpath or VirtualMachine.loadAgent().
@@ -49,10 +60,60 @@
   Thread-safe - concurrent calls will safely extract to the same location."
   []
   (try
-    (loader/extract-agent)
+    (if-let [path (loader/extract-agent)]
+      path
+      (do
+        (binding [*out* *err*]
+          (println "criterium: native agent not available -"
+                   "unsupported platform:" (pr-str (platform/describe))))
+        nil))
     (catch Exception e
-      (println "WARNING: Failed to extract agent:" (.getMessage e))
+      (let [data (ex-data e)]
+        (binding [*out* *err*]
+          (println "WARNING: Failed to extract agent:"
+                   (ex-message e)
+                   (if data
+                     (pr-str (select-keys data [:stage :platform
+                                                :resource-path :target-path
+                                                :tmpdir]))
+                     ""))))
       nil)))
+
+(defn extract-agent!
+  "Explicitly extract the bundled native agent, surfacing all errors.
+
+  This is the explicit, fail-loud counterpart to `agent-path`. Where
+  `agent-path` degrades gracefully (logs and returns nil on failure, to keep
+  higher-level allocation tracking working without an agent), `extract-agent!`
+  performs the same extraction but *throws* a structured failure so callers can
+  detect and diagnose problems - useful for tooling that wires `-agentpath` and
+  must fail clearly if the agent cannot be extracted.
+
+  Options (map, optional):
+  - :cleanup-on-exit? (default false) - register a JVM shutdown hook to delete
+    the extracted file on exit. Only appropriate for ephemeral in-process use;
+    do NOT use when handing the path to a separately-launched JVM.
+
+  Returns:
+  - the absolute path to the extracted, persistent agent binary on success;
+  - nil only when the current platform is unsupported (a legitimate outcome).
+
+  Throws:
+  - clojure.lang.ExceptionInfo on any genuine failure. The ex-data carries:
+    - :criterium.agent/extraction-failure true
+    - :stage - the failing stage keyword, one of :read-hash, :resolve-binary,
+      :lock-dir-create, :open-lock, :acquire-lock, :create-temp, :copy,
+      :verify-hash, :atomic-move, :set-executable, :verify-permissions
+    - :platform, :resource-path, :target-path, :tmpdir - context for diagnosis
+    with the underlying throwable attached as the exception cause.
+
+  The extracted file is persistent (not deleted on JVM exit unless
+  :cleanup-on-exit? is set), so the returned path is valid for a
+  separately-launched JVM (e.g. via -agentpath).
+
+  Thread-safe - concurrent calls will safely extract to the same location."
+  ([] (loader/extract-agent))
+  ([opts] (loader/extract-agent opts)))
 
 (defn loaded?
   "Returns true if the Criterium native agent is currently loaded.

--- a/bases/agent/test/criterium/agent/degradation_test.clj
+++ b/bases/agent/test/criterium/agent/degradation_test.clj
@@ -97,6 +97,42 @@
         (is (str/includes? (first @warnings) "Failed to extract agent")
             "Warning should mention extraction failure")))))
 
+(deftest explicit-extract-test
+  ;; extract-agent! is the explicit, fail-loud counterpart to agent-path.
+  (let [boom (fn [stage]
+               (fn
+                 ([] (throw (ex-info "boom"
+                                     {:criterium.agent/extraction-failure true
+                                      :stage stage})))
+                 ([_] (throw (ex-info "boom"
+                                      {:criterium.agent/extraction-failure true
+                                       :stage stage})))))]
+    (testing "runtime/extract-agent! throws structured error on failure"
+      (with-redefs [loader/extract-agent (boom :copy)]
+        (let [ex (is (thrown? clojure.lang.ExceptionInfo (runtime/extract-agent!)))]
+          (is (= :copy (:stage (ex-data ex))))
+          (is (true? (:criterium.agent/extraction-failure (ex-data ex)))))))
+
+    (testing "runtime/extract-agent! returns nil for unsupported platform"
+      (with-redefs [loader/extract-agent (constantly nil)]
+        (is (nil? (runtime/extract-agent!)))))
+
+    (testing "agent/extract-agent! propagates structured failure"
+      (with-redefs [loader/extract-agent (boom :resolve-binary)]
+        (let [ex (is (thrown? clojure.lang.ExceptionInfo (agent/extract-agent!)))]
+          (is (= :resolve-binary (:stage (ex-data ex)))))))
+
+    (testing "agent/extract-agent! returns nil for unsupported platform"
+      (with-redefs [loader/extract-agent (constantly nil)]
+        (is (nil? (agent/extract-agent!)))))
+
+    (testing "agent/extract-agent! passes options through"
+      (let [seen (atom nil)]
+        (with-redefs [loader/extract-agent (fn ([] (reset! seen {}) "/tmp/x")
+                                             ([opts] (reset! seen opts) "/tmp/x"))]
+          (is (= "/tmp/x" (agent/extract-agent! {:cleanup-on-exit? true})))
+          (is (= {:cleanup-on-exit? true} @seen)))))))
+
 (deftest jvm-opts-degradation-test
   ;; Test jvm-opts graceful degradation
   (testing "jvm-opts with unavailable agent"

--- a/bases/agent/test/criterium/agent/integration_test.clj
+++ b/bases/agent/test/criterium/agent/integration_test.clj
@@ -13,8 +13,8 @@
   - JNI interface verification tests
   - Full integration smoke tests
 
-  Note: These tests require the agent binary to be present in
-  resources/native/{platform}/ and cannot run if the agent is
+  Note: These tests require the agent binary to be present as the resource
+  criterium/agent/{platform}/ and cannot run if the agent is
   already loaded via -agentpath."
   (:require
    [clojure.java.io :as io]

--- a/bases/agent/test/criterium/agent/loader_test.clj
+++ b/bases/agent/test/criterium/agent/loader_test.clj
@@ -74,13 +74,113 @@
           (is (str/includes? (ex-message ex) "SHA256 hash file not found")))))))
 
 (deftest extract-agent-missing-binary-test
-  ;; Missing binary file handling
+  ;; Missing binary file handling - now a structured failure, not a silent nil
   (testing "extract-agent with missing binary"
-    (testing "returns nil when agent binary not found"
+    (testing "throws structured :resolve-binary error when agent binary not found"
       (with-redefs [platform/detect (constantly "linux-x64")
                     loader/read-hash (constantly "testhash123")]
-        ;; No binaries bundled yet, so should return nil
-        (is (nil? (loader/extract-agent)))))))
+        ;; No binaries bundled in dev, so this must surface a failure
+        (let [ex (is (thrown? clojure.lang.ExceptionInfo (loader/extract-agent)))]
+          (is (= :resolve-binary (:stage (ex-data ex))))
+          (is (true? (:criterium.agent/extraction-failure (ex-data ex))))
+          (is (str/includes? (ex-message ex) "agent binary not found")))))))
+
+(deftest verify-hash-test
+  ;; SHA-256 integrity verification of extracted bytes
+  (testing "verify-hash!"
+    (let [tmp (Files/createTempFile
+               "vh-" ".bin"
+               (into-array java.nio.file.attribute.FileAttribute []))]
+      (try
+        (spit (.toFile tmp) "hello criterium")
+        (let [good (#'loader/compute-sha256 tmp)]
+          (testing "passes for matching hash"
+            (is (nil? (#'loader/verify-hash! tmp good {}))))
+          (testing "is a no-op when no expected hash provided"
+            (is (nil? (#'loader/verify-hash! tmp nil {})))
+            (is (nil? (#'loader/verify-hash! tmp "" {}))))
+          (testing "throws :verify-hash on mismatch"
+            (let [ex (is (thrown? clojure.lang.ExceptionInfo
+                                  (#'loader/verify-hash! tmp "deadbeef" {})))]
+              (is (= :verify-hash (:stage (ex-data ex))))
+              (is (str/includes? (ex-message ex) "SHA-256 mismatch")))))
+        (finally
+          (Files/delete tmp))))))
+
+(deftest extract-with-lock-success-test
+  ;; End-to-end extraction of a real classpath resource (no hash check).
+  ;; Exercises lock-dir-create, open-lock, acquire-lock, create-temp, copy,
+  ;; atomic-move, set-executable and verify-permissions stages on a real FS.
+  (testing "extract-with-lock"
+    (let [resource "criterium/agent/platform.clj" ; always on the classpath
+          target (str (System/getProperty "java.io.tmpdir")
+                      "/criterium-extract-ok-" (System/nanoTime) ".so")]
+      (is (some? (io/resource resource)) "test resource must be on classpath")
+      (try
+        (testing "copies resource and returns true"
+          (is (true? (#'loader/extract-with-lock resource target "linux-x64" nil)))
+          (is (.exists (io/file target)))
+          (is (Files/isExecutable (.toPath (io/file target)))))
+        (finally
+          (.delete (io/file target))
+          (.delete (io/file (str target ".lock"))))))))
+
+(deftest extract-with-lock-hash-mismatch-test
+  ;; A wrong expected hash fails with :verify-hash and leaves no target behind.
+  (testing "extract-with-lock with bad hash"
+    (let [resource "criterium/agent/platform.clj"
+          target (str (System/getProperty "java.io.tmpdir")
+                      "/criterium-extract-bad-" (System/nanoTime) ".so")]
+      (try
+        (let [ex (is (thrown? clojure.lang.ExceptionInfo
+                              (#'loader/extract-with-lock
+                               resource target "linux-x64" "deadbeef")))]
+          (is (= :verify-hash (:stage (ex-data ex))))
+          (is (not (.exists (io/file target)))
+              "no partially-published target should be left behind"))
+        (finally
+          (.delete (io/file target))
+          (.delete (io/file (str target ".lock"))))))))
+
+(deftest extract-with-lock-copy-failure-test
+  ;; A missing resource surfaces as a :copy stage failure (not a silent false).
+  (testing "extract-with-lock with missing resource"
+    (let [target (str (System/getProperty "java.io.tmpdir")
+                      "/criterium-extract-copyfail-" (System/nanoTime) ".so")]
+      (try
+        (let [ex (is (thrown? clojure.lang.ExceptionInfo
+                              (#'loader/extract-with-lock
+                               "no/such/resource.bin" target "linux-x64" nil)))]
+          (is (= :copy (:stage (ex-data ex)))))
+        (finally
+          (.delete (io/file target))
+          (.delete (io/file (str target ".lock"))))))))
+
+(deftest extract-agent-persistence-test
+  ;; Part A: extraction is persistent by default; cleanup is opt-in.
+  ;; Exercises the reuse branch (target already present) so no real bundled
+  ;; binary is required.
+  (testing "extract-agent cleanup registration"
+    (with-redefs [platform/detect (constantly "macos-x64")
+                  loader/read-hash (constantly "persisttest")]
+      (let [target-path (#'loader/temp-path "macos-x64" "persisttest")
+            target-file (io/file target-path)
+            agents-atom (deref #'loader/extracted-agents)]
+        (try
+          (spit target-file "stub-agent-bytes")
+          (testing "default extraction does NOT register file for deletion"
+            (reset! agents-atom #{})
+            (is (= target-path (loader/extract-agent)))
+            (is (not (contains? @agents-atom target-path))
+                "default extraction must be persistent (no cleanup registration)"))
+          (testing "cleanup-on-exit? true registers file for deletion"
+            (reset! agents-atom #{})
+            (is (= target-path (loader/extract-agent {:cleanup-on-exit? true})))
+            (is (contains? @agents-atom target-path)
+                "cleanup-on-exit? true must register the file for shutdown deletion"))
+          (finally
+            (reset! agents-atom #{})
+            (.delete target-file)))))))
 
 (deftest permission-functions-test
   ;; File permission setting and verification

--- a/build/src/build/agent.clj
+++ b/build/src/build/agent.clj
@@ -51,10 +51,16 @@
     "libcriterium.dylib"))
 
 (defn resources-base-dir
-  "Returns the base directory for agent resources.
+  "Returns the base directory for bundled agent resources.
+
+  Binaries live at {resources-base-dir}/{platform}/libcriterium.{ext}, which on
+  the classpath resolves to the resource path `criterium/agent/{platform}/...`
+  that `criterium.agent.platform/resource-path` reads at runtime. This is the
+  same location the release workflow populates.
+
   This function exists to allow tests to override the target directory."
   []
-  (io/file "bases/agent/resources/native"))
+  (io/file "bases/criterium/resources/criterium/agent"))
 
 ;;; Agent Build and Copy
 
@@ -151,12 +157,13 @@
 (defn validate-agent-binaries!
   "Validates that required agent binaries are present before building JAR.
 
-  Agent binaries are downloaded from CI and placed in bases/agent/resources/native/{platform}/
-  but are NOT committed to version control (they are in .gitignore).
+  Agent binaries are downloaded from CI and placed in
+  bases/criterium/resources/criterium/agent/{platform}/ but are NOT committed to
+  version control (they are in .gitignore).
 
   Throws an exception with helpful error message if binaries are missing."
   []
-  (let [base-path "bases/agent/resources/native"
+  (let [base-path "bases/criterium/resources/criterium/agent"
         platforms ["linux-x64" "macos-x64" "macos-arm64"]
         required-files {"linux-x64" ["libcriterium.so" "libcriterium.so.sha256"]
                         "macos-x64" ["libcriterium.dylib" "libcriterium.dylib.sha256"]

--- a/docs/contributor/building-agent.md
+++ b/docs/contributor/building-agent.md
@@ -72,20 +72,20 @@ Move the downloaded binaries and hash files to the appropriate resource paths:
 
 ```bash
 # Create resource directories if they don't exist
-mkdir -p bases/agent/resources/native/linux-x64
-mkdir -p bases/agent/resources/native/macos-x64
-mkdir -p bases/agent/resources/native/macos-arm64
+mkdir -p bases/criterium/resources/criterium/agent/linux-x64
+mkdir -p bases/criterium/resources/criterium/agent/macos-x64
+mkdir -p bases/criterium/resources/criterium/agent/macos-arm64
 
 # Copy binaries and hash files to resource paths
-cp agent-cpp-linux-x64/libcriterium.* bases/agent/resources/native/linux-x64/
-cp agent-cpp-macos-x64/libcriterium.* bases/agent/resources/native/macos-x64/
-cp agent-cpp-macos-arm64/libcriterium.* bases/agent/resources/native/macos-arm64/
+cp agent-cpp-linux-x64/libcriterium.* bases/criterium/resources/criterium/agent/linux-x64/
+cp agent-cpp-macos-x64/libcriterium.* bases/criterium/resources/criterium/agent/macos-x64/
+cp agent-cpp-macos-arm64/libcriterium.* bases/criterium/resources/criterium/agent/macos-arm64/
 ```
 
 **Resource Path Convention:**
 ```
-bases/agent/resources/native/{platform}/libcriterium.{ext}
-bases/agent/resources/native/{platform}/libcriterium.{ext}.sha256
+bases/criterium/resources/criterium/agent/{platform}/libcriterium.{ext}
+bases/criterium/resources/criterium/agent/{platform}/libcriterium.{ext}.sha256
 ```
 
 Where:
@@ -123,7 +123,7 @@ Use this checklist when updating agent binaries for a release:
   - Download `agent-cpp-linux-x64`, `agent-cpp-macos-x64`, and `agent-cpp-macos-arm64` artifacts
 
 - [ ] **Place in Resources (Not Committed to Git):**
-  - Copy binaries to `bases/agent/resources/native/{platform}/`
+  - Copy binaries to `bases/criterium/resources/criterium/agent/{platform}/`
   - Verify file permissions (should be readable)
   - **IMPORTANT:** Binaries are in `.gitignore` and should NOT be committed to version control
   - Binaries must be downloaded fresh from CI before building release JARs

--- a/docs/contributor/tasks/persistent-agent-extraction-and-error-handling.md
+++ b/docs/contributor/tasks/persistent-agent-extraction-and-error-handling.md
@@ -1,0 +1,282 @@
+# Task: Persistent agent extraction + non-silent error handling
+
+Status: implemented (Part A + Part B)
+Area: `bases/agent` (native agent loader / runtime)
+Related files:
+- `bases/agent/src/clj/criterium/agent/loader.clj`
+- `bases/agent/src/clj/criterium/agent/platform.clj`
+- `bases/agent/src/clj/criterium/agent/runtime.clj`
+- `bases/agent/src/clj/criterium/agent.clj`
+- `bases/agent/test/criterium/agent/loader_test.clj`
+- `bases/agent/test/criterium/agent/platform_test.clj`
+- `bases/agent/test/criterium/agent/degradation_test.clj`
+- `bases/agent/test/criterium/agent/integration_test.clj`
+
+## Background / motivation
+
+Two defects in the bundled-agent extraction path were found while debugging a
+user report (published jar `org.hugoduncan/criterium {:mvn/version "0.5.245-ALPHA"}`):
+
+> The path reported by `(first (criterium.agent/jvm-opts))` did not exist.
+
+### Defect 1 — extraction is deleted out from under its documented use
+
+`criterium.agent/jvm-opts` → `runtime/agent-path` → `loader/extract-agent`.
+`extract-agent` extracts the platform binary to a content-addressed temp file
+**and registers a JVM shutdown hook that deletes that file on exit**
+(`register-cleanup-hook!` / `extracted-agents` in `loader.clj`).
+
+The documented workflow for `jvm-opts` (see `criterium/agent.clj`) is:
+
+> "use (jvm-opts) to get the correct path, then restart your JVM with that option."
+
+These are incompatible:
+
+1. JVM **A** calls `(jvm-opts)` → extracts `/tmp/criterium-agent-<hash>.dylib`,
+   returns `["-agentpath:/tmp/criterium-agent-<hash>.dylib"]`.
+2. Caller launches JVM **B** with that `-agentpath`.
+3. JVM **A** exits → shutdown hook deletes the file.
+4. JVM **B** tries to load `-agentpath` **at launch** (before any Clojure runs,
+   so it cannot self-extract) → file missing → failure.
+
+The path is stable (SHA256-named) so it *looks* valid, but the file is ephemeral
+and tied to the lifetime of the producing JVM.
+
+Reproduced against the published jar on macos-arm64: the file exists during the
+producing JVM's life (full 112432 bytes) and is gone the instant it exits.
+
+### Defect 2 — silent failures make this class of bug undiagnosable
+
+`extract-with-lock` wraps the entire extraction in `(catch Exception _e false)`.
+Any failure (locking unsupported, `noexec` tmpdir failing `verify-permissions!`,
+disk full, atomic-move across filesystems, permission errors, etc.) is swallowed
+and surfaces only as `extract-agent` returning `nil`. Several other stages also
+fail silently or ambiguously:
+
+- `platform/detect` → `nil` for unsupported platform (legitimate) is
+  indistinguishable from a misdetection bug; no diagnostic about `os.name`/`os.arch`.
+- binary-resource lookup `(io/resource resource-path)` → `nil` returns `nil` with
+  no message (packaging problem looks identical to "unsupported").
+- `read-hash` throws for a missing `.sha256` but the binary-missing case is silent.
+- `runtime/agent-path` catches `Exception`, prints a one-line WARNING to stdout,
+  and returns `nil`, discarding the cause/stack.
+- The SHA256 is only used to *name* the temp file; extracted bytes are never
+  verified, so a corrupt/truncated bundled binary extracts "successfully" and
+  fails later at load time.
+
+## Goal
+
+A. Make extraction **persistent** so the `jvm-opts` / `-agentpath` workflow works:
+   the extracted binary must outlive the producing JVM. Cleanup-on-exit becomes
+   opt-in and is not used by the default `agent-path` path.
+
+B. **Eliminate silent failures** at every extraction stage. Every failure must be
+   diagnosable: it either throws a structured error or is logged with full context
+   (stage + cause + relevant paths). "Unsupported platform" remains a legitimate,
+   clearly-signalled non-error.
+
+## Part A — Persistent extraction
+
+### Design
+
+1. Remove the unconditional shutdown-hook deletion from the default path.
+   - `extract-agent` (default, used by `runtime/agent-path`) extracts to the
+     content-addressed temp file and **does not** register a deletion hook.
+   - The SHA256-named path makes the file self-deduplicating across runs and JAR
+     versions, so leaving it in place is safe (at most one stale file per
+     platform+build in `java.io.tmpdir`).
+2. Keep cleanup as an explicit opt-in for genuinely ephemeral, in-process use:
+   - Provide an arity/option, e.g. `(extract-agent {:cleanup-on-exit? true})`,
+     that registers the existing shutdown-hook behavior.
+   - Default is `:cleanup-on-exit? false`.
+   - Audit shows current built-in callers (`load-agent!`, `jvm-opts`) do **not**
+     need deletion, so both use the persistent default.
+3. Keep the existing reuse-if-present and concurrent-safe locking behavior.
+
+### Optional (recommended) follow-up
+
+Consider extracting to a stable per-user cache dir (e.g.
+`<user.home>/.cache/criterium/agent/<hash>/…`) instead of `java.io.tmpdir`, with
+versioned GC, so the binary survives temp reapers and reboots. Out of scope for
+the first cut but note it in the docstring/decision log.
+
+### Acceptance (A)
+
+- After `(criterium.agent/jvm-opts)` returns in JVM A and JVM A exits, the file
+  referenced by the returned `-agentpath:` string still exists and is loadable by
+  a freshly launched JVM B.
+- `load-agent!` still works (loads into the current JVM).
+- Repeated calls across processes reuse the same file; no unbounded growth beyond
+  one file per platform+build hash.
+
+## Part B — Non-silent error handling at every stage
+
+### Principles
+
+- Distinguish three outcomes explicitly:
+  - **success** → absolute path;
+  - **unsupported** (platform not in the supported set) → `nil`, with a single
+    clear debug/info message including `os.name` and `os.arch`. This is the only
+    legitimate `nil`.
+  - **failure** (anything that *should* have worked but didn't) → never silent.
+    Throw a structured `ex-info`, or log an error with full context and return a
+    value the caller can distinguish from "unsupported".
+- Never use a bare `(catch Exception _ false)` / `(catch Exception _ nil)` that
+  discards the cause anywhere in the extraction path.
+- Errors carry structured context: `{:stage <kw> :platform <s> :resource-path <s>
+  :target-path <s> :tmpdir <s>}` plus the original throwable as `:cause`.
+
+### Stage-by-stage requirements
+
+1. **platform/detect**
+   - On unsupported, expose *why*: which of `os.name`/`os.arch` was unrecognized.
+   - Add a helper (e.g. `platform/describe`) returning the raw + canonical values
+     for logging, so a misdetected platform is diagnosable, not silent.
+
+2. **read-hash** (`:stage :read-hash`)
+   - Keep throwing on missing `.sha256`, but include `resource-path`, the hash
+     resource path, and a packaging-fix pointer in `ex-info` data (not just a
+     string).
+
+3. **binary resource lookup** (`:stage :resolve-binary`)
+   - `(io/resource resource-path)` → `nil` must raise a clear failure: "agent
+     binary not found in JAR resources at `<resource-path>`" with `ex-info` data
+     and the packaging-doc pointer. Must NOT be confused with "unsupported".
+
+4. **extract-with-lock** — replace the blanket catch with per-step context.
+   Each sub-step records its stage so the surfaced error names the failing
+   operation. Sub-stages and their `:stage` keys:
+   - `:lock-dir-create` — `mkdirs` of lock parent
+   - `:open-lock` — `FileChannel/open` of lock file (e.g. locking unsupported on FS)
+   - `:acquire-lock` — `.lock`
+   - `:create-temp` — `Files/createTempFile`
+   - `:copy` — resource → temp copy (e.g. ENOSPC)
+   - `:atomic-move` — `Files/move` (e.g. `AtomicMoveNotSupportedException` across FS)
+   - `:set-executable` — POSIX perms (only `UnsupportedOperationException` is a
+     benign no-op; anything else is a failure, not swallowed)
+   - `:verify-permissions` — readable/executable check (e.g. `noexec` tmpdir);
+     error message must explicitly mention a possible `noexec` mount
+   - `:unlock-cleanup` — lock file deletion failure should warn, not abort
+   - Wrap each step so the thrown `ex-info` includes `:stage` and `:cause`.
+     Do not collapse to `false`.
+
+5. **integrity verification** (`:stage :verify-hash`) — NEW
+   - After extraction, compute SHA256 of the extracted file and compare to the
+     expected hash from `read-hash`. On mismatch, fail with both hashes in the
+     `ex-info` data and delete the bad file. (Promotes the hash from "naming only"
+     to actual integrity checking.)
+
+6. **runtime/agent-path**
+   - Replace the lossy `(catch Exception e (println "WARNING:" ...) nil)`:
+     - Re-throw or log (via the project's logging mechanism, not bare
+       `println` to stdout) with full stage context and stack.
+     - Preserve the existing "return `nil` for unsupported platform" contract, but
+       only for the genuine unsupported case — failures must be visible.
+   - Keep `jvm-opts` returning `[]` only for the unsupported case; failures should
+     surface, not masquerade as "no agent".
+
+### Logging
+
+Use the project's existing logging facility if one exists; otherwise emit to
+`*err*` (never `*out*`) and include stage + context. Confirm the convention
+before implementing and keep it consistent across the loader/runtime.
+
+### Acceptance (B)
+
+- A forced failure at each stage produces a distinct, identifiable error/log
+  naming the stage and cause (covered by tests below). No path returns a bare
+  `nil`/`false` without a corresponding diagnostic, except genuine "unsupported
+  platform", which logs a clear single message.
+- A corrupted bundled binary (hash mismatch) is detected and reported, not loaded.
+- `noexec` tmpdir produces a message that explicitly suggests the `noexec` cause.
+
+## Tests
+
+Add/extend under `bases/agent/test/criterium/agent/`:
+
+- `loader_test.clj`
+  - persistence: extracted file is NOT deleted on simulated shutdown for the
+    default path; IS deleted when `:cleanup-on-exit? true`.
+  - reuse: second extraction returns the same path without re-copying.
+  - hash mismatch: corrupt the extracted/source bytes → `:verify-hash` failure,
+    bad file removed.
+  - per-stage failures via injection (redef/`with-redefs` the relevant fs ops or
+    point at a read-only / `noexec` temp dir): assert each `:stage` surfaces.
+  - missing binary resource (hash present, binary absent) → `:resolve-binary`
+    failure (currently silent `nil`).
+- `degradation_test.clj`
+  - unsupported platform still returns `nil` with a clear, asserted log message,
+    distinct from failure.
+- `integration_test.clj`
+  - end-to-end: `jvm-opts` path survives producing-JVM exit (spawn a child JVM
+    that loads `-agentpath` from a path produced by a separate process), gated on
+    the binary being present like the existing integration guard.
+
+## Out of scope / flag separately
+
+> Note: the resource-path inconsistency below has since been **resolved** — see
+> "Follow-ups (now done)" near the end of this document.
+
+- **Resource-path convention inconsistency** (discovered while investigating):
+  - `docs/contributor/building-agent.md` and `build/src/build/agent.clj`
+    (`resources-base-dir` → `bases/agent/resources/native/{platform}`) document/use
+    a `native/{platform}/…` layout.
+  - The runtime loader (`platform/resource-path`) and its tests use
+    `criterium/agent/{platform}/…`, which is what the published jar actually
+    contains.
+  - These disagree. The release path works (jar has `criterium/agent/…`), so this
+    is latent, but the `native/` references should be reconciled to avoid future
+    breakage. Track as a separate cleanup task.
+
+## Definition of done
+
+- [x] Default `extract-agent` does not delete on JVM exit; cleanup is opt-in
+      (`{:cleanup-on-exit? true}`).
+- [x] `jvm-opts` / `-agentpath` workflow verified across separate JVMs
+      (file persists after the producing JVM exits).
+- [x] No silent `catch`/`nil`/`false` anywhere in the extraction/runtime path;
+      every failure is a structured `ex-info` (carrying `:stage` +
+      `:criterium.agent/extraction-failure` + context) or logged-with-context to
+      stderr. The `extract-with-lock` blanket `(catch Exception _ false)` is gone.
+- [x] SHA256 integrity check on extracted bytes (`verify-hash!`, stage
+      `:verify-hash`), bad bytes deleted before publishing.
+- [x] Unsupported-platform path remains a `nil`, now with a clear stderr message
+      including `os.name`/`os.arch` via `platform/describe`.
+- [x] Tests cover persistence, reuse, hash mismatch, missing binary, per-stage
+      failures (`:copy`, `:verify-hash`, `:resolve-binary`), and the existing
+      cross-JVM integration case.
+- [x] Docstrings in `loader.clj`, `runtime.clj`, `agent.clj` updated to reflect
+      persistent extraction and the new error contract.
+
+### Implementation notes
+
+- `runtime/agent-path` logs failures richly to stderr (stage + context) and
+  still returns `nil`, deliberately preserving the graceful degradation of
+  higher-level allocation tracking (`with-allocation-tracing` etc.) rather than
+  throwing. The failure is now visible (non-silent) instead of a bare one-line
+  stdout WARNING. If callers later want hard failures to surface, `extract-agent`
+  itself now throws structured errors that `agent-path` could re-raise.
+- Stages implemented in `extract-with-lock`: `:lock-dir-create`, `:open-lock`,
+  `:acquire-lock`, `:create-temp`, `:copy`, `:verify-hash`, `:atomic-move`,
+  `:set-executable`, `:verify-permissions`. The fragile filename-regex used to
+  derive the file extension was replaced with the `platform` argument.
+- All agent test namespaces pass; namespaces compile clean under
+  `*warn-on-reflection*`.
+
+### Follow-ups (now done)
+
+- Explicit, fail-loud extract API added: `criterium.agent/extract-agent!`
+  (delegating to `criterium.agent.runtime/extract-agent!`). It performs the same
+  persistent extraction as `agent-path` but *throws* the structured per-stage
+  error instead of degrading to nil, for tooling that must fail clearly.
+  Accepts the same `{:cleanup-on-exit? bool}` option. Documented with the full
+  error/stage contract; covered by `degradation-test/explicit-extract-test`.
+
+- Resource-path convention inconsistency resolved. The canonical location (used
+  by `.github/workflows/release.yml`) is
+  `bases/criterium/resources/criterium/agent/{platform}/libcriterium.{ext}`,
+  which resolves on the classpath to `criterium/agent/{platform}/...` — exactly
+  what `platform/resource-path` reads. The stale `native/` references were
+  corrected in `build/src/build/agent.clj` (`resources-base-dir`,
+  `validate-agent-binaries!`), `.gitignore`, `docs/contributor/building-agent.md`,
+  `projects/agent/README.md`, and the `integration_test` namespace comment.

--- a/projects/agent/README.md
+++ b/projects/agent/README.md
@@ -156,9 +156,9 @@ When making changes to the native agent that should be released:
 
 1. **Wait for CI to build** - The GitHub Actions workflow builds binaries for all supported platforms
 2. **Download artifacts** - See [docs/contributor/building-agent.md](../../docs/contributor/building-agent.md) for detailed instructions
-3. **Place in resources** - Copy to `projects/agent/resources/native/{platform}/`
-4. **Update SHA256 hashes** - Generate `.sha256` files for version tracking
-5. **Commit and release** - Include binaries in the release commit
+3. **Place in resources** - Copy to `bases/criterium/resources/criterium/agent/{platform}/`
+4. **SHA256 hashes** - Each artifact ships a `.sha256` used for the extracted-file name and integrity check
+5. **Build and release** - Binaries are gitignored (not committed); the release workflow downloads them fresh into the JAR
 
 Full process documentation: [Building the Agent](../../docs/contributor/building-agent.md)
 
@@ -178,20 +178,20 @@ Tests gracefully skip when agent binaries are unavailable.
 
 ### Resource Layout
 
-Agent binaries are stored in the JAR at:
+Agent binaries are stored in the JAR at (source: `bases/criterium/resources/`):
 
 ```
-resources/native/linux-x64/libcriterium.so
-resources/native/macos-x64/libcriterium.dylib
-resources/native/macos-arm64/libcriterium.dylib
+criterium/agent/linux-x64/libcriterium.so
+criterium/agent/macos-x64/libcriterium.dylib
+criterium/agent/macos-arm64/libcriterium.dylib
 ```
 
 SHA256 hash files track binary versions:
 
 ```
-resources/native/linux-x64/libcriterium.so.sha256
-resources/native/macos-x64/libcriterium.dylib.sha256
-resources/native/macos-arm64/libcriterium.dylib.sha256
+criterium/agent/linux-x64/libcriterium.so.sha256
+criterium/agent/macos-x64/libcriterium.dylib.sha256
+criterium/agent/macos-arm64/libcriterium.dylib.sha256
 ```
 
 ### Extraction Strategy


### PR DESCRIPTION
## Summary

Primarily fixes the bundled native-agent extraction path. Also carries one
pre-existing commit on this branch (`restore allocation analysis notebooks`)
since the branch is named for it — happy to split that out if preferred.

### Bug fixed
The path returned by `(criterium.agent/jvm-opts)` could point to a file that
did not exist. `extract-agent` registered a JVM shutdown hook that deleted the
content-addressed temp binary on exit, so a path produced in one JVM was gone
before a separately-launched `-agentpath` JVM could load it.

## Changes

### Part A — persistent extraction
- `extract-agent` no longer deletes the extracted binary on JVM exit. The file
  is persistent and reused across runs (content-addressed by SHA256), so the
  path stays valid for a separately-launched JVM.
- Cleanup-on-exit is now opt-in: `(extract-agent {:cleanup-on-exit? true})`.

### Part B — no silent failures
- Replaced the blanket `(catch Exception _ false)` in `extract-with-lock` with
  per-stage structured `ex-info` errors carrying `:stage`, context
  (`:platform`, `:resource-path`, `:target-path`, `:tmpdir`) and the cause.
  Stages: `:read-hash`, `:resolve-binary`, `:lock-dir-create`, `:open-lock`,
  `:acquire-lock`, `:create-temp`, `:copy`, `:verify-hash`, `:atomic-move`,
  `:set-executable`, `:verify-permissions`.
- Added SHA256 integrity verification of extracted bytes (`verify-hash!`).
- Previously-silent missing-binary case now throws `:resolve-binary`.
- `runtime/agent-path` logs failures richly to stderr (stage + context) while
  still degrading to `nil`; `platform/describe` explains unsupported platforms
  (`os.name`/`os.arch`) instead of a bare `nil`.

### Explicit extract API
- Added `criterium.agent/extract-agent!` (via `runtime/extract-agent!`): the
  fail-loud counterpart to `jvm-opts`/`agent-path`. Returns the path, `nil`
  only when unsupported, and throws the structured error otherwise.

### Resource-path consistency fix
- Corrected stale `native/` references to the canonical bundling location
  `bases/criterium/resources/criterium/agent/{platform}/` (the location
  `release.yml` populates; resolves to the `criterium/agent/{platform}/`
  resource the loader reads). Updated `build/agent.clj`, `.gitignore`,
  `building-agent.md`, `projects/agent/README.md`, and the `integration_test`
  comment.

### Housekeeping
- `.gitignore`: ignore `**/.clj-kondo/.cache/` at any depth.

## Testing
- Agent suites (loader/degradation/platform/integration/core): 39 tests,
  112 assertions, 0 failures.
- Build suites (smoke/defaults): 4 tests, 19 assertions, 0 failures.
- New coverage: persistence/reuse, hash mismatch, missing binary, per-stage
  failures, and explicit `extract-agent!`.
- Namespaces compile clean under `*warn-on-reflection*`.
- Verified end-to-end against the published `0.5.245-ALPHA` jar that the
  extracted file now survives the producing JVM exit.

## Design notes / docs
- `agent-path` intentionally degrades (logs + `nil`) to preserve graceful
  degradation of higher-level allocation tracking; `extract-agent!` is the
  explicit fail-loud path.
- Full task write-up: `docs/contributor/tasks/persistent-agent-extraction-and-error-handling.md`.
