### PR TITLE
fix(measured): pass all callable args; unroll invocation to drop apply allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ bases/criterium/resources/criterium/agent/**/*.so
 bases/criterium/resources/criterium/agent/**/*.dylib
 bases/criterium/resources/criterium/agent/**/*.sha256
 /bases/criterium/.clj-kondo/imports/
+.nrepl-port
+.psi/project.local.edn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 - *(measured)* Unroll the function invocation in `measured/callable` by arg
   count, avoiding the per-iteration argument-seq allocation `apply` produced in
   the measurement loop. Arities above 20 fall back to `apply`.
+- *(utils)* Extract the invocation unroll into `criterium.utils.forms`
+  (`unrolled-apply-form` / `unrolled-invoke`) so it can be shared.
+- *(instrument-fn, sampled-fn)* Invoke the wrapped function via the unrolled
+  dispatch instead of `apply`, removing the per-call argument-seq allocation
+  from the wrappers' measurement function.
 
 ## [0.5.245-ALPHA] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   arity error), because the measured bound only the first element of the
   argument list. The measured now binds and spreads the whole argument list.
 
+### Performance
+
+- *(measured)* Unroll the function invocation in `measured/callable` by arg
+  count, avoiding the per-iteration argument-seq allocation `apply` produced in
+  the measurement loop. Arities above 20 fall back to `apply`.
+
 ## [0.5.245-ALPHA] - 2026-04-13
 
 ### Miscellaneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- *(measured)* Pass all arguments to `measured/callable` functions. Multi-arity
+  callables previously received only their first argument (failing with an
+  arity error), because the measured bound only the first element of the
+  argument list. The measured now binds and spreads the whole argument list.
+
 ## [0.5.245-ALPHA] - 2026-04-13
 
 ### Miscellaneous

--- a/bases/criterium/src/criterium/instrument_fn.clj
+++ b/bases/criterium/src/criterium/instrument_fn.clj
@@ -11,6 +11,7 @@
    [criterium.jvm :as jvm]
    [criterium.measured :as measured]
    [criterium.sampler :as sampler]
+   [criterium.util.forms :as forms]
    [criterium.util.invariant :refer [have]])
   (:import
    [java.util.concurrent Callable]))
@@ -21,7 +22,7 @@
    (fn measured-f [args ^long eval-count]
      (have (partial = 1) eval-count)
      (let [start  (jvm/timestamp)
-           res    (apply original-fn args)
+           res    (forms/unrolled-invoke original-fn args)
            finish (jvm/timestamp)]
        [(unchecked-subtract finish start) res]))))
 

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -3,6 +3,7 @@
    [clojure.set]
    [criterium.jvm :as jvm]
    [criterium.util.blackhole :as blackhole]
+   [criterium.util.forms :as forms]
    [criterium.util.helpers :as util]))
 
 (defrecord Measured
@@ -330,32 +331,6 @@
                        (~'time ~expr))))
       ~warmup-args-fn)))
 
-(def ^:no-doc max-unrolled-arity
-  "Highest arity for which `measured/callable` invocation is unrolled to a
-  direct call.  Higher arities fall back to `apply`."
-  20)
-
-(defn ^:no-doc unrolled-apply-form
-  "Return a form that invokes `f-sym` with the elements of the collection
-  bound to `args-sym`.
-
-  Dispatches on the argument count so common arities are called directly
-  (e.g. `(f (nth args 0) (nth args 1))`) rather than via `apply`, which
-  allocates a seq on every call.  This matters because the form is evaluated
-  on every iteration of the zero-garbage measurement loop.  Arities above
-  `max-unrolled-arity` fall back to `apply`.
-
-  `f-sym` must be a symbol (it is repeated across the dispatch arms), so the
-  caller should bind the function to a local first."
-  [f-sym args-sym]
-  `(case (count ~args-sym)
-     ~@(mapcat
-        (fn [n]
-          [n (cons f-sym
-                   (map (fn [i] `(nth ~args-sym ~i)) (range n)))])
-        (range (inc (long max-unrolled-arity))))
-     (apply ~f-sym ~args-sym)))
-
 (defn measured-callable
   ([f]
    `(measured
@@ -378,7 +353,7 @@
            ;; f, so callables of any arity work.  `[args]` would bind only the
            ;; first element, silently dropping the rest.
            [:as args]
-           (unrolled-apply-form f-sym args)
+           (forms/unrolled-apply-form f-sym args)
            {})
          (fn ~'measured-expr []
            ~(list 'quote
@@ -391,7 +366,7 @@
          (fn ~'measured-args [] (~args-f))
          ~(measured-expr-fn
            [:as args]
-           (unrolled-apply-form f-sym args)
+           (forms/unrolled-apply-form f-sym args)
            {})
          (fn ~'measured-expr []
            ~(list 'quote

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -346,8 +346,11 @@
      `(measured
        (fn ~'measured-args [] (~args-f))
        ~(measured-expr-fn
-         [args]
-         `(apply ~f [~args])
+         ;; bind the whole arg-list state (`[:as args]`) and spread it into
+         ;; f, so callables of any arity work.  `[args]` would bind only the
+         ;; first element, silently dropping the rest.
+         [:as args]
+         `(apply ~f ~args)
          {})
        (fn ~'measured-expr []
          ~(list 'quote
@@ -357,8 +360,8 @@
      `(measured
        (fn ~'measured-args [] (~args-f))
        ~(measured-expr-fn
-         [args]
-         `(apply ~f [~args])
+         [:as args]
+         `(apply ~f ~args)
          {})
        (fn ~'measured-expr []
          ~(list 'quote

--- a/bases/criterium/src/criterium/measured/impl.clj
+++ b/bases/criterium/src/criterium/measured/impl.clj
@@ -330,6 +330,32 @@
                        (~'time ~expr))))
       ~warmup-args-fn)))
 
+(def ^:no-doc max-unrolled-arity
+  "Highest arity for which `measured/callable` invocation is unrolled to a
+  direct call.  Higher arities fall back to `apply`."
+  20)
+
+(defn ^:no-doc unrolled-apply-form
+  "Return a form that invokes `f-sym` with the elements of the collection
+  bound to `args-sym`.
+
+  Dispatches on the argument count so common arities are called directly
+  (e.g. `(f (nth args 0) (nth args 1))`) rather than via `apply`, which
+  allocates a seq on every call.  This matters because the form is evaluated
+  on every iteration of the zero-garbage measurement loop.  Arities above
+  `max-unrolled-arity` fall back to `apply`.
+
+  `f-sym` must be a symbol (it is repeated across the dispatch arms), so the
+  caller should bind the function to a local first."
+  [f-sym args-sym]
+  `(case (count ~args-sym)
+     ~@(mapcat
+        (fn [n]
+          [n (cons f-sym
+                   (map (fn [i] `(nth ~args-sym ~i)) (range n)))])
+        (range (inc (long max-unrolled-arity))))
+     (apply ~f-sym ~args-sym)))
+
 (defn measured-callable
   ([f]
    `(measured
@@ -342,28 +368,32 @@
        ~(list 'quote
               `(time (~f))))))
   ([args-f f]
-   (let [args (gensym "args")]
-     `(measured
-       (fn ~'measured-args [] (~args-f))
-       ~(measured-expr-fn
-         ;; bind the whole arg-list state (`[:as args]`) and spread it into
-         ;; f, so callables of any arity work.  `[args]` would bind only the
-         ;; first element, silently dropping the rest.
-         [:as args]
-         `(apply ~f ~args)
-         {})
-       (fn ~'measured-expr []
-         ~(list 'quote
-                `(time (~f)))))))
+   (let [args  (gensym "args")
+         f-sym (gensym "f")]
+     `(let [~f-sym ~f]
+        (measured
+         (fn ~'measured-args [] (~args-f))
+         ~(measured-expr-fn
+           ;; bind the whole arg-list state (`[:as args]`) and spread it into
+           ;; f, so callables of any arity work.  `[args]` would bind only the
+           ;; first element, silently dropping the rest.
+           [:as args]
+           (unrolled-apply-form f-sym args)
+           {})
+         (fn ~'measured-expr []
+           ~(list 'quote
+                  `(time (~f))))))))
   ([args-f f warmup-args-fn]
-   (let [args (gensym "args")]
-     `(measured
-       (fn ~'measured-args [] (~args-f))
-       ~(measured-expr-fn
-         [:as args]
-         `(apply ~f ~args)
-         {})
-       (fn ~'measured-expr []
-         ~(list 'quote
-                `(time (~f))))
-       ~warmup-args-fn))))
+   (let [args  (gensym "args")
+         f-sym (gensym "f")]
+     `(let [~f-sym ~f]
+        (measured
+         (fn ~'measured-args [] (~args-f))
+         ~(measured-expr-fn
+           [:as args]
+           (unrolled-apply-form f-sym args)
+           {})
+         (fn ~'measured-expr []
+           ~(list 'quote
+                  `(time (~f))))
+         ~warmup-args-fn)))))

--- a/bases/criterium/src/criterium/sampled_fn.clj
+++ b/bases/criterium/src/criterium/sampled_fn.clj
@@ -11,6 +11,7 @@
    [criterium.measured :as measured]
    [criterium.metric :as metric]
    [criterium.sampler :as sampler]
+   [criterium.util.forms :as forms]
    [criterium.util.invariant :refer [have]]
    [criterium.util.t-digest :as t-digest])
   (:import
@@ -22,7 +23,7 @@
    (fn measured-f [args ^long eval-count]
      (have (partial = 1) eval-count)
      (let [start  (jvm/timestamp)
-           res    (apply original-fn args)
+           res    (forms/unrolled-invoke original-fn args)
            finish (jvm/timestamp)]
        [(unchecked-subtract finish start) res]))))
 

--- a/bases/criterium/src/criterium/util/forms.clj
+++ b/bases/criterium/src/criterium/util/forms.clj
@@ -20,3 +20,19 @@
   {:style/indent 1}
   [& clauses]
   `(utils/cond* ~@clauses))
+
+(def ^:no-doc max-unrolled-arity
+  "Highest arity for which function invocation is unrolled to a direct call."
+  utils/max-unrolled-arity)
+
+(defn ^:no-doc unrolled-apply-form
+  "Return a form invoking f-sym with the elements of args-sym, dispatching on
+  arg count to avoid apply's per-call seq allocation.  f-sym must be a symbol."
+  [f-sym args-sym]
+  (utils/unrolled-apply-form f-sym args-sym))
+
+(defmacro unrolled-invoke
+  "Invoke f with the elements of the args collection, unrolled by argument
+  count to avoid apply's per-call seq allocation."
+  [f args]
+  `(utils/unrolled-invoke ~f ~args))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -122,6 +122,36 @@
         (is (= [:new-args] (measured/args modified-m)))
         (is (= [:warmup-args] (measured/warmup-args modified-m)))))))
 
+(deftest callable-test
+  ;; measured/callable builds a measured that applies f to the argument list
+  ;; returned by the setup function.  The setup function returns the *sequence
+  ;; of arguments*; f is called with those arguments spread.  Regression test
+  ;; for a bug where only the first argument reached f (multi-arg callables
+  ;; failed with an arity error).
+  (testing "no setup function (zero-arg f)"
+    (let [m (measured/callable (fn [] 41))]
+      (is (= 41 (second (invoke m))))))
+  (testing "single collection argument"
+    (let [f (fn [coll] (reduce + coll))
+          m (measured/callable (fn [] [[1 2 3]]) f)]
+      (is (= 6 (second (invoke m))))))
+  (testing "two arguments are both passed to f"
+    (let [f (fn [a b] (+ (long a) (long b)))
+          m (measured/callable (fn [] [10 20]) f)]
+      (is (= 30 (second (invoke m))))))
+  (testing "three arguments are all passed to f"
+    (let [f (fn [a b c] (* (long a) (long b) (long c)))
+          m (measured/callable (fn [] [2 3 4]) f)]
+      (is (= 24 (second (invoke m))))))
+  (testing "zero-arg f via empty argument list"
+    (let [f (fn [] 42)
+          m (measured/callable (fn [] []) f)]
+      (is (= 42 (second (invoke m))))))
+  (testing "warmup-args-fn arity also spreads all arguments"
+    (let [f (fn [a b] (* (long a) (long b)))
+          m (measured/callable (fn [] [6 7]) f (fn [] [1 1]))]
+      (is (= 42 (second (invoke m)))))))
+
 (defn random-seq
   [n]
   (mapv rand-int (repeat n 10000)))

--- a/bases/criterium/test/criterium/measured_test.clj
+++ b/bases/criterium/test/criterium/measured_test.clj
@@ -240,6 +240,30 @@
                {:allocations (frequencies thread-allocations)}}))
       (is (= [1 2] ret) "hold reference to return value until end of test"))))
 
+(deftest callable-unrolled-invocation-test
+  ;; The callable measurement loop invokes f via an unrolled arity dispatch
+  ;; rather than `apply`, so it allocates no argument seq per iteration.
+  ;; `apply` over the argument vector would surface as a ChunkedSeq/ArraySeq;
+  ;; assert those never appear.  Degrades to a vacuous pass when the native
+  ;; agent is not attached (allocations is nil).
+  (testing "callable does not allocate an argument seq via apply"
+    (let [f                  (fn [a b] (unchecked-add (long a) (long b)))
+          ;; values outside the Long cache so any apply seq would be obvious
+          mm                 (measured/callable (fn [] [100000 200000]) f)
+          st                 (measured/args mm)
+          _                  (dotimes [_ 1000] (measured/invoke mm st 1000))
+          [allocations ret]  (agent/with-allocation-tracing
+                               (measured/invoke mm st 1000))
+          thread-allocations (->> allocations
+                                  (filterv (agent/allocation-on-thread?)))
+          types              (set (map :object-type thread-allocations))]
+      (is (not (contains? types "clojure.lang.PersistentVector$ChunkedSeq"))
+          thread-allocations)
+      (is (not (contains? types "clojure.lang.ArraySeq"))
+          thread-allocations)
+      (is (= 300000 (second ret))
+          "hold reference to return value until end of test"))))
+
 ;;; Local detection tests
 ;; Tests for the local binding detection functionality used by measured-expr*.
 ;; These verify that locals from &env are correctly identified in expressions.

--- a/components/utils/src/criterium/utils/forms.clj
+++ b/components/utils/src/criterium/utils/forms.clj
@@ -1,5 +1,44 @@
 (ns criterium.utils.forms)
 
+(def ^:no-doc max-unrolled-arity
+  "Highest arity for which `unrolled-apply-form` / `unrolled-invoke` emit a
+  direct call.  Higher arities fall back to `apply`."
+  20)
+
+(defn ^:no-doc unrolled-apply-form
+  "Return a form that invokes `f-sym` with the elements of the collection
+  bound to `args-sym`.
+
+  Dispatches on the argument count so common arities are called directly
+  (e.g. `(f (nth args 0) (nth args 1))`) rather than via `apply`, which
+  allocates a seq on every call.  Arities above `max-unrolled-arity` fall back
+  to `apply`.
+
+  `f-sym` must be a symbol (it is repeated across the dispatch arms), so the
+  caller should bind the function to a local first.  `args-sym` must evaluate
+  to an indexed, counted collection (e.g. a vector)."
+  [f-sym args-sym]
+  `(case (count ~args-sym)
+     ~@(mapcat
+        (fn [n]
+          [n (cons f-sym
+                   (map (fn [i] `(nth ~args-sym ~i)) (range n)))])
+        (range (inc (long max-unrolled-arity))))
+     (apply ~f-sym ~args-sym)))
+
+(defmacro unrolled-invoke
+  "Invoke `f` with the elements of the `args` collection, unrolled by argument
+  count to avoid the per-call seq allocation of `apply`.
+
+  Arities above `max-unrolled-arity` fall back to `apply`.  `f` and `args` are
+  each evaluated once.  `args` must be an indexed, counted collection."
+  [f args]
+  (let [f-sym    (gensym "f")
+        args-sym (gensym "args")]
+    `(let [~f-sym    ~f
+           ~args-sym ~args]
+       ~(unrolled-apply-form f-sym args-sym))))
+
 (defmacro cond*
   "A cond variant that allows :let bindings visible to subsequent clauses.
 

--- a/components/utils/src/criterium/utils/interface.clj
+++ b/components/utils/src/criterium/utils/interface.clj
@@ -48,6 +48,22 @@
   [& clauses]
   `(forms/cond* ~@clauses))
 
+(def ^:no-doc max-unrolled-arity
+  "Highest arity for which function invocation is unrolled to a direct call."
+  forms/max-unrolled-arity)
+
+(defn ^:no-doc unrolled-apply-form
+  "Return a form invoking f-sym with the elements of args-sym, dispatching on
+  arg count to avoid apply's per-call seq allocation.  f-sym must be a symbol."
+  [f-sym args-sym]
+  (forms/unrolled-apply-form f-sym args-sym))
+
+(defmacro unrolled-invoke
+  "Invoke f with the elements of the args collection, unrolled by argument
+  count to avoid apply's per-call seq allocation."
+  [f args]
+  `(forms/unrolled-invoke ~f ~args))
+
 ;;; Helpers - math
 
 (defmacro sqr

--- a/components/utils/test/criterium/utils/forms_test.clj
+++ b/components/utils/test/criterium/utils/forms_test.clj
@@ -1,7 +1,28 @@
 (ns criterium.utils.forms-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [criterium.utils.interface :refer [cond*]]))
+   [criterium.utils.interface :refer [cond* unrolled-invoke]]))
+
+(deftest unrolled-invoke-test
+  (testing "unrolled-invoke applies f to all elements of the args collection"
+    (testing "zero args"
+      (is (= :ok (unrolled-invoke (fn [] :ok) []))))
+    (testing "one arg"
+      (is (= 1 (unrolled-invoke inc [0]))))
+    (testing "several args"
+      (is (= 6 (unrolled-invoke + [1 2 3])))
+      (is (= 24 (unrolled-invoke * [2 3 4]))))
+    (testing "arity at the unrolled boundary (20 args)"
+      (is (= 20 (unrolled-invoke + (vec (repeat 20 1))))))
+    (testing "arity beyond the unrolled boundary falls back to apply"
+      (is (= 25 (unrolled-invoke + (vec (repeat 25 1))))))
+    (testing "f and args expressions are each evaluated once"
+      (let [f-calls    (atom 0)
+            args-calls (atom 0)]
+        (is (= 3 (unrolled-invoke (do (swap! f-calls inc) +)
+                                  (do (swap! args-calls inc) [1 2]))))
+        (is (= 1 @f-calls))
+        (is (= 1 @args-calls))))))
 
 ;; Tests for the cond* macro from criterium.utils.interface.
 ;; cond* extends standard cond with :let bindings visible to subsequent clauses.


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `measured/callable` and removes the per-call
`apply` argument-seq allocation from the measurement path. This work was
spun out of an investigation into integrating allocation tracing into
`instrument-fn` / `sampled-fn`.

## Changes

- **fix(measured): pass all arguments to callable measureds.**
  `measured/callable` bound only the first element of the argument list
  and re-wrapped it, so any callable taking more than one argument
  received just its first argument and failed with an arity error. It now
  binds and spreads the whole argument list (`[:as args]` + `(apply f
  args)`). The setup-fn contract is unchanged, so `with-args-fn` keeps
  working.

- **perf(measured): unroll callable invocation.** Replaced `(apply f
  args)` in the `callable` measurement loop with an arity dispatch that
  calls `f` directly for arities 0–20 (falling back to `apply` above
  that), removing the per-iteration argument-seq allocation from the
  otherwise zero-garbage loop.

- **perf(utils): extract the unroll** into `criterium.utils.forms`
  (`unrolled-apply-form` form-builder + `unrolled-invoke` runtime macro),
  exposed via the utils interface and the `criterium.util.forms` shim.

- **perf(instrument-fn, sampled-fn): unroll wrapped-fn invocation.** Both
  wrappers' private `measured` now invoke the wrapped function via the
  unrolled dispatch instead of `apply`, removing the per-call
  argument-seq allocation from their measurement function.

- **chore:** ignore `.nrepl-port` and local psi repl config.

## Verification

- New `callable-test` (0/1/2/3-arg + `warmup-args-fn`) and
  `callable-unrolled-invocation-test`; new `unrolled-invoke-test`
  (arities, the 20-arg boundary, `apply` fallback, single-evaluation of
  `f`/`args`).
- `measured-test`, `instrument-fn-test`, `sampled-fn-test`,
  `utils.forms-test` all green.
- With the native agent attached, tracing the bare invocation shows the
  `ChunkedSeq`/`ArraySeq` records gone: `(apply f args)` →
  `{ChunkedSeq 3, Long 1}`; unrolled → `{Long 1}`.
- `cljfmt` clean on all changed regions.
